### PR TITLE
読み上げ内のメンション対応

### DIFF
--- a/app/cmd/buki.js
+++ b/app/cmd/buki.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch');
+
 const common = require('../common.js');
 const weaponsUrl = 'https://stat.ink/api/v2/weapon';
 const { MessageEmbed } = require('discord.js');

--- a/app/cmd/recruit.js
+++ b/app/cmd/recruit.js
@@ -358,7 +358,7 @@ function getCloseEmbed() {
 
 function getCommandHelpEmbed(command) {
     const embed = new MessageEmbed();
-    embed.setDescription('募集コマンドは `' + `${command}` + '`\n詳しくは <#560485660696510484> を確認するでし！');
+    embed.setDescription('募集コマンドは ' + `${command}` + `\n詳しくは <#${process.env.CHANNEL_ID_RECRUIT_HELP}> を確認するでし！`);
     return embed;
 }
 

--- a/app/cmd/recruit.js
+++ b/app/cmd/recruit.js
@@ -53,7 +53,7 @@ async function recruitLeagueMatch(msg, type) {
     const args = strCmd.split(' ');
     args.shift();
     if (strCmd.match('〆')) {
-        sendCloseMessage(msg);
+        sendCloseMessage(msg, '`now` か `next`');
     } else {
         try {
             const response = await fetch(schedule_url);
@@ -83,7 +83,7 @@ async function regularMatch(msg) {
     const args = strCmd.split(' ');
     args.shift();
     if (strCmd.match('〆')) {
-        sendCloseMessage(msg);
+        sendCloseMessage(msg, 'nawabari');
     } else {
         try {
             const response = await fetch(schedule_url);
@@ -110,14 +110,15 @@ async function regularMatch(msg) {
             const sentMessage = await msg.channel.send({
                 content: txt,
                 files: [recruit, stage],
-                components: [recruitActionRow(msg)],
             });
+            // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
+            sentMessage.edit({ components: [recruitActionRow(sentMessage)] });
             setTimeout(function () {
-                const host_mention = `<@${msg.author.id}>`;
                 sentMessage.edit({
-                    content: `${host_mention}たんの募集は〆！`,
+                    content: `↑の募集は〆！`,
                     components: [disableButtons()],
                 });
+                sendCloseMessage(msg, 'nawabari');
             }, 7200000);
         } catch (error) {
             msg.channel.send('なんかエラーでてるわ');
@@ -136,7 +137,7 @@ async function salmonRun(msg) {
     const args = strCmd.split(' ');
     args.shift();
     if (strCmd.match('〆')) {
-        sendCloseMessage(msg);
+        sendCloseMessage(msg, 'run');
     } else {
         try {
             const response = await fetch(coop_schedule_url);
@@ -170,14 +171,15 @@ async function salmonRun(msg) {
             const sentMessage = await msg.channel.send({
                 content: txt,
                 files: [recruit, stageImage],
-                components: [recruitActionRow(msg)],
             });
+            // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
+            sentMessage.edit({ components: [recruitActionRow(sentMessage)] });
             setTimeout(function () {
-                const host_mention = `<@${msg.author.id}>`;
                 sentMessage.edit({
-                    content: `${host_mention}たんの募集は〆！`,
+                    content: `↑の募集は〆！`,
                     components: [disableButtons()],
                 });
+                sendCloseMessage(msg, 'run');
             }, 7200000);
         } catch (error) {
             msg.channel.send('なんかエラーでてるわ');
@@ -226,7 +228,7 @@ async function sendOtherGames(msg, title, txt, color, image, logo) {
     const args = strCmd.split(' ');
     args.shift();
     if (args[0] == '〆') {
-        sendCloseMessage(msg);
+        sendCloseMessage(msg, '`!apex` か `!dbd` か `!mhr`');
     } else {
         let condition = 'なし';
         if (args.length > 0) condition = args.join(' ') + '\n';
@@ -247,14 +249,15 @@ async function sendOtherGames(msg, title, txt, color, image, logo) {
             const sentMessage = await msg.channel.send({
                 content: txt,
                 embeds: [embed],
-                components: [recruitActionRow(msg)],
             });
+            // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
+            sentMessage.edit({ components: [recruitActionRow(sentMessage)] });
             setTimeout(function () {
-                const host_mention = `<@${msg.author.id}>`;
                 sentMessage.edit({
-                    content: `${host_mention}たんの募集は〆！`,
+                    content: `↑の募集は〆！`,
                     components: [disableButtons()],
                 });
+                sendCloseMessage(msg, 'run');
             }, 7200000);
         } catch (error) {
             console.log(error);
@@ -319,35 +322,44 @@ async function sendLeagueMatch(msg, txt, condition, l_args, stageImages) {
         const sentMessage = await msg.channel.send({
             content: txt,
             files: [recruit, stage],
-            components: [recruitActionRow(msg)],
         });
 
+        // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
+        sentMessage.edit({ components: [recruitActionRow(sentMessage)] });
         setTimeout(function () {
-            const host_mention = `<@${msg.author.id}>`;
             sentMessage.edit({
-                content: `${host_mention}たんの募集は〆！`,
+                content: `↑の募集は〆！`,
                 components: [disableButtons()],
             });
+            sendCloseMessage(msg, 'run');
         }, 7200000);
     } catch (error) {
         console.log(error);
     }
 }
 
-function sendCloseMessage(msg) {
+function sendCloseMessage(msg, command) {
     try {
-        const embed = getCloseEmbed(msg);
+        const embed = getCloseEmbed();
         msg.channel.send({ embeds: [embed] });
+        const cmdHelpEmbed = getCommandHelpEmbed(command);
+        msg.channel.send({ embeds: [cmdHelpEmbed] });
         msg.delete();
     } catch (error) {
         console.log(error);
     }
 }
 
-function getCloseEmbed(msg) {
-    const stageEmbed = new MessageEmbed();
-    stageEmbed.setDescription(`<@${msg.author.id}>たんの募集 〆`);
-    return stageEmbed;
+function getCloseEmbed() {
+    const embed = new MessageEmbed();
+    embed.setDescription(`↑の募集 〆`);
+    return embed;
+}
+
+function getCommandHelpEmbed(command) {
+    const embed = new MessageEmbed();
+    embed.setDescription('募集コマンドは `' + `${command}` + '`\n詳しくは <#560485660696510484> を確認するでし！');
+    return embed;
 }
 
 function isNotThisChannel(msg, channelName) {
@@ -372,14 +384,17 @@ function recruitActionRow(msg) {
     const joinParams = new URLSearchParams();
     joinParams.append('d', 'jr');
     joinParams.append('mid', msg.id);
+    joinParams.append('cid', msg.channel.id);
 
     const cancelParams = new URLSearchParams();
     cancelParams.append('d', 'cr');
     cancelParams.append('mid', msg.id);
+    cancelParams.append('cid', msg.channel.id);
 
     const closeParams = new URLSearchParams();
     closeParams.append('d', 'close');
     closeParams.append('mid', msg.id);
+    closeParams.append('cid', msg.channel.id);
 
     return new MessageActionRow().addComponents([
         new MessageButton().setCustomId(joinParams.toString()).setLabel('参加').setStyle('PRIMARY'),

--- a/app/cmd/recruit.js
+++ b/app/cmd/recruit.js
@@ -114,8 +114,9 @@ async function regularMatch(msg) {
             // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
             sentMessage.edit({ components: [recruitActionRow(sentMessage)] });
             setTimeout(function () {
+                const host_mention = `<@${msg.author.id}>`;
                 sentMessage.edit({
-                    content: `↑の募集は〆！`,
+                    content: `${host_mention}たんの募集は〆！`,
                     components: [disableButtons()],
                 });
                 sendCloseMessage(msg, 'nawabari');
@@ -175,8 +176,9 @@ async function salmonRun(msg) {
             // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
             sentMessage.edit({ components: [recruitActionRow(sentMessage)] });
             setTimeout(function () {
+                const host_mention = `<@${msg.author.id}>`;
                 sentMessage.edit({
-                    content: `↑の募集は〆！`,
+                    content: `${host_mention}たんの募集は〆！`,
                     components: [disableButtons()],
                 });
                 sendCloseMessage(msg, 'run');
@@ -253,8 +255,9 @@ async function sendOtherGames(msg, title, txt, color, image, logo) {
             // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
             sentMessage.edit({ components: [recruitActionRow(sentMessage)] });
             setTimeout(function () {
+                const host_mention = `<@${msg.author.id}>`;
                 sentMessage.edit({
-                    content: `↑の募集は〆！`,
+                    content: `${host_mention}たんの募集は〆！`,
                     components: [disableButtons()],
                 });
                 sendCloseMessage(msg, 'run');
@@ -326,9 +329,10 @@ async function sendLeagueMatch(msg, txt, condition, l_args, stageImages) {
 
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
         sentMessage.edit({ components: [recruitActionRow(sentMessage)] });
-        setTimeout(function () {
+        setTimeout(function async() {
+            const host_mention = `<@${msg.author.id}>`;
             sentMessage.edit({
-                content: `↑の募集は〆！`,
+                content: `${host_mention}たんの募集は〆！`,
                 components: [disableButtons()],
             });
             sendCloseMessage(msg, 'run');

--- a/app/cmd/recruit.js
+++ b/app/cmd/recruit.js
@@ -119,7 +119,6 @@ async function regularMatch(msg) {
                     content: `${host_mention}たんの募集は〆！`,
                     components: [disableButtons()],
                 });
-                sendCloseMessage(msg, 'nawabari');
             }, 7200000);
         } catch (error) {
             msg.channel.send('なんかエラーでてるわ');
@@ -181,7 +180,6 @@ async function salmonRun(msg) {
                     content: `${host_mention}たんの募集は〆！`,
                     components: [disableButtons()],
                 });
-                sendCloseMessage(msg, 'run');
             }, 7200000);
         } catch (error) {
             msg.channel.send('なんかエラーでてるわ');
@@ -260,7 +258,6 @@ async function sendOtherGames(msg, title, txt, color, image, logo) {
                     content: `${host_mention}たんの募集は〆！`,
                     components: [disableButtons()],
                 });
-                sendCloseMessage(msg, 'run');
             }, 7200000);
         } catch (error) {
             console.log(error);
@@ -335,7 +332,6 @@ async function sendLeagueMatch(msg, txt, condition, l_args, stageImages) {
                 content: `${host_mention}たんの募集は〆！`,
                 components: [disableButtons()],
             });
-            sendCloseMessage(msg, 'run');
         }, 7200000);
     } catch (error) {
         console.log(error);

--- a/app/event/recruit_button.js
+++ b/app/event/recruit_button.js
@@ -46,14 +46,15 @@ async function join(interaction, params) {
             force: true, // intentsによってはGuildMemberUpdateが配信されないため
         });
         const cmd_message = await interaction.channel.messages.fetch(msg_id);
-        if (member.user.id === cmd_message.author.id) {
+        const host_mention = await cmd_message.mentions.users.first();
+        if (member.user.id === host_mention.id) {
             await interaction.followUp({
                 content: `募集主は参加表明できないでし！`,
                 ephemeral: true,
             });
         } else {
             const member_mention = `<@!${member.user.id}>`;
-            const host_mention = `<@!${cmd_message.author.id}>`;
+            const host_mention = await cmd_message.mentions.users.first();
             let member_roles = member.roles.cache.map((role) => (role.name != '@everyone' ? role.name : '')).join(' / ');
             const embed = new MessageEmbed();
             embed.setDescription(`募集主は${member.user.username}たんに遊ぶ部屋を伝えるでし！イカ部心得を守って楽しく遊んでほしいでし！`);
@@ -95,7 +96,7 @@ async function cancel(interaction, params) {
         });
         const msg_id = params.get('mid');
         const cmd_message = await interaction.channel.messages.fetch(msg_id);
-        const host_mention = `<@${cmd_message.author.id}>`;
+        const host_mention = await cmd_message.mentions.users.first();
         const embed = new MessageEmbed().setDescription(`${host_mention}たんの募集〆`);
         if (member.user.id === cmd_message.author.id) {
             await interaction.update({
@@ -132,15 +133,18 @@ async function close(interaction, params) {
             force: true, // intentsによってはGuildMemberUpdateが配信されないため
         });
         const msg_id = params.get('mid');
+        const msg_ch_id = params.get('cid');
+        const helpEmbed = await getHelpEmbed(guild, msg_ch_id);
         const cmd_message = await interaction.channel.messages.fetch(msg_id);
-        const host_mention = `<@${cmd_message.author.id}>`;
+        const host_mention = await cmd_message.mentions.users.first();
         const embed = new MessageEmbed().setDescription(`${host_mention}たんの募集〆`);
-        if (member.user.id === cmd_message.author.id) {
+        if (member.user.id === host_mention.id) {
             await interaction.update({
                 content: `${host_mention}たんの募集は〆！`,
                 components: [disableButtons()],
             });
             await interaction.message.reply({ embeds: [embed] });
+            await cmd_message.channel.send({ embeds: [helpEmbed] });
         } else {
             await interaction.deferReply({
                 ephemeral: true,
@@ -153,6 +157,23 @@ async function close(interaction, params) {
     } catch (err) {
         handleError(err, { interaction });
     }
+}
+
+async function getHelpEmbed(guild, chid) {
+    const sendChannel = await guild.channels.cache.find((channel) => channel.id === chid);
+    let command = '';
+    if (sendChannel.name.match('リグマ募集')) {
+        command = '`now` か `next`';
+    } else if (sendChannel.name.match('ナワバリ・フェス募集')) {
+        command = '`nawabari`';
+    } else if (sendChannel.name.match('サーモン募集')) {
+        command = '`run`';
+    } else if (sendChannel.name.match('別ゲー募集')) {
+        command = '`!apex` か `!dbd` か `!mhr`';
+    }
+    const embed = new MessageEmbed();
+    embed.setDescription('募集コマンドは ' + `${command}` + `\n詳しくは <#${process.env.CHANNEL_ID_RECRUIT_HELP}> を確認するでし！`);
+    return embed;
 }
 
 function disableButtons() {

--- a/app/index.js
+++ b/app/index.js
@@ -73,7 +73,7 @@ client.on('guildMemberRemove', async (member) => {
         const guild = member.guild;
         const tag = member.user.tag;
         const period = Math.round((Date.now() - member.joinedAt) / 86400000); // サーバーに居た期間を日数にして計算
-        const retire_log = guild.channels.cache.find((channel) => channel.id === process.env.CHANNEL_ID_RETIRE_LOG);
+        const retire_log = await guild.channels.cache.find((channel) => channel.id === process.env.CHANNEL_ID_RETIRE_LOG);
         retire_log.send(`${tag} さんが退部しました。入部日: ${member.joinedAt} 入部期間：${period}日間`);
     } catch (err) {
         console.log(err);

--- a/app/tts/voice_bot_node.js
+++ b/app/tts/voice_bot_node.js
@@ -109,11 +109,44 @@ async function messageReplace(message) {
         return str.replace(pat, '');
     };
 
-    const mention_replace = (str) => {
-        const pat = /<@!(\d*)>/g;
-        const [matchAllElement] = str.matchAll(pat);
+    const role_mention_replace = (str) => {
+        const [matchAllElement] = str.matchAll(/<@&(\d*)>/g);
         if (matchAllElement === undefined) return str;
-        return str.replace(pat, message.mentions.users.first().username);
+        for (var i = 0; i < [matchAllElement].length; i++) {
+            let roleName = message.mentions.roles.get([matchAllElement][i][1]).name;
+            str = str.replace([matchAllElement][i][0], '@' + roleName);
+        }
+        return role_mention_replace(str);
+    };
+
+    const nickname_mention_replace = (str) => {
+        const [matchAllElement] = str.matchAll(/<@!(\d*)>/g);
+        if (matchAllElement === undefined) return str;
+        for (var i = 0; i < [matchAllElement].length; i++) {
+            let username = message.mentions.users.get([matchAllElement][i][1]).username;
+            str = str.replace([matchAllElement][i][0], '@' + username);
+        }
+        return nickname_mention_replace(str);
+    };
+
+    const mention_replace = (str) => {
+        const [matchAllElement] = str.matchAll(/<@(\d*)>/g);
+        if (matchAllElement === undefined) return str;
+        for (var i = 0; i < [matchAllElement].length; i++) {
+            let username = message.mentions.users.get([matchAllElement][i][1]).username;
+            str = str.replace([matchAllElement][i][0], '@' + username);
+        }
+        return mention_replace(str);
+    };
+
+    const channel_replace = (str) => {
+        const [matchAllElement] = str.matchAll(/<#(\d*)>/g);
+        if (matchAllElement === undefined) return str;
+        for (var i = 0; i < [matchAllElement].length; i++) {
+            let chName = message.guild.channels.cache.get([matchAllElement][i][1]).name;
+            str = str.replace([matchAllElement][i][0], chName);
+        }
+        return channel_replace(str);
     };
 
     const over200_cut = (str) => {
@@ -125,7 +158,15 @@ async function messageReplace(message) {
         }
     };
 
-    const yomiage_message = await over200_cut(mention_replace(w_replace(emoji_delete(url_delete(`${message.content}`)))));
+    let url_deleted = url_delete(`${message.content}`);
+    let emoji_deleted = emoji_delete(url_deleted);
+    let w_replaced = w_replace(emoji_deleted);
+    let mention_replaced = mention_replace(w_replaced);
+    let nickname_replaced = nickname_mention_replace(mention_replaced);
+    let role_mention_replaced = role_mention_replace(nickname_replaced);
+    let channel_replaced = channel_replace(role_mention_replaced);
+
+    const yomiage_message = await over200_cut(channel_replaced);
     return yomiage_message;
 }
 

--- a/package.json
+++ b/package.json
@@ -18,33 +18,33 @@
     "unit": "jest"
   },
   "dependencies": {
-    "@discordjs/builders": "^0.11.0",
-    "@discordjs/opus": "^0.3.3",
-    "@discordjs/rest": "^0.3.0",
-    "@discordjs/voice": "^0.7.5",
-    "canvas": "^2.9.0",
-    "config": "^3.3.4",
-    "config-reloadable": "^1.0.8",
+    "@discordjs/builders": "^0.13.0",
+    "@discordjs/opus": "^0.7.0",
+    "@discordjs/rest": "^0.4.1",
+    "@discordjs/voice": "^0.9.0",
+    "canvas": "^2.9.1",
+    "config": "^3.3.7",
+    "config-reloadable": "^1.0.9",
     "csv": "^6.0.5",
     "csv-stringify": "^6.0.5",
     "data-utils": "0.0.2",
     "date-utils": "^1.2.21",
     "discord.js": "^13.6.0",
-    "dotenv": "^8.2.0",
-    "express": "^4.17.1",
-    "ffmpeg-static": "^4.2.7",
+    "dotenv": "^16.0.0",
+    "express": "^4.18.1",
+    "ffmpeg-static": "^5.0.0",
     "fs": "^0.0.1-security",
     "install": "^0.13.0",
-    "js-combinatorics": "^0.5.5",
-    "node-fetch": "^2.6.7",
-    "npm": "^8.4.1",
-    "opusscript": "^0.0.7",
-    "pg": "^8.4.1",
+    "js-combinatorics": "^1.5.6",
+    "node-fetch": "^2.6.1",
+    "npm": "^8.9.0",
+    "opusscript": "^0.0.8",
+    "pg": "^8.7.3",
     "request": "^2.88.2",
-    "tweetnacl": "^0.14.5",
+    "tweetnacl": "^1.0.3",
     "voice-text": "^0.1.2",
-    "wikijs": "^6.0.1",
-    "ytdl-core": "^3.4.1"
+    "wikijs": "^6.3.3",
+    "ytdl-core": "^4.11.0"
   },
   "engines": {
     "node": "16.9.0"
@@ -55,10 +55,10 @@
     "express"
   ],
   "devDependencies": {
-    "eslint": "^8.8.0",
-    "eslint-config-prettier": "^8.3.0",
+    "eslint": "^8.15.0",
+    "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "prettier": "^2.5.1"
+    "prettier": "^2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "node",
     "express"
   ],
+  "compilerOptions": {
+      "lib": ["es2020.string"]
+  },
   "devDependencies": {
     "eslint": "^8.15.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
読み上げメッセージにメンションがあった場合に名前に置き換える処理が動作いなくなっていたので修正
- 普通のメンションはもともと1つ目しか変換してなかったので複数入ってても動くように再帰処理にして対応
- ロールメンション、ニックネームメンション、チャンネル名にも同様に対応