### PR TITLE
create regular recruit & VC Option

### DIFF
--- a/app/cmd/recruit.js
+++ b/app/cmd/recruit.js
@@ -346,7 +346,7 @@ function getCloseEmbed() {
 const recruit_command = {
     リグマ募集: '`/now` or `/next`',
     'ナワバリ・フェス募集': '`/now` or `/next`',
-    サーモン募集: `run`,
+    サーモン募集: `/run`,
     別ゲー募集: '`/apex` or `/dbd` or `/mhr` or `/valo` or `/other`',
 };
 

--- a/app/cmd/recruit.js
+++ b/app/cmd/recruit.js
@@ -180,13 +180,6 @@ async function salmonRun(msg) {
             });
             // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
             sentMessage.edit({ components: [recruitActionRow(sentMessage, msg.author)] });
-            setTimeout(function () {
-                const host_mention = `<@${msg.author.id}>`;
-                sentMessage.edit({
-                    content: `${host_mention}たんの募集は〆！`,
-                    components: [disableButtons()],
-                });
-            }, 7200000);
         } catch (error) {
             msg.channel.send('なんかエラーでてるわ');
             console.error(error);
@@ -258,13 +251,6 @@ async function sendOtherGames(msg, title, txt, color, image, logo) {
             });
             // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
             sentMessage.edit({ components: [recruitActionRow(sentMessage, msg.author)] });
-            setTimeout(function () {
-                const host_mention = `<@${msg.author.id}>`;
-                sentMessage.edit({
-                    content: `${host_mention}たんの募集は〆！`,
-                    components: [disableButtons()],
-                });
-            }, 7200000);
         } catch (error) {
             console.log(error);
         }

--- a/app/cmd/recruit.js
+++ b/app/cmd/recruit.js
@@ -344,8 +344,8 @@ function getCloseEmbed() {
     return embed;
 }
 const recruit_command = {
-    リグマ募集: '`now` か `next`',
-    'ナワバリ・フェス募集': `nawabari`,
+    リグマ募集: '`/now` or `/next`',
+    'ナワバリ・フェス募集': '`/now` or `/next`',
     サーモン募集: `run`,
     別ゲー募集: '`/apex` or `/dbd` or `/mhr` or `/valo` or `/other`',
 };

--- a/app/cmd/recruit/button_components.js
+++ b/app/cmd/recruit/button_components.js
@@ -4,20 +4,68 @@ const { URLSearchParams } = require('url');
 module.exports = {
     recruitDeleteButton: recruitDeleteButton,
     recruitActionRow: recruitActionRow,
+    recruitDeleteButtonWithChannel: recruitDeleteButtonWithChannel,
+    recruitActionRowWithChannel: recruitActionRowWithChannel,
     disableButtons: disableButtons,
+    unlockChannelButton: unlockChannelButton,
 };
+
+function recruitDeleteButtonWithChannel(msg, host_user, channel_id) {
+    const joinParams = new URLSearchParams();
+    joinParams.append('d', 'jr');
+    joinParams.append('mid', msg.id);
+    joinParams.append('hid', host_user.id);
+    joinParams.append('vid', channel_id);
+
+    const deleteParams = new URLSearchParams();
+    deleteParams.append('d', 'del');
+    deleteParams.append('mid', msg.id);
+    deleteParams.append('hid', host_user.id);
+    deleteParams.append('vid', channel_id);
+
+    let button = new MessageActionRow();
+    button.addComponents([
+        new MessageButton().setCustomId(joinParams.toString()).setLabel('参加').setStyle('PRIMARY'),
+        new MessageButton().setCustomId(deleteParams.toString()).setLabel('削除').setStyle('DANGER'),
+    ]);
+    return button;
+}
+
+function recruitActionRowWithChannel(msg, host_user, channel_id) {
+    const joinParams = new URLSearchParams();
+    joinParams.append('d', 'jr');
+    joinParams.append('mid', msg.id);
+    joinParams.append('hid', host_user.id);
+    joinParams.append('vid', channel_id);
+
+    const cancelParams = new URLSearchParams();
+    cancelParams.append('d', 'cr');
+    cancelParams.append('mid', msg.id);
+    cancelParams.append('hid', host_user.id);
+    cancelParams.append('vid', channel_id);
+
+    const closeParams = new URLSearchParams();
+    closeParams.append('d', 'close');
+    closeParams.append('mid', msg.id);
+    closeParams.append('hid', host_user.id);
+    closeParams.append('vid', channel_id);
+
+    return new MessageActionRow().addComponents([
+        new MessageButton().setCustomId(joinParams.toString()).setLabel('参加').setStyle('PRIMARY'),
+        new MessageButton().setCustomId(cancelParams.toString()).setLabel('キャンセル').setStyle('DANGER'),
+        new MessageButton().setCustomId(closeParams.toString()).setLabel('〆').setStyle('SECONDARY'),
+    ]);
+}
 
 function recruitDeleteButton(msg, host_user) {
     const joinParams = new URLSearchParams();
     joinParams.append('d', 'jr');
     joinParams.append('mid', msg.id);
-    joinParams.append('cid', msg.channel.id);
     joinParams.append('hid', host_user.id);
 
     const deleteParams = new URLSearchParams();
     deleteParams.append('d', 'del');
     deleteParams.append('mid', msg.id);
-    deleteParams.append('cid', msg.channel.id);
     deleteParams.append('hid', host_user.id);
 
     let button = new MessageActionRow();
@@ -32,19 +80,16 @@ function recruitActionRow(msg, host_user) {
     const joinParams = new URLSearchParams();
     joinParams.append('d', 'jr');
     joinParams.append('mid', msg.id);
-    joinParams.append('cid', msg.channel.id);
     joinParams.append('hid', host_user.id);
 
     const cancelParams = new URLSearchParams();
     cancelParams.append('d', 'cr');
     cancelParams.append('mid', msg.id);
-    cancelParams.append('cid', msg.channel.id);
     cancelParams.append('hid', host_user.id);
 
     const closeParams = new URLSearchParams();
     closeParams.append('d', 'close');
     closeParams.append('mid', msg.id);
-    closeParams.append('cid', msg.channel.id);
     closeParams.append('hid', host_user.id);
 
     return new MessageActionRow().addComponents([
@@ -53,6 +98,7 @@ function recruitActionRow(msg, host_user) {
         new MessageButton().setCustomId(closeParams.toString()).setLabel('〆').setStyle('SECONDARY'),
     ]);
 }
+
 function disableButtons() {
     let buttons = new MessageActionRow().addComponents([
         new MessageButton().setCustomId('join').setLabel('参加').setStyle('PRIMARY').setDisabled(),
@@ -60,4 +106,15 @@ function disableButtons() {
         new MessageButton().setCustomId('close').setLabel('〆').setStyle('SECONDARY').setDisabled(),
     ]);
     return buttons;
+}
+
+function unlockChannelButton(channel_id) {
+    const buttonParams = new URLSearchParams();
+    buttonParams.append('d', 'unl');
+    buttonParams.append('vid', channel_id);
+
+    let button = new MessageActionRow().addComponents([
+        new MessageButton().setCustomId(buttonParams.toString()).setLabel('ボイスチャンネルのロック解除').setStyle('SECONDARY'),
+    ]);
+    return button;
 }

--- a/app/cmd/recruit/canvas_components.js
+++ b/app/cmd/recruit/canvas_components.js
@@ -3,15 +3,28 @@ const Canvas = require('canvas');
 module.exports = {
     createRoundRect: createRoundRect,
     drawArcImage: drawArcImage,
+    fillTextWithStroke: fillTextWithStroke,
 };
 
-/*
- 角が丸い四角形を作成
- x,yは座標
- width,heightは幅と高さ
- radiusは角丸の半径
-*/
-
+/**
+ *
+ * @param {Canvas.CanvasRenderingContext2D} ctx Canvas Context
+ * @param {String} text テキスト
+ * @param {String} font_style フォントスタイル
+ * @param {String} fill_color 塗りつぶしの色
+ * @param {String} stroke_color フチの色
+ * @param {float} strokeWidth フチの太さ
+ * @param {float} x x座標
+ * @param {float} y y座標
+ */
+function fillTextWithStroke(ctx, text, font_style, fill_color, stroke_color, strokeWidth, x, y) {
+    ctx.font = font_style;
+    ctx.fillStyle = fill_color;
+    ctx.fillText(text, x, y);
+    ctx.strokeStyle = stroke_color;
+    ctx.lineWidth = strokeWidth;
+    ctx.strokeText(text, x, y);
+}
 /**
  * 角が丸い四角形を作成
  * @param {Canvas.CanvasRenderingContext2D} ctx Canvas Context

--- a/app/cmd/recruit/league_recruit.js
+++ b/app/cmd/recruit/league_recruit.js
@@ -69,7 +69,7 @@ async function leagueRecruit(interaction) {
     }
 
     // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply();
 
     var usable_channel = ['alfa', 'bravo', 'charlie', 'delta', 'echo', 'fox', 'golf', 'hotel', 'india', 'juliett', 'kilo', 'lima', 'mike'];
 
@@ -198,9 +198,10 @@ async function sendLeagueMatch(interaction, channel, txt, recruit_num, condition
     const rule = new MessageAttachment(await ruleCanvas(l_rule, l_date, l_time, l_stage1, l_stage2, stageImages, thumbnail), 'stages.png');
 
     try {
-        const sentMessage = await channel.send({
+        const sentMessage = await interaction.followUp({
             content: txt,
             files: [recruit, rule],
+            ephemeral: false,
         });
 
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
@@ -218,14 +219,14 @@ async function sendLeagueMatch(interaction, channel, txt, recruit_num, condition
         }
 
         if (count == 2) {
-            await interaction.editReply({
+            await interaction.followUp({
                 content:
                     '2リグで募集がかかったでし！\n4リグで募集をたてるには参加者に指定するか、募集人数を変更して募集し直すでし！\n15秒間は募集を取り消せるでし！',
                 components: reserve_channel != null ? [unlockChannelButton(reserve_channel.id)] : [],
                 ephemeral: true,
             });
         } else {
-            await interaction.editReply({
+            await interaction.followUp({
                 content: '募集完了でし！参加者が来るまで待つでし！\n15秒間は募集を取り消せるでし！',
                 components: reserve_channel != null ? [unlockChannelButton(reserve_channel.id)] : [],
                 ephemeral: true,

--- a/app/cmd/recruit/league_recruit.js
+++ b/app/cmd/recruit/league_recruit.js
@@ -2,7 +2,7 @@ const Canvas = require('canvas');
 const path = require('path');
 const fetch = require('node-fetch');
 const { stage2txt, rule2txt, unixTime2hm, unixTime2ymdw } = require('../../common.js');
-const { createRoundRect, drawArcImage } = require('./canvas_components.js');
+const { createRoundRect, drawArcImage, fillTextWithStroke } = require('./canvas_components.js');
 const {
     recruitDeleteButton,
     recruitActionRow,
@@ -68,26 +68,26 @@ async function leagueRecruit(interaction) {
         return;
     }
 
-    // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply();
-
     var usable_channel = ['alfa', 'bravo', 'charlie', 'delta', 'echo', 'fox', 'golf', 'hotel', 'india', 'juliett', 'kilo', 'lima', 'mike'];
 
     if (voice_channel != null) {
         if (voice_channel.members.size != 0 && !voice_channel.members.has(host_user.id)) {
-            await interaction.editReply({
+            await interaction.reply({
                 content: 'そのチャンネルは使用中でし！',
                 ephemeral: true,
             });
             return;
         } else if (!usable_channel.includes(voice_channel.name)) {
-            await interaction.editReply({
+            await interaction.reply({
                 content: 'そのチャンネルは指定できないでし！\n🔉alfa ～ 🔉mikeの間のチャンネルで指定するでし！',
                 ephemeral: true,
             });
             return;
         }
     }
+
+    // 'インタラクションに失敗'が出ないようにするため
+    await interaction.deferReply();
 
     // 新入部員用リグマ募集ようにメンションを変更
     let mention = '@everyone';
@@ -195,7 +195,7 @@ async function sendLeagueMatch(interaction, channel, txt, recruit_num, condition
     const recruitBuffer = await recruitCanvas(recruit_num, count, host_user, user1, user2, condition, channel_name);
     const recruit = new MessageAttachment(recruitBuffer, 'ikabu_recruit.png');
 
-    const rule = new MessageAttachment(await ruleCanvas(l_rule, l_date, l_time, l_stage1, l_stage2, stageImages, thumbnail), 'stages.png');
+    const rule = new MessageAttachment(await ruleCanvas(l_rule, l_date, l_time, l_stage1, l_stage2, stageImages, thumbnail), 'rules.png');
 
     try {
         const sentMessage = await interaction.followUp({
@@ -280,12 +280,7 @@ async function recruitCanvas(recruit_num, count, host_user, user1, user2, condit
     let league_icon = await Canvas.loadImage('https://cdn.glitch.me/4ea6ca87-8ea7-482c-ab74-7aee445ea445%2Fleague.png');
     recruit_ctx.drawImage(league_icon, 20, 20, 80, 80);
 
-    recruit_ctx.font = '50px Splatfont';
-    recruit_ctx.fillStyle = '#F02D7E';
-    recruit_ctx.fillText('リーグマッチ', 115, 80);
-    recruit_ctx.strokeStyle = '#bd2363';
-    recruit_ctx.lineWidth = 1;
-    recruit_ctx.strokeText('リーグマッチ', 115, 80);
+    fillTextWithStroke(recruit_ctx, 'リーグマッチ', '50px Splatfont', '#F02D7E', '#bd2363', 1, 115, 80);
 
     // 募集主の画像
     let host_img = await Canvas.loadImage(host_user.displayAvatarURL({ format: 'png' }));
@@ -340,26 +335,11 @@ async function recruitCanvas(recruit_num, count, host_user, user1, user2, condit
     let host_icon = await Canvas.loadImage('https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/squid.png');
     recruit_ctx.drawImage(host_icon, 0, 0, host_icon.width, host_icon.height, 90, 172, 75, 75);
 
-    recruit_ctx.font = '39px "Splatfont"';
-    recruit_ctx.fillStyle = '#FFFFFF';
-    recruit_ctx.fillText('募集人数', 525, 155);
-    recruit_ctx.strokeStyle = '#2D3130';
-    recruit_ctx.lineWidth = 1.0;
-    recruit_ctx.strokeText('募集人数', 525, 155);
+    fillTextWithStroke(recruit_ctx, '募集人数', '39px "Splatfont"', '#FFFFFF', '#2D3130', 1, 525, 155);
 
-    recruit_ctx.font = '42px "Splatfont"';
-    recruit_ctx.fillStyle = '#FFFFFF';
-    recruit_ctx.fillText('@' + recruit_num, 580, 218);
-    recruit_ctx.strokeStyle = '#2D3130';
-    recruit_ctx.lineWidth = 1.0;
-    recruit_ctx.strokeText('@' + recruit_num, 580, 218);
+    fillTextWithStroke(recruit_ctx, '@' + recruit_num, '42px "Splatfont"', '#FFFFFF', '#2D3130', 1, 580, 218);
 
-    recruit_ctx.font = '43px "Splatfont"';
-    recruit_ctx.fillStyle = '#FFFFFF';
-    recruit_ctx.fillText('参加条件', 35, 290);
-    recruit_ctx.strokeStyle = '#2D3130';
-    recruit_ctx.lineWidth = 1.0;
-    recruit_ctx.strokeText('参加条件', 35, 290);
+    fillTextWithStroke(recruit_ctx, '参加条件', '43px "Splatfont"', '#FFFFFF', '#2D3130', 1, 35, 290);
 
     recruit_ctx.font = '30px "Genshin", "SEGUI"';
     const width = 600;
@@ -394,12 +374,7 @@ async function recruitCanvas(recruit_num, count, host_user, user1, user2, condit
         }
     }
 
-    recruit_ctx.font = '37px Splatfont';
-    recruit_ctx.fillStyle = '#FFFFFF';
-    recruit_ctx.fillText(channel_name, 30, 520);
-    recruit_ctx.strokeStyle = '#2D3130';
-    recruit_ctx.lineWidth = 1.0;
-    recruit_ctx.strokeText(channel_name, 30, 520);
+    fillTextWithStroke(recruit_ctx, channel_name, '37px "Splatfont"', '#FFFFFF', '#2D3130', 1, 30, 520);
 
     const recruit = recruitCanvas.toBuffer();
     return recruit;
@@ -419,66 +394,26 @@ async function ruleCanvas(l_rule, l_date, l_time, l_stage1, l_stage2, stageImage
     rule_ctx.lineWidth = 4;
     rule_ctx.stroke();
 
-    rule_ctx.font = '33px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText('ルール', 35, 80);
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText('ルール', 35, 80);
+    fillTextWithStroke(rule_ctx, 'ルール', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 80);
 
     rule_width = rule_ctx.measureText(l_rule).width;
-    rule_ctx.font = '45px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText(l_rule, (320 - rule_width) / 2, 145); // 中央寄せ
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText(l_rule, (320 - rule_width) / 2, 145);
+    fillTextWithStroke(rule_ctx, l_rule, '45px Splatfont', '#FFFFFF', '#2D3130', 1, (320 - rule_width) / 2, 145); // 中央寄せ
 
-    rule_ctx.font = '32px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText('日時', 35, 220);
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText('日時', 35, 220);
+    fillTextWithStroke(rule_ctx, '日時', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 220);
 
     date_width = rule_ctx.measureText(l_date).width;
-    rule_ctx.font = '35px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText(l_date, (350 - date_width) / 2, 270);
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText(l_date, (350 - date_width) / 2, 270);
+    fillTextWithStroke(rule_ctx, l_date, '35px Splatfont', '#FFFFFF', '#2D3130', 1, (350 - date_width) / 2, 270); // 中央寄せ
 
     time_width = rule_ctx.measureText(l_time).width;
-    rule_ctx.font = '35px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText(l_time, 15 + (350 - time_width) / 2, 320);
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText(l_time, 15 + (350 - time_width) / 2, 320);
+    fillTextWithStroke(rule_ctx, l_time, '35px Splatfont', '#FFFFFF', '#2D3130', 1, 15 + (350 - time_width) / 2, 320); // 中央寄せ
 
-    rule_ctx.font = '33px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText('ステージ', 35, 390);
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText('ステージ', 35, 390);
+    fillTextWithStroke(rule_ctx, 'ステージ', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 390);
 
     stage1_width = rule_ctx.measureText(l_stage1).width;
-    rule_ctx.font = '35px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText(l_stage1, (350 - stage1_width) / 2 + 10, 440);
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText(l_stage1, (350 - stage1_width) / 2 + 10, 440);
+    fillTextWithStroke(rule_ctx, l_stage1, '35px Splatfont', '#FFFFFF', '#2D3130', 1, (350 - stage1_width) / 2 + 10, 440); // 中央寄せ
 
     stage2_width = rule_ctx.measureText(l_stage2).width;
-    rule_ctx.font = '35px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText(l_stage2, (350 - stage2_width) / 2 + 10, 490);
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText(l_stage2, (350 - stage2_width) / 2 + 10, 490);
+    fillTextWithStroke(rule_ctx, l_stage2, '35px Splatfont', '#FFFFFF', '#2D3130', 1, (350 - stage2_width) / 2 + 10, 490); // 中央寄せ
 
     let stage1_img = await Canvas.loadImage(stageImages[0]);
     rule_ctx.save();

--- a/app/cmd/recruit/league_recruit.js
+++ b/app/cmd/recruit/league_recruit.js
@@ -71,10 +71,18 @@ async function leagueRecruit(interaction) {
     // 'インタラクションに失敗'が出ないようにするため
     await interaction.deferReply({ ephemeral: true });
 
+    var usable_channel = ['alfa', 'bravo', 'charlie', 'delta', 'echo', 'fox', 'golf', 'hotel', 'india', 'juliett', 'kilo', 'lima', 'mike'];
+
     if (voice_channel != null) {
         if (voice_channel.members.size != 0 && !voice_channel.members.has(host_user.id)) {
             await interaction.editReply({
                 content: 'そのチャンネルは使用中でし！',
+                ephemeral: true,
+            });
+            return;
+        } else if (!usable_channel.includes(voice_channel.name)) {
+            await interaction.editReply({
+                content: 'そのチャンネルは指定できないでし！\n🔉alfa ～ 🔉mikeの間のチャンネルで指定するでし！',
                 ephemeral: true,
             });
             return;
@@ -233,18 +241,19 @@ async function sendLeagueMatch(interaction, channel, txt, recruit_num, condition
             } else {
                 sentMessage.edit({ components: [recruitActionRowWithChannel(sentMessage, host_user, reserve_channel.id)] });
             }
-        } else {
-            return;
         }
 
         // 2時間後にボタンを無効化する
-        setTimeout(function async() {
-            const host_mention = `<@${host_user.id}>`;
-            sentMessage.edit({
-                content: `${host_mention}たんの募集は〆！`,
-                components: [disableButtons()],
-            });
-        }, 7200000 - 15000);
+        await sleep(7200000 - 15000);
+        const host_mention = `<@${host_user.id}>`;
+        sentMessage.edit({
+            content: `${host_mention}たんの募集は〆！`,
+            components: [disableButtons()],
+        });
+        if (reserve_channel != null) {
+            reserve_channel.permissionOverwrites.delete(interaction.guild.roles.everyone, 'UnLock Voice Channel');
+            reserve_channel.permissionOverwrites.delete(host_user, 'UnLock Voice Channel');
+        }
     } catch (error) {
         console.log(error);
     }

--- a/app/cmd/recruit/league_recruit.js
+++ b/app/cmd/recruit/league_recruit.js
@@ -3,8 +3,15 @@ const path = require('path');
 const fetch = require('node-fetch');
 const { stage2txt, rule2txt, unixTime2hm, unixTime2ymdw } = require('../../common.js');
 const { createRoundRect, drawArcImage } = require('./canvas_components.js');
-const { recruitDeleteButton, recruitActionRow, disableButtons } = require('./button_components.js');
-const { MessageAttachment } = require('discord.js');
+const {
+    recruitDeleteButton,
+    recruitActionRow,
+    disableButtons,
+    recruitDeleteButtonWithChannel,
+    recruitActionRowWithChannel,
+    unlockChannelButton,
+} = require('./button_components.js');
+const { MessageAttachment, Permissions } = require('discord.js');
 const schedule_url = 'https://splatoon2.ink/data/schedules.json';
 
 Canvas.registerFont(path.resolve('./fonts/Splatfont.ttf'), { family: 'Splatfont' });
@@ -23,6 +30,7 @@ async function leagueRecruit(interaction) {
 
     const options = interaction.options;
     const channel = interaction.channel;
+    const voice_channel = interaction.options.getChannel('使用チャンネル');
     let recruit_num = options.getInteger('募集人数');
     let condition = options.getString('参加条件');
     let host_user = interaction.member.user;
@@ -62,6 +70,16 @@ async function leagueRecruit(interaction) {
 
     // 'インタラクションに失敗'が出ないようにするため
     await interaction.deferReply({ ephemeral: true });
+
+    if (voice_channel != null) {
+        if (voice_channel.members.size != 0 && !voice_channel.members.has(host_user.id)) {
+            await interaction.editReply({
+                content: 'そのチャンネルは使用中でし！',
+                ephemeral: true,
+            });
+            return;
+        }
+    }
 
     // 新入部員用リグマ募集ようにメンションを変更
     let mention = '@everyone';
@@ -156,9 +174,17 @@ async function sendLeagueMatch(interaction, channel, txt, recruit_num, condition
             break;
     }
 
+    const reserve_channel = interaction.options.getChannel('使用チャンネル');
+
+    if (reserve_channel == null) {
+        channel_name = '🔉 VC指定なし';
+    } else {
+        channel_name = '🔉 ' + reserve_channel.name;
+    }
+
     const thumbnail = [thumbnail_url, thumbnailXP, thumbnailYP, thumbScaleX, thumbScaleY];
 
-    const recruitBuffer = await recruitCanvas(recruit_num, count, host_user, user1, user2, condition);
+    const recruitBuffer = await recruitCanvas(recruit_num, count, host_user, user1, user2, condition, channel_name);
     const recruit = new MessageAttachment(recruitBuffer, 'ikabu_recruit.png');
 
     const rule = new MessageAttachment(await ruleCanvas(l_rule, l_date, l_time, l_stage1, l_stage2, stageImages, thumbnail), 'stages.png');
@@ -170,16 +196,30 @@ async function sendLeagueMatch(interaction, channel, txt, recruit_num, condition
         });
 
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
-        sentMessage.edit({ components: [recruitDeleteButton(sentMessage, host_user)] });
+        if (reserve_channel == null) {
+            sentMessage.edit({ components: [recruitDeleteButton(sentMessage, host_user)] });
+        } else {
+            sentMessage.edit({ components: [recruitDeleteButtonWithChannel(sentMessage, host_user, reserve_channel.id)] });
+            reserve_channel.permissionOverwrites.set(
+                [
+                    { id: interaction.guild.roles.everyone.id, deny: [Permissions.FLAGS.CONNECT] },
+                    { id: host_user.id, allow: [Permissions.FLAGS.CONNECT] },
+                ],
+                'Reserve Voice Channel',
+            );
+        }
+
         if (count == 2) {
             await interaction.editReply({
                 content:
                     '2リグで募集がかかったでし！\n4リグで募集をたてるには参加者に指定するか、募集人数を変更して募集し直すでし！\n15秒間は募集を取り消せるでし！',
+                components: reserve_channel != null ? [unlockChannelButton(reserve_channel.id)] : [],
                 ephemeral: true,
             });
         } else {
             await interaction.editReply({
                 content: '募集完了でし！参加者が来るまで待つでし！\n15秒間は募集を取り消せるでし！',
+                components: reserve_channel != null ? [unlockChannelButton(reserve_channel.id)] : [],
                 ephemeral: true,
             });
         }
@@ -188,7 +228,11 @@ async function sendLeagueMatch(interaction, channel, txt, recruit_num, condition
         await sleep(15000);
         let cmd_message = await channel.messages.cache.get(sentMessage.id);
         if (cmd_message != undefined) {
-            sentMessage.edit({ components: [recruitActionRow(sentMessage, host_user)] });
+            if (reserve_channel == null) {
+                sentMessage.edit({ components: [recruitActionRow(sentMessage, host_user)] });
+            } else {
+                sentMessage.edit({ components: [recruitActionRowWithChannel(sentMessage, host_user, reserve_channel.id)] });
+            }
         } else {
             return;
         }
@@ -209,7 +253,7 @@ async function sendLeagueMatch(interaction, channel, txt, recruit_num, condition
 /*
  * 募集用のキャンバス(1枚目)を作成する
  */
-async function recruitCanvas(recruit_num, count, host_user, user1, user2, condition) {
+async function recruitCanvas(recruit_num, count, host_user, user1, user2, condition, channel_name) {
     blank_avatar_url = 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/blank_avatar.png'; // blankのアバター画像URL
 
     const recruitCanvas = Canvas.createCanvas(720, 550);
@@ -229,8 +273,8 @@ async function recruitCanvas(recruit_num, count, host_user, user1, user2, condit
     recruit_ctx.font = '50px Splatfont';
     recruit_ctx.fillStyle = '#F02D7E';
     recruit_ctx.fillText('リーグマッチ', 115, 80);
-    recruit_ctx.strokeStyle = '#FFFFFF';
-    recruit_ctx.lineWidth = 2;
+    recruit_ctx.strokeStyle = '#bd2363';
+    recruit_ctx.lineWidth = 1;
     recruit_ctx.strokeText('リーグマッチ', 115, 80);
 
     // 募集主の画像
@@ -310,6 +354,7 @@ async function recruitCanvas(recruit_num, count, host_user, user1, user2, condit
     recruit_ctx.font = '30px "Genshin", "SEGUI"';
     const width = 600;
     const size = 40;
+    const column_num = 4;
     let column = [''];
     let line = 0;
     condition = condition.replace('{br}', '\n', 'gm');
@@ -329,15 +374,22 @@ async function recruitCanvas(recruit_num, count, host_user, user1, user2, condit
         }
     }
 
-    if (column.length > 5) {
-        column[4] += '…';
+    if (column.length > column_num) {
+        column[column_num - 1] += '…';
     }
 
     for (var j = 0; j < column.length; j++) {
-        if (j < 5) {
-            recruit_ctx.fillText(column[j], 65, 350 + size * j);
+        if (j < column_num) {
+            recruit_ctx.fillText(column[j], 65, 345 + size * j);
         }
     }
+
+    recruit_ctx.font = '37px Splatfont';
+    recruit_ctx.fillStyle = '#FFFFFF';
+    recruit_ctx.fillText(channel_name, 30, 520);
+    recruit_ctx.strokeStyle = '#2D3130';
+    recruit_ctx.lineWidth = 1.0;
+    recruit_ctx.strokeText(channel_name, 30, 520);
 
     const recruit = recruitCanvas.toBuffer();
     return recruit;

--- a/app/cmd/recruit/other_game_recruit.js
+++ b/app/cmd/recruit/other_game_recruit.js
@@ -1,5 +1,5 @@
 const { MessageEmbed } = require('discord.js');
-const { recruitDeleteButton, recruitActionRow, disableButtons } = require('./button_components.js');
+const { recruitDeleteButton, recruitActionRow } = require('./button_components.js');
 
 module.exports = {
     otherGameRecruit: otherGameRecruit,
@@ -7,11 +7,15 @@ module.exports = {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-function otherGameRecruit(interaction) {
+async function otherGameRecruit(interaction) {
     // subCommands取得
     if (!interaction.isCommand()) return;
 
+    // 募集がfollowUpでないとリグマと同じfunctionでeditできないため
+    await interaction.deferReply();
+
     const options = interaction.options;
+
     if (options.getSubcommand() === 'apex') {
         apexLegends(interaction);
     } else if (options.getSubcommand() === 'mhr') {
@@ -110,13 +114,13 @@ async function sendOtherGames(interaction, title, recruitNumText, txt, color, im
         .setThumbnail(logo);
 
     try {
-        await interaction.reply({
-            content: '募集完了でし！参加者が来るまで気長に待つでし！\n15秒間は募集を取り消せるでし！',
-            ephemeral: true,
-        });
-        const sentMessage = await interaction.channel.send({
+        const sentMessage = await interaction.followUp({
             content: txt,
             embeds: [embed],
+        });
+        await interaction.followUp({
+            content: '募集完了でし！参加者が来るまで気長に待つでし！\n15秒間は募集を取り消せるでし！',
+            ephemeral: true,
         });
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
         sentMessage.edit({ components: [recruitDeleteButton(sentMessage, interaction.member)] });
@@ -129,14 +133,6 @@ async function sendOtherGames(interaction, title, recruitNumText, txt, color, im
         } else {
             return;
         }
-
-        setTimeout(function () {
-            const host_mention = `<@${interaction.member.id}>`;
-            sentMessage.edit({
-                content: `${host_mention}たんの募集は〆！`,
-                components: [disableButtons()],
-            });
-        }, 7200000);
     } catch (error) {
         console.log(error);
     }

--- a/app/cmd/recruit/other_game_recruit.js
+++ b/app/cmd/recruit/other_game_recruit.js
@@ -28,80 +28,61 @@ function otherGameRecruit(interaction) {
 function monsterHunterRise(interaction) {
     const role_id = interaction.member.guild.roles.cache.find((role) => role.name === 'ハンター');
     let title = 'MONSTER HUNTER RISE';
+    let recruitNumText = interaction.options.getString('募集人数');
     let txt = role_id.toString() + ' 【モンハンライズ募集】\n' + `<@${interaction.member.id}>` + 'たんがモンハンライズ参加者募集中でし！\n';
     let color = '#b71008';
     const image = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/MonsterHunterRiseSunBreak.jpg';
     const logo = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/MonsterHunterRiseSunBreak_logo.png';
-    sendOtherGames(interaction, title, txt, color, image, logo);
+    sendOtherGames(interaction, title, recruitNumText, txt, color, image, logo);
 }
 
 function apexLegends(interaction) {
     const role_id = interaction.member.guild.roles.cache.find((role) => role.name === 'レジェンド');
     let title = 'Apex Legends';
+    let recruitNumText = interaction.options.getString('募集人数');
     let txt = role_id.toString() + ' 【Apex Legends募集】\n' + `<@${interaction.member.id}>` + 'たんがApexLegendsの参加者募集中でし！\n';
     let color = '#F30100';
     const image = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/ApexLegends.jpg';
     const logo = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/ApexLegends_logo.png';
-    sendOtherGames(interaction, title, txt, color, image, logo);
+    sendOtherGames(interaction, title, recruitNumText, txt, color, image, logo);
 }
 
 function deadByDayLight(interaction) {
     const role_id = interaction.member.guild.roles.cache.find((role) => role.name === 'DbD');
     let title = 'Dead by Daylight';
+    let recruitNumText = interaction.options.getString('募集人数');
     const txt = role_id.toString() + ' 【Dead by Daylight募集】\n' + `<@${interaction.member.id}>` + 'たんがDbD参加者募集中でし！\n';
     let color = '#84331F';
     const image = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/DeadByDaylight.jpg';
     const logo = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/deadbydaylight_logo.png';
-    sendOtherGames(interaction, title, txt, color, image, logo);
+    sendOtherGames(interaction, title, recruitNumText, txt, color, image, logo);
 }
 
 function valorant(interaction) {
     const role_id = interaction.member.guild.roles.cache.find((role) => role.name === 'エージェント');
     let title = 'VALORANT';
+    let recruitNumText = interaction.options.getString('募集人数');
     const txt = role_id.toString() + ' 【VALORANT募集】\n' + `<@${interaction.member.id}>` + 'たんがVALORANT参加者募集中でし！\n';
     let color = '#FF4654';
     const image = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/valorant.jpg';
     const logo = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/valorant_logo.png';
-    sendOtherGames(interaction, title, txt, color, image, logo);
+    sendOtherGames(interaction, title, recruitNumText, txt, color, image, logo);
 }
 
 function others(interaction) {
     const role_id = interaction.member.guild.roles.cache.find((role) => role.name === '別ゲー');
     let title = interaction.options.getString('ゲームタイトル');
+    let recruitNumText = interaction.options.getString('募集人数');
     const txt = role_id.toString() + ` 【${title}募集】\n` + `<@${interaction.member.id}>` + `たんが${title}参加者募集中でし！\n`;
     let color = '#379C30';
     const image = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/others.jpg';
     const logo = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/others_logo.png';
-    sendOtherGames(interaction, title, txt, color, image, logo);
+    sendOtherGames(interaction, title, recruitNumText, txt, color, image, logo);
 }
 
-async function sendOtherGames(interaction, title, txt, color, image, logo) {
+async function sendOtherGames(interaction, title, recruitNumText, txt, color, image, logo) {
     let options = interaction.options;
-    let recruitMinNum = options.getInteger('募集人数');
-    let recruitMaxNum = options.getInteger('最大人数');
-    if (recruitMinNum <= 0) {
-        await interaction.reply({
-            content: 'デバッグしようとする頭の良い子は嫌いでし！',
-            ephemeral: true,
-        });
-        return;
-    }
-    if (recruitMaxNum != null && recruitMaxNum <= 0) {
-        await interaction.reply({
-            content: 'デバッグしようとする頭の良い子は嫌いでし！',
-            ephemeral: true,
-        });
-        return;
-    }
-    if (recruitMaxNum != null && recruitMinNum >= recruitMaxNum) {
-        await interaction.reply({
-            content: '最大人数に募集人数より少ない数は設定できないでし！',
-            ephemeral: true,
-        });
-        return;
-    }
-    let recruitNumText = recruitMinNum.toString();
-    if (recruitMaxNum != null) recruitNumText = recruitNumText + `～` + recruitMaxNum.toString();
+
     let condition = options.getString('内容または参加条件');
 
     let authorName = interaction.member.nickname == null ? interaction.member.user.username : interaction.member.nickname;
@@ -117,7 +98,7 @@ async function sendOtherGames(interaction, title, txt, color, image, logo) {
         .addFields([
             {
                 name: '募集人数',
-                value: '＠' + recruitNumText,
+                value: recruitNumText,
             },
             {
                 name: '参加条件',

--- a/app/cmd/recruit/private_recruit.js
+++ b/app/cmd/recruit/private_recruit.js
@@ -1,5 +1,5 @@
 const { MessageEmbed } = require('discord.js');
-const { recruitDeleteButton, recruitActionRow, disableButtons } = require('./button_components.js');
+const { recruitDeleteButton, recruitActionRow } = require('./button_components.js');
 
 module.exports = {
     privateRecruit: privateRecruit,
@@ -19,6 +19,9 @@ async function privateRecruit(interaction) {
     let logo = 'https://cdn.wikimg.net/en/splatoonwiki/images/1/1a/Private-battles-badge%402x.png';
     let authorName = interaction.member.nickname == null ? interaction.member.user.username : interaction.member.nickname;
     let authorAvatarUrl = interaction.member.user.avatarURL();
+
+    // 募集がfollowUpでないとリグマと同じfunctionでeditできないため
+    await interaction.deferReply();
 
     const embed = new MessageEmbed()
         .setAuthor({
@@ -49,13 +52,14 @@ async function privateRecruit(interaction) {
         .setThumbnail(logo);
 
     try {
-        await interaction.reply({
-            content: '募集完了でし！参加者が来るまで気長に待つでし！\n15秒間は募集を取り消せるでし！',
-            ephemeral: true,
-        });
-        const sentMessage = await interaction.channel.send({
+        const sentMessage = await interaction.followUp({
             content: `@everyone \n<@${interaction.member.id}>たんがプライベートマッチ募集中でし！`,
             embeds: [embed],
+            ephemeral: false,
+        });
+        await interaction.followUp({
+            content: '募集完了でし！参加者が来るまで気長に待つでし！\n15秒間は募集を取り消せるでし！',
+            ephemeral: true,
         });
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
         sentMessage.edit({ components: [recruitDeleteButton(sentMessage, interaction.member)] });
@@ -68,14 +72,6 @@ async function privateRecruit(interaction) {
         } else {
             return;
         }
-
-        setTimeout(function () {
-            const host_mention = `<@${interaction.member.id}>`;
-            sentMessage.edit({
-                content: `${host_mention}たんの募集は〆！`,
-                components: [disableButtons()],
-            });
-        }, 7200000);
     } catch (error) {
         console.log(error);
     }

--- a/app/cmd/recruit/private_recruit.js
+++ b/app/cmd/recruit/private_recruit.js
@@ -13,31 +13,8 @@ async function privateRecruit(interaction) {
     const options = interaction.options;
     let start_time = interaction.options.getString('開始時刻');
     let time = interaction.options.getString('所要時間');
-    let recruitMinNum = options.getInteger('募集人数');
-    let recruitMaxNum = options.getInteger('最大人数');
-    if (recruitMinNum <= 0) {
-        await interaction.reply({
-            content: 'デバッグしようとする頭の良い子は嫌いでし！',
-            ephemeral: true,
-        });
-        return;
-    }
-    if (recruitMaxNum != null && recruitMaxNum <= 0) {
-        await interaction.reply({
-            content: 'デバッグしようとする頭の良い子は嫌いでし！',
-            ephemeral: true,
-        });
-        return;
-    }
-    if (recruitMaxNum != null && recruitMinNum >= recruitMaxNum) {
-        await interaction.reply({
-            content: '最大人数に募集人数より少ない数は設定できないでし！',
-            ephemeral: true,
-        });
-        return;
-    }
-    let recruitNumText = recruitMinNum.toString();
-    if (recruitMaxNum != null) recruitNumText = recruitNumText + `～` + recruitMaxNum.toString();
+    let recruitNumText = options.getString('募集人数');
+
     let condition = options.getString('内容または参加条件');
     let logo = 'https://cdn.wikimg.net/en/splatoonwiki/images/1/1a/Private-battles-badge%402x.png';
     let authorName = interaction.member.nickname == null ? interaction.member.user.username : interaction.member.nickname;
@@ -60,7 +37,7 @@ async function privateRecruit(interaction) {
             },
             {
                 name: '募集人数',
-                value: '＠' + recruitNumText,
+                value: recruitNumText,
             },
             {
                 name: 'プラベ内容または参加条件',

--- a/app/cmd/recruit/regular_recruit.js
+++ b/app/cmd/recruit/regular_recruit.js
@@ -1,0 +1,427 @@
+const Canvas = require('canvas');
+const path = require('path');
+const fetch = require('node-fetch');
+const { stage2txt, rule2txt, unixTime2hm, unixTime2ymdw } = require('../../common.js');
+const { createRoundRect, drawArcImage, fillTextWithStroke } = require('./canvas_components.js');
+const {
+    recruitDeleteButton,
+    recruitActionRow,
+    disableButtons,
+    recruitDeleteButtonWithChannel,
+    recruitActionRowWithChannel,
+    unlockChannelButton,
+} = require('./button_components.js');
+const { MessageAttachment, Permissions } = require('discord.js');
+const schedule_url = 'https://splatoon2.ink/data/schedules.json';
+
+Canvas.registerFont(path.resolve('./fonts/Splatfont.ttf'), { family: 'Splatfont' });
+Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Medium.ttf'), { family: 'Genshin' });
+Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Bold.ttf'), { family: 'Genshin-Bold' });
+Canvas.registerFont(path.resolve('./fonts/SEGUISYM.TTF'), { family: 'SEGUI' });
+
+module.exports = {
+    regularRecruit: regularRecruit,
+};
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function regularRecruit(interaction) {
+    if (!interaction.isCommand()) return;
+
+    const options = interaction.options;
+    const channel = interaction.channel;
+    const voice_channel = interaction.options.getChannel('使用チャンネル');
+    let recruit_num = options.getInteger('募集人数');
+    let condition = options.getString('参加条件');
+    let host_user = interaction.member.user;
+    let user1 = options.getUser('参加者1');
+    let user2 = options.getUser('参加者2');
+    let user3 = options.getUser('参加者3');
+    let member_counter = recruit_num; // プレイ人数のカウンター
+    let type;
+
+    if (options.getSubcommand() === 'now') {
+        type = 0;
+    } else if (options.getSubcommand() === 'next') {
+        type = 1;
+    }
+
+    if (recruit_num < 1 || recruit_num > 7) {
+        await interaction.reply({
+            content: '募集人数は1～7までで指定するでし！',
+            ephemeral: true,
+        });
+        return;
+    } else {
+        member_counter++;
+    }
+
+    // プレイヤー指定があればカウンターを増やす
+    if (user1 != null) member_counter++;
+    if (user2 != null) member_counter++;
+    if (user3 != null) member_counter++;
+
+    if (member_counter > 8) {
+        await interaction.reply({
+            content: '募集人数がおかしいでし！',
+            ephemeral: true,
+        });
+        return;
+    }
+
+    var usable_channel = ['alfa', 'bravo', 'charlie', 'delta', 'echo', 'fox', 'golf', 'hotel', 'india', 'juliett', 'kilo', 'lima', 'mike'];
+
+    if (voice_channel != null) {
+        if (voice_channel.members.size != 0 && !voice_channel.members.has(host_user.id)) {
+            await interaction.reply({
+                content: 'そのチャンネルは使用中でし！',
+                ephemeral: true,
+            });
+            return;
+        } else if (!usable_channel.includes(voice_channel.name)) {
+            await interaction.reply({
+                content: 'そのチャンネルは指定できないでし！\n🔉alfa ～ 🔉mikeの間のチャンネルで指定するでし！',
+                ephemeral: true,
+            });
+            return;
+        }
+    }
+
+    // 'インタラクションに失敗'が出ないようにするため
+    await interaction.deferReply();
+
+    try {
+        const response = await fetch(schedule_url);
+        const data = await response.json();
+        const args = getRegular(data, type).split(',');
+        let txt = '@everyone 【ナワバリ募集】\n' + `<@${host_user.id}>` + 'たんがナワバリ中でし！\n';
+        let members = [];
+
+        if (user1 != null) {
+            members.push(`<@${user1.id}>` + 'たん');
+        }
+        if (user2 != null) {
+            members.push(`<@${user2.id}>` + 'たん');
+        }
+        if (user3 != null) {
+            members.push(`<@${user3.id}>` + 'たん');
+        }
+
+        if (members.length != 0) {
+            for (let i in members) {
+                if (i == 0) {
+                    txt = txt + members[i];
+                } else {
+                    txt = txt + 'と' + members[i];
+                }
+            }
+            txt += 'の参加が既に決定しているでし！\n';
+        }
+
+        txt += 'よければ合流しませんか？';
+
+        if (condition == null) condition = 'なし';
+        const stage_a = 'https://splatoon2.ink/assets/splatnet' + data.regular[type].stage_a.image;
+        const stage_b = 'https://splatoon2.ink/assets/splatnet' + data.regular[type].stage_b.image;
+        const stageImages = [stage_a, stage_b];
+        await sendRegularMatch(
+            interaction,
+            channel,
+            txt,
+            recruit_num,
+            condition,
+            member_counter,
+            host_user,
+            user1,
+            user2,
+            user3,
+            args,
+            stageImages,
+        );
+    } catch (error) {
+        channel.send('なんかエラーでてるわ');
+        console.error(error);
+    }
+}
+
+async function sendRegularMatch(
+    interaction,
+    channel,
+    txt,
+    recruit_num,
+    condition,
+    count,
+    host_user,
+    user1,
+    user2,
+    user3,
+    args,
+    stageImages,
+) {
+    let r_date = args[0]; // 日付
+    let r_time = args[1]; // 時間
+    let r_rule = 'ナワバリバトル';
+    let r_stage1 = args[3]; // ステージ1
+    let r_stage2 = args[4]; // ステージ2
+
+    const reserve_channel = interaction.options.getChannel('使用チャンネル');
+
+    if (reserve_channel == null) {
+        channel_name = '🔉 VC指定なし';
+    } else {
+        channel_name = '🔉 ' + reserve_channel.name;
+    }
+
+    const recruitBuffer = await recruitCanvas(recruit_num, count, host_user, user1, user2, user3, condition, channel_name);
+    const recruit = new MessageAttachment(recruitBuffer, 'ikabu_recruit.png');
+
+    const rule = new MessageAttachment(await ruleCanvas(r_rule, r_date, r_time, r_stage1, r_stage2, stageImages), 'rules.png');
+
+    try {
+        const sentMessage = await interaction.followUp({
+            content: txt,
+            files: [recruit, rule],
+            ephemeral: false,
+        });
+
+        // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
+        if (reserve_channel == null) {
+            sentMessage.edit({ components: [recruitDeleteButton(sentMessage, host_user)] });
+        } else {
+            sentMessage.edit({ components: [recruitDeleteButtonWithChannel(sentMessage, host_user, reserve_channel.id)] });
+            reserve_channel.permissionOverwrites.set(
+                [
+                    { id: interaction.guild.roles.everyone.id, deny: [Permissions.FLAGS.CONNECT] },
+                    { id: host_user.id, allow: [Permissions.FLAGS.CONNECT] },
+                ],
+                'Reserve Voice Channel',
+            );
+        }
+
+        await interaction.followUp({
+            content: '募集完了でし！参加者が来るまで待つでし！\n15秒間は募集を取り消せるでし！',
+            components: reserve_channel != null ? [unlockChannelButton(reserve_channel.id)] : [],
+            ephemeral: true,
+        });
+
+        // 15秒後に削除ボタンを消す
+        await sleep(15000);
+        let cmd_message = await channel.messages.cache.get(sentMessage.id);
+        if (cmd_message != undefined) {
+            if (reserve_channel == null) {
+                sentMessage.edit({ components: [recruitActionRow(sentMessage, host_user)] });
+            } else {
+                sentMessage.edit({ components: [recruitActionRowWithChannel(sentMessage, host_user, reserve_channel.id)] });
+            }
+        }
+
+        // 2時間後にボタンを無効化する
+        await sleep(7200000 - 15000);
+        const host_mention = `<@${host_user.id}>`;
+        sentMessage.edit({
+            content: `${host_mention}たんの募集は〆！`,
+            components: [disableButtons()],
+        });
+        if (reserve_channel != null) {
+            reserve_channel.permissionOverwrites.delete(interaction.guild.roles.everyone, 'UnLock Voice Channel');
+            reserve_channel.permissionOverwrites.delete(host_user, 'UnLock Voice Channel');
+        }
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+/*
+ * 募集用のキャンバス(1枚目)を作成する
+ */
+async function recruitCanvas(recruit_num, count, host_user, user1, user2, user3, condition, channel_name) {
+    blank_avatar_url = 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/blank_avatar.png'; // blankのアバター画像URL
+
+    const recruitCanvas = Canvas.createCanvas(720, 550);
+    const recruit_ctx = recruitCanvas.getContext('2d');
+
+    // 下地
+    createRoundRect(recruit_ctx, 1, 1, 718, 548, 30);
+    recruit_ctx.fillStyle = '#2F3136';
+    recruit_ctx.fill();
+    recruit_ctx.strokeStyle = '#FFFFFF';
+    recruit_ctx.lineWidth = 4;
+    recruit_ctx.stroke();
+
+    let regular_icon = await Canvas.loadImage('https://splatoon2.ink/assets/img/battle-regular.01b5ef.png');
+    recruit_ctx.drawImage(regular_icon, 25, 25, 70, 70);
+
+    fillTextWithStroke(recruit_ctx, 'レギュラーマッチ', '50px Splatfont', '#CFF622', '#45520B', 1, 115, 80);
+
+    let member_urls = [];
+
+    if (user1 != null) {
+        member_urls.push(user1.displayAvatarURL({ format: 'png' }));
+    }
+    if (user2 != null) {
+        member_urls.push(user2.displayAvatarURL({ format: 'png' }));
+    }
+    if (user3 != null) {
+        member_urls.push(user3.displayAvatarURL({ format: 'png' }));
+    }
+
+    // 募集主の画像
+    let host_img = await Canvas.loadImage(host_user.displayAvatarURL({ format: 'png' }));
+    recruit_ctx.save();
+    drawArcImage(recruit_ctx, host_img, 40, 120, 40);
+    recruit_ctx.strokeStyle = '#1e1f23';
+    recruit_ctx.lineWidth = 9;
+    recruit_ctx.stroke();
+    recruit_ctx.restore();
+
+    for (let i = 0; i < 7; i++) {
+        if (count >= i + 2) {
+            let user_url = member_urls[i] != null ? member_urls[i] : blank_avatar_url;
+            let user_img = await Canvas.loadImage(user_url);
+            recruit_ctx.save();
+            if (i < 3) {
+                drawArcImage(recruit_ctx, user_img, (i + 1) * 100 + 40, 120, 40);
+            } else {
+                drawArcImage(recruit_ctx, user_img, (i - 3) * 100 + 40, 220, 40);
+            }
+            recruit_ctx.strokeStyle = '#1e1f23';
+            recruit_ctx.lineWidth = 9;
+            recruit_ctx.stroke();
+            recruit_ctx.restore();
+        }
+    }
+
+    let host_icon = await Canvas.loadImage('https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/squid.png');
+    recruit_ctx.drawImage(host_icon, 0, 0, host_icon.width, host_icon.height, 75, 155, 75, 75);
+
+    recruit_ctx.save();
+    recruit_ctx.textAlign = 'right';
+    fillTextWithStroke(recruit_ctx, channel_name, '33px "Splatfont"', '#FFFFFF', '#2D3130', 1, 680, 60);
+    recruit_ctx.restore();
+
+    fillTextWithStroke(recruit_ctx, '募集人数', '41px "Splatfont"', '#FFFFFF', '#2D3130', 1, 490, 185);
+
+    fillTextWithStroke(recruit_ctx, '@' + recruit_num, '43px "Splatfont"', '#FFFFFF', '#2D3130', 1, 535, 248);
+
+    fillTextWithStroke(recruit_ctx, '参加条件', '43px "Splatfont"', '#FFFFFF', '#2D3130', 1, 35, 360);
+
+    recruit_ctx.font = '31px "Genshin", "SEGUI"';
+    const width = 603;
+    const size = 40;
+    const column_num = 3;
+    let column = [''];
+    let line = 0;
+    condition = condition.replace('{br}', '\n', 'gm');
+
+    // 幅に合わせて自動改行
+    for (var i = 0; i < condition.length; i++) {
+        var char = condition.charAt(i);
+
+        if (char == '\n') {
+            line++;
+            column[line] = '';
+        } else if (recruit_ctx.measureText(column[line] + char).width > width) {
+            line++;
+            column[line] = char;
+        } else {
+            column[line] += char;
+        }
+    }
+
+    if (column.length > column_num) {
+        column[column_num - 1] += '…';
+    }
+
+    for (var j = 0; j < column.length; j++) {
+        if (j < column_num) {
+            recruit_ctx.fillText(column[j], 65, 415 + size * j);
+        }
+    }
+
+    const recruit = recruitCanvas.toBuffer();
+    return recruit;
+}
+
+/*
+ * ルール情報のキャンバス(2枚目)を作成する
+ */
+async function ruleCanvas(r_rule, r_date, r_time, r_stage1, r_stage2, stageImages) {
+    const ruleCanvas = Canvas.createCanvas(720, 550);
+    const rule_ctx = ruleCanvas.getContext('2d');
+
+    createRoundRect(rule_ctx, 1, 1, 718, 548, 30);
+    rule_ctx.fillStyle = '#2F3136';
+    rule_ctx.fill();
+    rule_ctx.strokeStyle = '#FFFFFF';
+    rule_ctx.lineWidth = 4;
+    rule_ctx.stroke();
+
+    fillTextWithStroke(rule_ctx, 'ルール', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 80);
+
+    rule_width = rule_ctx.measureText(r_rule).width;
+    fillTextWithStroke(rule_ctx, r_rule, '45px Splatfont', '#FFFFFF', '#2D3130', 1, (320 - rule_width) / 2, 145); // 中央寄せ
+
+    fillTextWithStroke(rule_ctx, '日時', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 220);
+
+    date_width = rule_ctx.measureText(r_date).width;
+    fillTextWithStroke(rule_ctx, r_date, '35px Splatfont', '#FFFFFF', '#2D3130', 1, (350 - date_width) / 2, 270); // 中央寄せ
+
+    time_width = rule_ctx.measureText(r_time).width;
+    fillTextWithStroke(rule_ctx, r_time, '35px Splatfont', '#FFFFFF', '#2D3130', 1, 15 + (350 - time_width) / 2, 320); // 中央寄せ
+
+    fillTextWithStroke(rule_ctx, 'ステージ', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 390);
+
+    stage1_width = rule_ctx.measureText(r_stage1).width;
+    fillTextWithStroke(rule_ctx, r_stage1, '35px Splatfont', '#FFFFFF', '#2D3130', 1, (350 - stage1_width) / 2 + 10, 440); // 中央寄せ
+
+    stage2_width = rule_ctx.measureText(r_stage2).width;
+    fillTextWithStroke(rule_ctx, r_stage2, '35px Splatfont', '#FFFFFF', '#2D3130', 1, (350 - stage2_width) / 2 + 10, 490); // 中央寄せ
+
+    let stage1_img = await Canvas.loadImage(stageImages[0]);
+    rule_ctx.save();
+    rule_ctx.beginPath();
+    createRoundRect(rule_ctx, 370, 130, 308, 176, 10);
+    rule_ctx.clip();
+    rule_ctx.drawImage(stage1_img, 370, 130, 308, 176);
+    rule_ctx.strokeStyle = '#FFFFFF';
+    rule_ctx.lineWidth = 6.0;
+    rule_ctx.stroke();
+    rule_ctx.restore();
+
+    let stage2_img = await Canvas.loadImage(stageImages[1]);
+    rule_ctx.save();
+    rule_ctx.beginPath();
+    createRoundRect(rule_ctx, 370, 340, 308, 176, 10);
+    rule_ctx.clip();
+    rule_ctx.drawImage(stage2_img, 370, 340, 308, 176);
+    rule_ctx.strokeStyle = '#FFFFFF';
+    rule_ctx.lineWidth = 6.0;
+    rule_ctx.stroke();
+    rule_ctx.restore();
+
+    createRoundRect(rule_ctx, 1, 1, 718, 548, 30);
+    rule_ctx.clip();
+
+    const rule = ruleCanvas.toBuffer();
+    return rule;
+}
+
+/**
+ * commonにあるgetRegularを、情報を2行に分けるためにカスタムしたもの
+ */
+function getRegular(data, x) {
+    let stage1;
+    let stage2;
+    let date;
+    let time;
+    let rule;
+    let rstr;
+
+    date = unixTime2ymdw(data.regular[x].start_time);
+    time = unixTime2hm(data.regular[x].start_time) + ' – ' + unixTime2hm(data.regular[x].end_time);
+    rule = rule2txt(data.regular[x].rule.key);
+    stage1 = stage2txt(data.regular[x].stage_a.id);
+    stage2 = stage2txt(data.regular[x].stage_b.id);
+    rstr = date + ',' + time + ',' + rule + ',' + stage1 + ',' + stage2;
+    return rstr;
+}

--- a/app/cmd/recruit/salmon_recruit.js
+++ b/app/cmd/recruit/salmon_recruit.js
@@ -2,7 +2,7 @@ const Canvas = require('canvas');
 const path = require('path');
 const fetch = require('node-fetch');
 const { unixTime2mdwhm, coop_stage2txt, weapon2txt } = require('../../common.js');
-const { createRoundRect, drawArcImage } = require('./canvas_components.js');
+const { createRoundRect, drawArcImage, fillTextWithStroke } = require('./canvas_components.js');
 const {
     recruitDeleteButton,
     recruitActionRow,
@@ -59,26 +59,26 @@ async function salmonRecruit(interaction) {
         return;
     }
 
-    // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply();
-
     var usable_channel = ['alfa', 'bravo', 'charlie', 'delta', 'echo', 'fox', 'golf', 'hotel', 'india', 'juliett', 'kilo', 'lima', 'mike'];
 
     if (voice_channel != null) {
         if (voice_channel.members.size != 0 && !voice_channel.members.has(host_user.id)) {
-            await interaction.editReply({
+            await interaction.reply({
                 content: 'そのチャンネルは使用中でし！',
                 ephemeral: true,
             });
             return;
         } else if (!usable_channel.includes(voice_channel.name)) {
-            await interaction.editReply({
+            await interaction.reply({
                 content: 'そのチャンネルは指定できないでし！\n🔉alfa ～ 🔉limaの間のチャンネルで指定するでし！',
                 ephemeral: true,
             });
             return;
         }
     }
+
+    // 'インタラクションに失敗'が出ないようにするため
+    await interaction.deferReply();
 
     try {
         const response = await fetch(coop_schedule_url);
@@ -188,12 +188,7 @@ async function recruitCanvas(recruit_num, count, host_user, user1, user2, condit
     let league_icon = await Canvas.loadImage('https://splatoon2.ink/assets/img/salmon-run-mini.aee5e8.png');
     recruit_ctx.drawImage(league_icon, 22, 35, 80, 52.8);
 
-    recruit_ctx.font = '50px Splatfont';
-    recruit_ctx.fillStyle = '#FF5600';
-    recruit_ctx.fillText('サーモンラン', 115, 80);
-    recruit_ctx.strokeStyle = '#ff9a00';
-    recruit_ctx.lineWidth = 2;
-    recruit_ctx.strokeText('サーモンラン', 115, 80);
+    fillTextWithStroke(recruit_ctx, 'サーモンラン', '50px Splatfont', '#FF5600', '#FF9A00', 2, 115, 80);
 
     // 募集主の画像
     let host_img = await Canvas.loadImage(host_user.displayAvatarURL({ format: 'png' }));
@@ -250,26 +245,11 @@ async function recruitCanvas(recruit_num, count, host_user, user1, user2, condit
     let host_icon = await Canvas.loadImage('https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/squid.png');
     recruit_ctx.drawImage(host_icon, 0, 0, host_icon.width, host_icon.height, 90, 172, 75, 75);
 
-    recruit_ctx.font = '39px "Splatfont"';
-    recruit_ctx.fillStyle = '#FFFFFF';
-    recruit_ctx.fillText('募集人数', 525, 155);
-    recruit_ctx.strokeStyle = '#2D3130';
-    recruit_ctx.lineWidth = 1.0;
-    recruit_ctx.strokeText('募集人数', 525, 155);
+    fillTextWithStroke(recruit_ctx, '募集人数', '39px "Splatfont"', '#FFFFFF', '#2D3130', 1, 525, 155);
 
-    recruit_ctx.font = '42px "Splatfont"';
-    recruit_ctx.fillStyle = '#FFFFFF';
-    recruit_ctx.fillText('@' + recruit_num, 580, 218);
-    recruit_ctx.strokeStyle = '#2D3130';
-    recruit_ctx.lineWidth = 1.0;
-    recruit_ctx.strokeText('@' + recruit_num, 580, 218);
+    fillTextWithStroke(recruit_ctx, '@' + recruit_num, '42px "Splatfont"', '#FFFFFF', '#2D3130', 1, 580, 218);
 
-    recruit_ctx.font = '43px "Splatfont"';
-    recruit_ctx.fillStyle = '#FFFFFF';
-    recruit_ctx.fillText('参加条件', 35, 290);
-    recruit_ctx.strokeStyle = '#2D3130';
-    recruit_ctx.lineWidth = 1.0;
-    recruit_ctx.strokeText('参加条件', 35, 290);
+    fillTextWithStroke(recruit_ctx, '参加条件', '43px "Splatfont"', '#FFFFFF', '#2D3130', 1, 35, 290);
 
     recruit_ctx.font = '30px "Genshin", "SEGUI"';
     const width = 600;
@@ -304,12 +284,7 @@ async function recruitCanvas(recruit_num, count, host_user, user1, user2, condit
         }
     }
 
-    recruit_ctx.font = '37px Splatfont';
-    recruit_ctx.fillStyle = '#FFFFFF';
-    recruit_ctx.fillText(channel_name, 30, 520);
-    recruit_ctx.strokeStyle = '#2D3130';
-    recruit_ctx.lineWidth = 1.0;
-    recruit_ctx.strokeText(channel_name, 30, 520);
+    fillTextWithStroke(recruit_ctx, channel_name, '37px "Splatfont"', '#FFFFFF', '#2D3130', 1, 30, 520);
 
     const recruit = recruitCanvas.toBuffer();
     return recruit;
@@ -329,27 +304,12 @@ async function ruleCanvas(date, stage, weapon1, weapon2, weapon3, weapon4, stage
     rule_ctx.lineWidth = 4;
     rule_ctx.stroke();
 
-    rule_ctx.font = '32px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText('日時', 35, 80);
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText('日時', 35, 80);
+    fillTextWithStroke(rule_ctx, '日時', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 80);
 
     date_width = rule_ctx.measureText(date).width;
-    rule_ctx.font = '37px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText(date, (650 - date_width) / 2, 145); // 中央寄せ
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText(date, (650 - date_width) / 2, 145);
+    fillTextWithStroke(rule_ctx, date, '37px Splatfont', '#FFFFFF', '#2D3130', 1, (650 - date_width) / 2, 145);
 
-    rule_ctx.font = '32px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText('武器', 35, 245);
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText('武器', 35, 245);
+    fillTextWithStroke(rule_ctx, '武器', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 245);
 
     rule_ctx.save();
     if (weapon1 === '❓') {
@@ -427,20 +387,10 @@ async function ruleCanvas(date, stage, weapon1, weapon2, weapon3, weapon4, stage
     rule_ctx.strokeText(weapon4, (350 - weapons4_width) / 2, 505);
     rule_ctx.restore();
 
-    rule_ctx.font = '33px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText('ステージ', 350, 245);
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText('ステージ', 350, 245);
+    fillTextWithStroke(rule_ctx, 'ステージ', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 350, 245);
 
     stage_width = rule_ctx.measureText(stage).width;
-    rule_ctx.font = '38px "Splatfont"';
-    rule_ctx.fillStyle = '#FFFFFF';
-    rule_ctx.fillText(stage, 150 + (700 - stage_width) / 2, 300);
-    rule_ctx.strokeStyle = '#2D3130';
-    rule_ctx.lineWidth = 1.0;
-    rule_ctx.strokeText(stage, 150 + (700 - stage_width) / 2, 300);
+    fillTextWithStroke(rule_ctx, stage, '38px Splatfont', '#FFFFFF', '#2D3130', 1, 150 + (700 - stage_width) / 2, 300);
 
     let stage_img = await Canvas.loadImage(stageImage);
     rule_ctx.save();

--- a/app/cmd/recruit/salmon_recruit.js
+++ b/app/cmd/recruit/salmon_recruit.js
@@ -63,10 +63,18 @@ async function salmonRecruit(interaction) {
     // 'インタラクションに失敗'が出ないようにするため
     await interaction.deferReply({ ephemeral: true });
 
+    var usable_channel = ['alfa', 'bravo', 'charlie', 'delta', 'echo', 'fox', 'golf', 'hotel', 'india', 'juliett', 'kilo', 'lima', 'mike'];
+
     if (voice_channel != null) {
         if (voice_channel.members.size != 0 && !voice_channel.members.has(host_user.id)) {
             await interaction.editReply({
                 content: 'そのチャンネルは使用中でし！',
+                ephemeral: true,
+            });
+            return;
+        } else if (!usable_channel.includes(voice_channel.name)) {
+            await interaction.editReply({
+                content: 'そのチャンネルは指定できないでし！\n🔉alfa ～ 🔉limaの間のチャンネルで指定するでし！',
                 ephemeral: true,
             });
             return;
@@ -154,18 +162,19 @@ async function sendSalmonRun(interaction, channel, txt, recruit_num, condition, 
             } else {
                 sentMessage.edit({ components: [recruitActionRowWithChannel(sentMessage, host_user, reserve_channel.id)] });
             }
-        } else {
-            return;
         }
 
         // 2時間後にボタンを無効化する
-        setTimeout(function async() {
-            const host_mention = `<@${host_user.id}>`;
-            sentMessage.edit({
-                content: `${host_mention}たんの募集は〆！`,
-                components: [disableButtons()],
-            });
-        }, 7200000 - 15000);
+        await sleep(7200000 - 15000);
+        const host_mention = `<@${host_user.id}>`;
+        sentMessage.edit({
+            content: `${host_mention}たんの募集は〆！`,
+            components: [disableButtons()],
+        });
+        if (reserve_channel != null) {
+            reserve_channel.permissionOverwrites.delete(interaction.guild.roles.everyone, 'UnLock Voice Channel');
+            reserve_channel.permissionOverwrites.delete(host_user, 'UnLock Voice Channel');
+        }
     } catch (error) {
         console.log(error);
     }

--- a/app/cmd/recruit/salmon_recruit.js
+++ b/app/cmd/recruit/salmon_recruit.js
@@ -6,7 +6,6 @@ const { createRoundRect, drawArcImage } = require('./canvas_components.js');
 const {
     recruitDeleteButton,
     recruitActionRow,
-    disableButtons,
     recruitDeleteButtonWithChannel,
     recruitActionRowWithChannel,
     unlockChannelButton,
@@ -61,7 +60,7 @@ async function salmonRecruit(interaction) {
     }
 
     // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply();
 
     var usable_channel = ['alfa', 'bravo', 'charlie', 'delta', 'echo', 'fox', 'golf', 'hotel', 'india', 'juliett', 'kilo', 'lima', 'mike'];
 
@@ -128,9 +127,10 @@ async function sendSalmonRun(interaction, channel, txt, recruit_num, condition, 
     const rule = new MessageAttachment(await ruleCanvas(date, coop_stage, weapon1, weapon2, weapon3, weapon4, stageImage), 'schedule.png');
 
     try {
-        const sentMessage = await channel.send({
+        const sentMessage = await interaction.followUp({
             content: txt,
             files: [recruit, rule],
+            ephemeral: false,
         });
 
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
@@ -147,7 +147,7 @@ async function sendSalmonRun(interaction, channel, txt, recruit_num, condition, 
             );
         }
 
-        await interaction.editReply({
+        await interaction.followUp({
             content: '募集完了でし！参加者が来るまで待つでし！\n15秒間は募集を取り消せるでし！',
             components: reserve_channel != null ? [unlockChannelButton(reserve_channel.id)] : [],
             ephemeral: true,
@@ -162,18 +162,6 @@ async function sendSalmonRun(interaction, channel, txt, recruit_num, condition, 
             } else {
                 sentMessage.edit({ components: [recruitActionRowWithChannel(sentMessage, host_user, reserve_channel.id)] });
             }
-        }
-
-        // 2時間後にボタンを無効化する
-        await sleep(7200000 - 15000);
-        const host_mention = `<@${host_user.id}>`;
-        sentMessage.edit({
-            content: `${host_mention}たんの募集は〆！`,
-            components: [disableButtons()],
-        });
-        if (reserve_channel != null) {
-            reserve_channel.permissionOverwrites.delete(interaction.guild.roles.everyone, 'UnLock Voice Channel');
-            reserve_channel.permissionOverwrites.delete(host_user, 'UnLock Voice Channel');
         }
     } catch (error) {
         console.log(error);

--- a/app/common.js
+++ b/app/common.js
@@ -16,6 +16,7 @@ module.exports = {
     composeEmbed: composeEmbed,
     dateAdd: dateAdd,
     dateDiff: dateDiff,
+    datetimeDiff: datetimeDiff,
     isEmpty: isEmpty,
     isNotEmpty: isNotEmpty,
 };
@@ -560,4 +561,12 @@ function dateDiff(dt1, dt2, u, f) {
         r = dateDiff(dt3, dt2, 'D');
     }
     return r;
+}
+/*
+ *  経過時間（分）の計算
+ */
+function datetimeDiff(dt1, dt2) {
+    diff = dt2.getTime() - dt1.getTime();
+    const diffMinutes = Math.abs(diff) / (60 * 1000);
+    return diffMinutes;
 }

--- a/app/event/recruit_button.js
+++ b/app/event/recruit_button.js
@@ -1,10 +1,11 @@
 const { MessageEmbed, MessageActionRow, MessageButton, Client } = require('discord.js');
-const { isNotEmpty } = require('../common');
+const { isNotEmpty, datetimeDiff } = require('../common');
 module.exports = {
     join: join,
     cancel: cancel,
     del: del,
     close: close,
+    unlock: unlock,
 };
 
 /**
@@ -46,6 +47,7 @@ async function join(interaction, params) {
             force: true, // intentsによってはGuildMemberUpdateが配信されないため
         });
         const host_id = params.get('hid');
+        const channelId = params.get('vid');
         if (member.user.id === host_id) {
             await interaction.followUp({
                 content: `募集主は参加表明できないでし！`,
@@ -69,10 +71,18 @@ async function join(interaction, params) {
                 content: `<@${host_id}> ${member_mention}`,
                 embeds: [embed],
             });
-            await interaction.followUp({
-                content: `<@${host_id}>からの返答を待つでし！\n条件を満たさない場合は参加を断られる場合があるでし！`,
-                ephemeral: true,
-            });
+            if (channelId == undefined) {
+                await interaction.followUp({
+                    content: `<@${host_id}>からの返答を待つでし！\n条件を満たさない場合は参加を断られる場合があるでし！`,
+                    ephemeral: true,
+                });
+            } else {
+                await interaction.followUp({
+                    content: `<@${host_id}>からの返答を待つでし！\n条件を満たさない場合は参加を断られる場合があるでし！`,
+                    components: [channelLinkButtons(interaction.guildId, channelId)],
+                    ephemeral: true,
+                });
+            }
         }
     } catch (err) {
         handleError(err, { interaction });
@@ -89,10 +99,12 @@ async function cancel(interaction, params) {
     /** @type {Discord.Snowflake} */
     try {
         const guild = await interaction.guild.fetch();
+        await guild.channels.fetch();
         const member = await guild.members.fetch(interaction.member.user.id, {
             force: true, // intentsによってはGuildMemberUpdateが配信されないため
         });
         const host_id = params.get('hid');
+        const channelId = params.get('vid');
         const embed = new MessageEmbed().setDescription(`<@${host_id}>たんの募集〆`);
         if (member.user.id == host_id) {
             await interaction.update({
@@ -100,6 +112,11 @@ async function cancel(interaction, params) {
                 components: [disableButtons()],
             });
             await interaction.message.reply({ embeds: [embed] });
+            if (channelId != undefined) {
+                let channel = await guild.channels.cache.get(channelId);
+                channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
+                channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
+            }
         } else {
             await interaction.deferReply({
                 ephemeral: true,
@@ -118,13 +135,20 @@ async function del(interaction, params) {
     /** @type {Discord.Snowflake} */
     try {
         const guild = await interaction.guild.fetch();
+        await guild.channels.fetch();
         const member = await guild.members.fetch(interaction.member.user.id, {
             force: true, // intentsによってはGuildMemberUpdateが配信されないため
         });
         const msg_id = params.get('mid');
         const cmd_message = await interaction.channel.messages.fetch(msg_id);
         const host_id = params.get('hid');
+        const channelId = params.get('vid');
         if (member.user.id == host_id) {
+            if (channelId != undefined) {
+                let channel = await guild.channels.cache.get(channelId);
+                channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
+                channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
+            }
             await cmd_message.delete();
         } else {
             interaction.reply({ content: '他人の募集は消せる訳無いでし！！！', ephemeral: true });
@@ -145,14 +169,16 @@ async function close(interaction, params) {
 
     try {
         const guild = await interaction.guild.fetch();
+        await guild.channels.fetch();
         const member = await guild.members.fetch(interaction.member.user.id, {
             force: true, // intentsによってはGuildMemberUpdateが配信されないため
         });
         const msg_id = params.get('mid');
-        const msg_ch_id = params.get('cid');
-        const helpEmbed = await getHelpEmbed(guild, msg_ch_id);
         const cmd_message = await interaction.channel.messages.fetch(msg_id);
+        const msg_ch_id = cmd_message.channel.id;
+        const helpEmbed = await getHelpEmbed(guild, msg_ch_id);
         const host_id = params.get('hid');
+        const channelId = params.get('vid');
         const embed = new MessageEmbed().setDescription(`<@${host_id}>たんの募集〆`);
         if (member.user.id === host_id) {
             await interaction.update({
@@ -161,6 +187,23 @@ async function close(interaction, params) {
             });
             await interaction.message.reply({ embeds: [embed] });
             await cmd_message.channel.send({ embeds: [helpEmbed] });
+            if (channelId != undefined) {
+                let channel = await guild.channels.cache.get(channelId);
+                channel.setUserLimit(0);
+            }
+        } else if (datetimeDiff(new Date(), cmd_message.createdAt) > 120) {
+            await interaction.update({
+                content: `<@${host_id}>たんの募集は〆！`,
+                components: [disableButtons()],
+            });
+            const embed = new MessageEmbed().setDescription(`<@${host_id}>たんの募集〆 \n <@${interaction.member.user.id}>たんが代理〆`);
+            await interaction.message.reply({ embeds: [embed] });
+            await cmd_message.channel.send({ embeds: [helpEmbed] });
+            if (channelId != undefined) {
+                let channel = await guild.channels.cache.get(channelId);
+                channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
+                channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
+            }
         } else {
             await interaction.deferReply({
                 ephemeral: true,
@@ -170,6 +213,25 @@ async function close(interaction, params) {
                 ephemeral: true,
             });
         }
+    } catch (err) {
+        handleError(err, { interaction });
+    }
+}
+
+async function unlock(interaction, params) {
+    /** @type {Discord.Snowflake} */
+
+    try {
+        const channelId = params.get('vid');
+        const guild = await interaction.guild;
+        const channel = await guild.channels.cache.get(channelId);
+
+        channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
+        channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
+
+        await interaction.update({
+            components: [disableUnlockButton()],
+        });
     } catch (err) {
         handleError(err, { interaction });
     }
@@ -199,6 +261,21 @@ function disableButtons() {
         new MessageButton().setCustomId('join').setLabel('参加').setStyle('PRIMARY').setDisabled(),
         new MessageButton().setCustomId('cancel').setLabel('キャンセル').setStyle('DANGER').setDisabled(),
         new MessageButton().setCustomId('close').setLabel('〆').setStyle('SECONDARY').setDisabled(),
+    ]);
+    return buttons;
+}
+
+function disableUnlockButton() {
+    let buttons = new MessageActionRow().addComponents([
+        new MessageButton().setCustomId('unlocked').setLabel('ロック解除済み').setStyle('SECONDARY').setDisabled(),
+    ]);
+    return buttons;
+}
+
+function channelLinkButtons(guildId, channelId) {
+    const channel_link = `https://discord.com/channels/${guildId}/${channelId}`;
+    let buttons = new MessageActionRow().addComponents([
+        new MessageButton().setLabel('チャンネルに移動').setStyle('LINK').setURL(channel_link),
     ]);
     return buttons;
 }

--- a/app/event/recruit_button.js
+++ b/app/event/recruit_button.js
@@ -57,14 +57,9 @@ async function join(interaction, params) {
             const member_mention = `<@!${member.user.id}>`;
             let member_roles = member.roles.cache.map((role) => (role.name != '@everyone' ? role.name : '')).join(' / ');
             const embed = new MessageEmbed();
-            embed.setDescription(`募集主は${member.user.username}たんに遊ぶ部屋を伝えるでし！イカ部心得を守って楽しく遊んでほしいでし！`);
             embed.setAuthor({
                 name: `${member.user.username}たんが参加表明したでし！`,
                 iconURL: member.user.displayAvatarURL(),
-            });
-            embed.addFields({
-                name: `${member.user.username}の役職`,
-                value: isNotEmpty(member_roles) ? member_roles : 'なし',
             });
 
             await interaction.message.reply({
@@ -189,7 +184,8 @@ async function close(interaction, params) {
             await cmd_message.channel.send({ embeds: [helpEmbed] });
             if (channelId != undefined) {
                 let channel = await guild.channels.cache.get(channelId);
-                channel.setUserLimit(0);
+                channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
+                channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
             }
         } else if (datetimeDiff(new Date(), cmd_message.createdAt) > 120) {
             await interaction.update({

--- a/app/event/recruit_button.js
+++ b/app/event/recruit_button.js
@@ -55,7 +55,6 @@ async function join(interaction, params) {
             });
         } else {
             const member_mention = `<@!${member.user.id}>`;
-            let member_roles = member.roles.cache.map((role) => (role.name != '@everyone' ? role.name : '')).join(' / ');
             const embed = new MessageEmbed();
             embed.setAuthor({
                 name: `${member.user.username}たんが参加表明したでし！`,
@@ -239,7 +238,7 @@ async function getHelpEmbed(guild, chid) {
     if (sendChannel.name.match('リグマ募集')) {
         command = '`/now` or `/next`';
     } else if (sendChannel.name.match('ナワバリ・フェス募集')) {
-        command = '`nawabari`';
+        command = '`/now` or `/next`';
     } else if (sendChannel.name.match('サーモン募集')) {
         command = '`/run`';
     } else if (sendChannel.name.match('別ゲー募集')) {

--- a/app/index.js
+++ b/app/index.js
@@ -199,11 +199,13 @@ async function onVoiceStateUpdate(oldState, newState) {
         }
         if (oldChannel.members.size == 0) {
             oldChannel.setUserLimit(0);
-        } else {
-            // TODO:
-            if (oldChannel.members.has('ホストユーザーのID')) {
-                // 制限解除の呪文
-            }
+        }
+    }
+    if (newState.channelId != null) {
+        const newChannel = newState.guild.channels.cache.get(newState.channelId);
+        if (newChannel.members.size != 0) {
+            newChannel.permissionOverwrites.delete(newState.guild.roles.everyone, 'UnLock Voice Channel');
+            newChannel.permissionOverwrites.delete(newState.member, 'UnLock Voice Channel');
         }
     }
 }

--- a/app/index.js
+++ b/app/index.js
@@ -19,6 +19,7 @@ const DISCORD_VOICE = require('./tts/discordjs_voice.js');
 const handleStageInfo = require('./cmd/stageinfo.js');
 const { getCloseEmbed, getCommandHelpEmbed } = require('./cmd/recruit.js');
 const { otherGameRecruit } = require('./cmd/recruit/other_game_recruit.js');
+const { regularRecruit } = require('./cmd/recruit/regular_recruit.js');
 const { leagueRecruit } = require('./cmd/recruit/league_recruit.js');
 const { salmonRecruit } = require('./cmd/recruit/salmon_recruit.js');
 const { privateRecruit } = require('./cmd/recruit/private_recruit.js');
@@ -164,6 +165,8 @@ async function onInteraction(interaction) {
                 await otherGameRecruit(interaction);
             } else if (commandName === commandNames.private) {
                 await privateRecruit(interaction);
+            } else if (commandName === commandNames.regular) {
+                await regularRecruit(interaction);
             } else if (commandName === commandNames.league) {
                 await leagueRecruit(interaction);
             } else if (commandName === commandNames.salmon) {

--- a/app/index.js
+++ b/app/index.js
@@ -129,6 +129,7 @@ const buttons = {
     cr: recruitButton.cancel,
     del: recruitButton.del,
     close: recruitButton.close,
+    unl: recruitButton.unlock,
 };
 /**
  *
@@ -198,6 +199,11 @@ async function onVoiceStateUpdate(oldState, newState) {
         }
         if (oldChannel.members.size == 0) {
             oldChannel.setUserLimit(0);
+        } else {
+            // TODO:
+            if (oldChannel.members.has('ホストユーザーのID')) {
+                // 制限解除の呪文
+            }
         }
     }
 }

--- a/constant.js
+++ b/constant.js
@@ -3,6 +3,7 @@ module.exports = {
         voice_channel: 'voice_channel',
         close: 'close',
         other_game: '別ゲー募集',
+        regular: 'ナワバリ募集',
         league: 'リグマ募集',
         salmon: 'サーモンラン募集',
         private: 'プラベ募集',

--- a/register.js
+++ b/register.js
@@ -13,6 +13,77 @@ const closeRecruit = new SlashCommandBuilder()
     .setName(commandNames.close)
     .setDescription('募集を〆ます。ボタンが使えないときに使ってください。');
 
+const regularMatch = new SlashCommandBuilder()
+    .setName(commandNames.regular)
+    .setDescription('ナワバリ募集コマンド')
+    .addSubcommand((subcommand) =>
+        subcommand
+            .setName('now')
+            .setDescription('現在のナワバリバトルの募集をたてます。')
+            .addIntegerOption((option) =>
+                option
+                    .setName('募集人数')
+                    .setDescription('募集人数を設定します。あなたの他に参加者が決定している場合は参加者に指定してください。')
+                    .setChoices(
+                        { name: '@1', value: 1 },
+                        { name: '@2', value: 2 },
+                        { name: '@3', value: 3 },
+                        { name: '@4', value: 4 },
+                        { name: '@5', value: 5 },
+                        { name: '@6', value: 6 },
+                        { name: '@7', value: 7 },
+                    )
+                    .setRequired(true),
+            )
+            .addStringOption((option) => option.setName('参加条件').setDescription('プレイ内容や参加条件など').setRequired(false))
+            .addChannelOption((option) =>
+                option
+                    .setName('使用チャンネル')
+                    .setDescription('使用するボイスチャンネルを指定できます。')
+                    .addChannelTypes(ChannelType.GuildVoice)
+                    .setRequired(false),
+            )
+            .addUserOption((option) =>
+                option.setName('参加者1').setDescription('既に決定している参加者を指定してください。').setRequired(false),
+            )
+            .addUserOption((option) =>
+                option.setName('参加者2').setDescription('既に決定している参加者を指定してください。').setRequired(false),
+            )
+            .addUserOption((option) =>
+                option.setName('参加者3').setDescription('既に決定している参加者を指定してください。').setRequired(false),
+            ),
+    )
+    .addSubcommand((subcommand) =>
+        subcommand
+            .setName('next')
+            .setDescription('次のナワバリバトルの募集をたてます。')
+            .addIntegerOption((option) =>
+                option
+                    .setName('募集人数')
+                    .setDescription('募集人数を設定します。あなたの他に参加者が決定している場合は参加者に指定してください。')
+                    .setChoices(
+                        { name: '@1', value: 1 },
+                        { name: '@2', value: 2 },
+                        { name: '@3', value: 3 },
+                        { name: '@4', value: 4 },
+                        { name: '@5', value: 5 },
+                        { name: '@6', value: 6 },
+                        { name: '@7', value: 7 },
+                    )
+                    .setRequired(true),
+            )
+            .addStringOption((option) => option.setName('参加条件').setDescription('プレイ内容や参加条件など').setRequired(false))
+            .addUserOption((option) =>
+                option.setName('参加者1').setDescription('既に決定している参加者を指定してください。').setRequired(false),
+            )
+            .addUserOption((option) =>
+                option.setName('参加者2').setDescription('既に決定している参加者を指定してください。').setRequired(false),
+            )
+            .addUserOption((option) =>
+                option.setName('参加者3').setDescription('既に決定している参加者を指定してください。').setRequired(false),
+            ),
+    );
+
 const leagueMatch = new SlashCommandBuilder()
     .setName(commandNames.league)
     .setDescription('リグマ募集コマンド')
@@ -154,7 +225,7 @@ const otherGame = new SlashCommandBuilder()
             .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など')),
     );
 
-const commands = [voiceLock, closeRecruit, otherGame, privateMatch, leagueMatch, salmonRun];
+const commands = [voiceLock, closeRecruit, otherGame, privateMatch, regularMatch, leagueMatch, salmonRun];
 
 //登録用関数
 const { REST } = require('@discordjs/rest');

--- a/register.js
+++ b/register.js
@@ -32,12 +32,15 @@ const leagueMatch = new SlashCommandBuilder()
             )
             .addUserOption((option) =>
                 option.setName('参加者2').setDescription('既に決定している参加者を指定してください。').setRequired(false),
+            )
+            .addChannelOption((option) =>
+                option.setName('使用チャンネル').setDescription('使用するボイスチャンネルを指定できます。').setRequired(false),
             ),
     )
     .addSubcommand((subcommand) =>
         subcommand
             .setName('next')
-            .setDescription('現在のリーグマッチの募集をたてます。')
+            .setDescription('次のリーグマッチの募集をたてます。')
             .addIntegerOption((option) =>
                 option
                     .setName('募集人数')
@@ -74,6 +77,9 @@ const salmonRun = new SlashCommandBuilder()
             )
             .addUserOption((option) =>
                 option.setName('参加者2').setDescription('既に決定している参加者を指定してください。').setRequired(false),
+            )
+            .addChannelOption((option) =>
+                option.setName('使用チャンネル').setDescription('使用するボイスチャンネルを指定できます。').setRequired(false),
             ),
     );
 
@@ -83,7 +89,10 @@ const privateMatch = new SlashCommandBuilder()
     .addStringOption((option) => option.setName('開始時刻').setDescription('何時から始める？例：21:00').setRequired(true))
     .addStringOption((option) => option.setName('所要時間').setDescription('何時間ぐらいやる？例：2時間').setRequired(true))
     .addStringOption((option) => option.setName('募集人数').setDescription('募集人数 (自由入力)').setRequired(true))
-    .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など'));
+    .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など'))
+    .addChannelOption((option) =>
+        option.setName('使用チャンネル').setDescription('使用するVCのチャンネルを指定できます。').setRequired(false),
+    );
 
 const otherGame = new SlashCommandBuilder()
     .setName(commandNames.other_game)

--- a/register.js
+++ b/register.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder } = require(`@discordjs/builders`);
+const { ChannelType } = require('discord-api-types/v10');
 const { commandNames } = require('./constant.js');
 
 require('dotenv').config();
@@ -34,7 +35,11 @@ const leagueMatch = new SlashCommandBuilder()
                 option.setName('参加者2').setDescription('既に決定している参加者を指定してください。').setRequired(false),
             )
             .addChannelOption((option) =>
-                option.setName('使用チャンネル').setDescription('使用するボイスチャンネルを指定できます。').setRequired(false),
+                option
+                    .setName('使用チャンネル')
+                    .setDescription('使用するボイスチャンネルを指定できます。')
+                    .addChannelTypes(ChannelType.GuildVoice)
+                    .setRequired(false),
             ),
     )
     .addSubcommand((subcommand) =>
@@ -79,7 +84,11 @@ const salmonRun = new SlashCommandBuilder()
                 option.setName('参加者2').setDescription('既に決定している参加者を指定してください。').setRequired(false),
             )
             .addChannelOption((option) =>
-                option.setName('使用チャンネル').setDescription('使用するボイスチャンネルを指定できます。').setRequired(false),
+                option
+                    .setName('使用チャンネル')
+                    .setDescription('使用するボイスチャンネルを指定できます。')
+                    .addChannelTypes(ChannelType.GuildVoice)
+                    .setRequired(false),
             ),
     );
 
@@ -89,10 +98,7 @@ const privateMatch = new SlashCommandBuilder()
     .addStringOption((option) => option.setName('開始時刻').setDescription('何時から始める？例：21:00').setRequired(true))
     .addStringOption((option) => option.setName('所要時間').setDescription('何時間ぐらいやる？例：2時間').setRequired(true))
     .addStringOption((option) => option.setName('募集人数').setDescription('募集人数 (自由入力)').setRequired(true))
-    .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など'))
-    .addChannelOption((option) =>
-        option.setName('使用チャンネル').setDescription('使用するVCのチャンネルを指定できます。').setRequired(false),
-    );
+    .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など'));
 
 const otherGame = new SlashCommandBuilder()
     .setName(commandNames.other_game)

--- a/register.js
+++ b/register.js
@@ -82,8 +82,7 @@ const privateMatch = new SlashCommandBuilder()
     .setDescription('プラベ募集コマンド')
     .addStringOption((option) => option.setName('開始時刻').setDescription('何時から始める？例：21:00').setRequired(true))
     .addStringOption((option) => option.setName('所要時間').setDescription('何時間ぐらいやる？例：2時間').setRequired(true))
-    .addIntegerOption((option) => option.setName('募集人数').setDescription('あと最低何人いたらプラベができる？').setRequired(true))
-    .addIntegerOption((option) => option.setName('最大人数').setDescription('何人まで募集する？（上限）'))
+    .addStringOption((option) => option.setName('募集人数').setDescription('募集人数 (自由入力)').setRequired(true))
     .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など'));
 
 const otherGame = new SlashCommandBuilder()
@@ -93,40 +92,40 @@ const otherGame = new SlashCommandBuilder()
         subcommand
             .setName('apex')
             .setDescription('ApexLegendsの募集')
-            .addIntegerOption((option) =>
-                option.setName('募集人数').setDescription('あと何人募集する？（最低でもほしい人数）').setRequired(true),
+            .addStringOption((option) =>
+                option
+                    .setName('募集人数')
+                    .setDescription('募集人数')
+                    .setChoices({ name: '@1', value: '@1' }, { name: '@2', value: '@2' })
+                    .setRequired(true),
             )
-            .addIntegerOption((option) => option.setName('最大人数').setDescription('最高何人までなら一緒にあそべる？'))
             .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など')),
     )
     .addSubcommand((subcommand) =>
         subcommand
             .setName('mhr')
             .setDescription('モンスターハンターライズ:サンブレイクの募集')
-            .addIntegerOption((option) =>
-                option.setName('募集人数').setDescription('あと何人募集する？（最低でもほしい人数）').setRequired(true),
+            .addStringOption((option) =>
+                option
+                    .setName('募集人数')
+                    .setDescription('募集人数')
+                    .setChoices({ name: '@1', value: '@1' }, { name: '@2', value: '@2' }, { name: '@3', value: '@3' })
+                    .setRequired(true),
             )
-            .addIntegerOption((option) => option.setName('最大人数').setDescription('最高何人までなら一緒にあそべる？'))
             .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など')),
     )
     .addSubcommand((subcommand) =>
         subcommand
             .setName('dbd')
             .setDescription('Dead by Daylightの募集')
-            .addIntegerOption((option) =>
-                option.setName('募集人数').setDescription('あと何人募集する？（最低でもほしい人数）').setRequired(true),
-            )
-            .addIntegerOption((option) => option.setName('最大人数').setDescription('最高何人までなら一緒にあそべる？'))
+            .addStringOption((option) => option.setName('募集人数').setDescription('募集人数 (自由入力)').setRequired(true))
             .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など')),
     )
     .addSubcommand((subcommand) =>
         subcommand
             .setName('valo')
             .setDescription('Valorantの募集')
-            .addIntegerOption((option) =>
-                option.setName('募集人数').setDescription('あと何人募集する？（最低でもほしい人数）').setRequired(true),
-            )
-            .addIntegerOption((option) => option.setName('最大人数').setDescription('最高何人までなら一緒にあそべる？'))
+            .addStringOption((option) => option.setName('募集人数').setDescription('募集人数 (自由入力)').setRequired(true))
             .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など')),
     )
     .addSubcommand((subcommand) =>
@@ -136,10 +135,7 @@ const otherGame = new SlashCommandBuilder()
             .addStringOption((option) =>
                 option.setName('ゲームタイトル').setDescription('ゲームタイトルを入力してください。').setRequired(true),
             )
-            .addIntegerOption((option) =>
-                option.setName('募集人数').setDescription('あと何人募集する？（最低でもほしい人数）').setRequired(true),
-            )
-            .addIntegerOption((option) => option.setName('最大人数').setDescription('最高何人までなら一緒にあそべる？'))
+            .addStringOption((option) => option.setName('募集人数').setDescription('募集人数 (自由入力)').setRequired(true))
             .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など')),
     );
 


### PR DESCRIPTION
- ナワバリ募集コマンドの追加
- 代理〆の追加
- ボイスチャンネルオプションを追加(サーモン、リグマ(now)、ナワバリ(now)のみ)
- Canvasの縁付きテキストのコードを共通化
- 募集をリプライで送信する形に変更
- 参加時のEmbed変更
- 別ゲー、プラベ募集の募集人数のオプションを一部Stringに変更