### PR TITLE
参加ボタンの仕様変更

### DIFF
--- a/app/event/recruit_button.js
+++ b/app/event/recruit_button.js
@@ -1,6 +1,12 @@
 const { MessageEmbed, MessageActionRow, MessageButton, Client } = require('discord.js');
 const app = require('app-root-path').resolve('app');
+const db = require('app-root-path').resolve('db');
 const { isNotEmpty, datetimeDiff } = require(app + '/common');
+const { insert_recruit } = require(db + '/recruit_insert.js');
+const { delete_recruit, deleteRecruitByMemberId } = require(db + '/recruit_delete.js');
+const { getRecruitMessageByMemberId, getRecruitAllByMessageId } = require(db + '/recruit_select.js');
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 module.exports = {
     join: join,
     cancel: cancel,
@@ -60,20 +66,58 @@ async function join(interaction, params) {
                 ephemeral: true,
             });
         } else {
-            const member_mention = `<@!${member.user.id}>`;
+            // TODO: スレッドはあとで実装するかも
+            // const host = await guild.members.cache.get(host_id);
+            // const host_name = host.user.username;
+            // let thread = await interaction.channel.threads.cache.find((x) => x.name === `${host_name + 'の募集'}`);
+            // なかったらスレッド作成する
+            //   if (thread === undefined) {
+            //     // スレッド作成する
+            //     thread = await interaction.channel.threads.create({
+            //       name: `${host_name + "の募集"}`,
+            //     });
+            //     // botをjoin
+            //     thread.join();
+
+            //     // hostとメンバーをjoin
+            //     await thread.members.add(host_id);
+            //   }
+
+            // hostとメンバーをjoin
+            // await thread.members.add(member.user.id);
+            // スレッド内に募集主向けのメッセージを送信する
+
+            // 参加済みかチェック
+            const member_data = await getRecruitMessageByMemberId(interaction.message.id, member.user.id);
+            if (member_data.length > 0) {
+                // NOTE: 削除ボタンの切り替わり前に参加ボタン押されると
+                // 編集処理が中断されるので、もう一度押したときに参加表明一覧を更新する
+                await editMemberListMessage(interaction);
+
+                await interaction.followUp({
+                    content: `すでに参加ボタンを押してるでし！`,
+                    ephemeral: true,
+                });
+                return;
+            }
+
             const embed = new MessageEmbed();
             embed.setAuthor({
                 name: `${member.user.username}たんが参加表明したでし！`,
                 iconURL: member.user.displayAvatarURL(),
             });
 
-            await interaction.message.reply({
-                content: `<@${host_id}> ${member_mention}`,
+            // recruitテーブルにデータ追加
+            insert_recruit(interaction.message.id, host_id, member.user.id);
+            const notify_to_host_message = await interaction.message.reply({
+                content: `<@${host_id}>`,
                 embeds: [embed],
             });
+
             if (channelId == undefined) {
                 await interaction.followUp({
                     content: `<@${host_id}>からの返答を待つでし！\n条件を満たさない場合は参加を断られる場合があるでし！`,
+                    // components: [channelLinkButtons(interaction.guildId, thread_message.url)], TODO: スレッド内へのリンクボタンを作る
                     ephemeral: true,
                 });
             } else {
@@ -83,6 +127,12 @@ async function join(interaction, params) {
                     ephemeral: true,
                 });
             }
+
+            await editMemberListMessage(interaction);
+
+            // 15秒後にホストへの通知を削除
+            await sleep(15000);
+            notify_to_host_message.delete();
         }
     } catch (err) {
         handleError(err, { interaction });
@@ -98,6 +148,9 @@ async function join(interaction, params) {
 async function cancel(interaction, params) {
     /** @type {Discord.Snowflake} */
     try {
+        await interaction.deferReply({
+            ephemeral: true,
+        });
         const guild = await interaction.guild.fetch();
         await guild.channels.fetch();
         const member = await guild.members.fetch(interaction.member.user.id, {
@@ -113,6 +166,10 @@ async function cancel(interaction, params) {
                 content: `<@${host_id}>たんの募集はキャンセルされたでし！`,
                 components: [disableButtons()],
             });
+
+            // recruitテーブルから削除
+            await delete_recruit(interaction.message.id);
+
             await interaction.message.reply({ embeds: [embed] });
             if (channelId != undefined) {
                 let channel = await guild.channels.cache.get(channelId);
@@ -120,13 +177,24 @@ async function cancel(interaction, params) {
                 channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
             }
         } else {
-            await interaction.deferReply({
-                ephemeral: true,
-            });
-            await interaction.followUp({
-                content: `キャンセルするときぐらい、自分の言葉で伝えましょう！\n<@${host_id}>たんにメンションつきで伝えるでし！`,
-                ephemeral: true,
-            });
+            // NOTE: 参加表明済みかチェックして、参加表明済みならキャンセル可能
+            const member_data = await getRecruitMessageByMemberId(interaction.message.id, member.user.id);
+            if (member_data.length > 0) {
+                // recruitテーブルから自分のデータのみ削除
+                await deleteRecruitByMemberId(interaction.message.id, interaction.member.id);
+
+                // ホストに通知
+                await editMemberListMessage(interaction);
+                await interaction.message.reply({
+                    content: `<@${host_id}> <@${interaction.member.id}>たんがキャンセルしたでし！`,
+                });
+                return;
+            } else {
+                await interaction.followUp({
+                    content: `他人の募集は勝手にキャンセルできないでし！！`,
+                    ephemeral: true,
+                });
+            }
         }
     } catch (err) {
         handleError(err, { interaction });
@@ -155,6 +223,8 @@ async function del(interaction, params) {
             }
             await cmd_message.delete();
             await header_message.delete();
+            // recruitテーブルから削除
+            delete_recruit(interaction.message.id);
         } else {
             interaction.reply({ content: '他人の募集は消せる訳無いでし！！！', ephemeral: true });
         }
@@ -185,25 +255,35 @@ async function close(interaction, params) {
         const channelId = params.get('vid');
         const embed = new MessageEmbed().setDescription(`<@${host_id}>たんの募集〆`);
         if (member.user.id === host_id) {
+            const recruit_data = await getRecruitAllByMessageId(interaction.message.id);
+            const member_list = getMemberMentions(recruit_data);
             await interaction.update({
-                content: `<@${host_id}>たんの募集は〆！`,
+                content: `<@${host_id}>たんの募集は〆！\n${member_list}`,
                 components: [disableButtons()],
             });
             await interaction.message.reply({ embeds: [embed] });
             await interaction.channel.send({ embeds: [helpEmbed] });
+
+            // recruitテーブルから削除
+            delete_recruit(interaction.message.id);
+
             if (channelId != undefined) {
                 let channel = await guild.channels.cache.get(channelId);
                 channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
                 channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
             }
         } else if (datetimeDiff(new Date(), header_message.createdAt) > 120) {
+            const recruit_data = await getRecruitAllByMessageId(interaction.message.id);
+            const member_list = getMemberMentions(recruit_data);
             await interaction.update({
-                content: `<@${host_id}>たんの募集は〆！`,
+                content: `<@${host_id}>たんの募集は〆！\n${member_list}`,
                 components: [disableButtons()],
             });
             const embed = new MessageEmbed().setDescription(`<@${host_id}>たんの募集〆 \n <@${interaction.member.user.id}>たんが代理〆`);
             await interaction.message.reply({ embeds: [embed] });
             await header_message.channel.send({ embeds: [helpEmbed] });
+            // recruitテーブルから削除
+            deleteRecruitByMemberId(interaction.message.id, interaction.member.id);
             if (channelId != undefined) {
                 let channel = await guild.channels.cache.get(channelId);
                 channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
@@ -244,15 +324,26 @@ async function joinNotify(interaction, params) {
                 ephemeral: true,
             });
         } else {
-            const member_mention = `<@!${member.user.id}>`;
+            // 参加済みかチェック
+            const member_data = await getRecruitMessageByMemberId(interaction.message.id, member.user.id);
+            if (member_data.length > 0) {
+                await interaction.followUp({
+                    content: `すでに参加ボタンを押してるでし！`,
+                    ephemeral: true,
+                });
+                return;
+            }
+
             const embed = new MessageEmbed();
             embed.setAuthor({
                 name: `${member.user.username}たんが参加表明したでし！`,
                 iconURL: member.user.displayAvatarURL(),
             });
+            // recruitテーブルにデータ追加
+            insert_recruit(interaction.message.id, interaction.member.user.id, member.user.id);
 
-            await interaction.message.reply({
-                content: `<@${host_id}> ${member_mention}`,
+            const notify_to_host_message = await interaction.message.reply({
+                content: `<@${host_id}>`,
                 embeds: [embed],
             });
 
@@ -260,6 +351,11 @@ async function joinNotify(interaction, params) {
                 content: `<@${host_id}>からの返答を待つでし！\n条件を満たさない場合は参加を断られる場合があるでし！`,
                 ephemeral: true,
             });
+
+            await editMemberListMessage(interaction);
+            // 15秒後にホストへの通知を削除
+            await sleep(15000);
+            notify_to_host_message.delete();
         }
     } catch (err) {
         handleError(err, { interaction });
@@ -277,18 +373,21 @@ async function cancelNotify(interaction, params) {
         const host_id = params.get('hid');
         const embed = new MessageEmbed().setDescription(`<@${host_id}>たんの募集〆`);
         if (member.user.id == host_id) {
+            // recruitテーブルから削除
+            await delete_recruit(interaction.message.id);
             await interaction.update({
                 content: `<@${host_id}>たんの募集はキャンセルされたでし！`,
                 components: [disableButtons()],
             });
             await interaction.message.reply({ embeds: [embed] });
         } else {
-            await interaction.deferReply({
-                ephemeral: true,
-            });
-            await interaction.followUp({
-                content: `キャンセルするときぐらい、自分の言葉で伝えましょう！\n<@${host_id}>たんにメンションつきで伝えるでし！`,
-                ephemeral: true,
+            // recruitテーブルから自分のデータのみ削除
+            await deleteRecruitByMemberId(interaction.message.id, interaction.member.id);
+
+            // ホストに通知
+            await editMemberListMessage(interaction);
+            await interaction.message.reply({
+                content: `<@${host_id}> <@${interaction.member.id}>たんがキャンセルしたでし！`,
             });
         }
     } catch (err) {
@@ -309,20 +408,28 @@ async function closeNotify(interaction, params) {
         const embed = new MessageEmbed().setDescription(`<@${host_id}>たんの募集〆`);
         const helpEmbed = await getHelpEmbed(guild, interaction.channel.id);
         if (member.user.id === host_id) {
+            const recruit_data = await getRecruitAllByMessageId(interaction.message.id);
+            const member_list = getMemberMentions(recruit_data);
             await interaction.update({
-                content: `<@${host_id}>たんの募集は〆！`,
+                content: `<@${host_id}>たんの募集は〆！\n${member_list}`,
                 components: [disableButtons()],
             });
             await interaction.message.reply({ embeds: [embed] });
             await interaction.channel.send({ embeds: [helpEmbed] });
-        } else if (datetimeDiff(new Date(), header_message.createdAt) > 120) {
+            // recruitテーブルから削除
+            delete_recruit(interaction.message.id);
+        } else if (datetimeDiff(new Date(), interaction.message.createdAt) > 120) {
+            const recruit_data = await getRecruitAllByMessageId(interaction.message.id);
+            const member_list = getMemberMentions(recruit_data);
             await interaction.update({
-                content: `<@${host_id}>たんの募集は〆！`,
+                content: `<@${host_id}>たんの募集は〆！\n${member_list}`,
                 components: [disableButtons()],
             });
             const embed = new MessageEmbed().setDescription(`<@${host_id}>たんの募集〆 \n <@${interaction.member.user.id}>たんが代理〆`);
             await interaction.message.reply({ embeds: [embed] });
             await header_message.channel.send({ embeds: [helpEmbed] });
+            // recruitテーブルから削除
+            deleteRecruitByMemberId(interaction.message.id);
         } else {
             await interaction.deferReply({
                 ephemeral: true,
@@ -401,4 +508,23 @@ function channelLinkButtons(guildId, channelId) {
         new MessageButton().setLabel('チャンネルに移動').setStyle('LINK').setURL(channel_link),
     ]);
     return buttons;
+}
+
+function getMemberMentions(members) {
+    let mentionString = `【参加表明一覧】`;
+    for (let i = 0; i < members.length; i++) {
+        const member = members[i].member_id;
+        mentionString = mentionString + `\n<@${member}> `;
+    }
+    return mentionString;
+}
+
+async function editMemberListMessage(interaction) {
+    const recruit_data = await getRecruitAllByMessageId(interaction.message.id);
+    const member_list = getMemberMentions(recruit_data);
+    const interaction_message = await interaction.channel.messages.fetch(interaction.message.id);
+    const message_first_row = interaction_message.content.split('\n')[0];
+    interaction_message.edit({
+        content: message_first_row + '\n' + member_list,
+    });
 }

--- a/db/create_table.sql
+++ b/db/create_table.sql
@@ -17,3 +17,9 @@ CREATE TABLE IF NOT EXISTS random_matching_message (
     message_id varchar(20) primary key
     ,author_id varchar(20)
 );
+
+CREATE TABLE IF NOT EXISTS recruit (
+    message_id varchar(20)
+    ,author_id varchar(20)
+    ,member_id varchar(20)
+);

--- a/db/recruit_delete.js
+++ b/db/recruit_delete.js
@@ -1,0 +1,37 @@
+var { getPostgresClient } = require('./db.js');
+module.exports = {
+    delete_recruit,
+    deleteRecruitByMemberId,
+};
+
+async function delete_recruit(message_id, member_id) {
+    const db = await getPostgresClient();
+    try {
+        const sql = 'DELETE from recruit where message_id = $1 and member_id = $2';
+        const params = [message_id, member_id];
+        await db.begin();
+        await db.execute(sql, params);
+        await db.commit();
+    } catch (e) {
+        await db.rollback();
+        throw e;
+    } finally {
+        await db.release();
+    }
+}
+
+async function deleteRecruitByMemberId(message_id, member_id) {
+    const db = await getPostgresClient();
+    try {
+        const sql = 'DELETE from recruit where message_id = $1 and member_id = $2';
+        const params = [message_id, member_id];
+        await db.begin();
+        await db.execute(sql, params);
+        await db.commit();
+    } catch (e) {
+        await db.rollback();
+        throw e;
+    } finally {
+        await db.release();
+    }
+}

--- a/db/recruit_insert.js
+++ b/db/recruit_insert.js
@@ -1,0 +1,20 @@
+var { getPostgresClient } = require('./db.js');
+module.exports = {
+    insert_recruit,
+};
+async function insert_recruit(message_id, author_id, member_id) {
+    const db = await getPostgresClient();
+    try {
+        const sql = 'INSERT INTO recruit (message_id, author_id, member_id) VALUES ($1, $2, $3) ';
+        const params = [message_id, author_id, member_id];
+
+        await db.begin();
+        await db.execute(sql, params);
+        await db.commit();
+    } catch (e) {
+        await db.rollback();
+        throw e;
+    } finally {
+        await db.release();
+    }
+}

--- a/db/recruit_select.js
+++ b/db/recruit_select.js
@@ -1,0 +1,49 @@
+var { getPostgresClient } = require('./db.js');
+
+module.exports = {
+    getRecruitAllByMessageId,
+    getRecruitMessageByAuthorId,
+    getRecruitMessageByMemberId,
+};
+
+async function getRecruitAllByMessageId(message_id) {
+    const db = await getPostgresClient();
+    let result;
+    try {
+        const sql = 'SELECT * FROM recruit where message_id = $1';
+        const params = [message_id];
+
+        result = await db.execute(sql, params);
+    } finally {
+        await db.release();
+        return result;
+    }
+}
+
+async function getRecruitMessageByAuthorId(author_id) {
+    const db = await getPostgresClient();
+    let result;
+    try {
+        const sql = 'SELECT message_id FROM recruit where author_id = $1';
+        const params = [author_id];
+
+        result = await db.execute(sql, params);
+    } finally {
+        await db.release();
+        return result;
+    }
+}
+
+async function getRecruitMessageByMemberId(message_id, member_id) {
+    const db = await getPostgresClient();
+    let result;
+    try {
+        const sql = 'SELECT member_id FROM recruit where message_id = $1 and member_id = $2';
+        const params = [message_id, member_id];
+
+        result = await db.execute(sql, params);
+    } finally {
+        await db.release();
+        return result;
+    }
+}

--- a/register.js
+++ b/register.js
@@ -531,7 +531,9 @@ const privateMatch = new SlashCommandBuilder()
             .addStringOption((option) => option.setName('内容または参加条件').setDescription('プレイ内容や参加条件など')),
     )
     .addSubcommand((subcommand) =>
-        subcommand.setName('button').setDescription('募集条件を通常のチャットで打ち込んだ後に通知と募集用のボタンを出せます。'),
+        subcommand
+            .setName('button')
+            .setDescription('募集条件を通常のチャットで打ち込んだ後に通知と募集用のボタンを出せます。※@everyoneメンションを使用します。'),
     );
 
 const otherGame = new SlashCommandBuilder()


### PR DESCRIPTION
## 参加ボタン押したあとの動き
### 参加者側
- ephemeralで参加完了メッセージ（従来どおり）
- 二回目以降はephemeralで参加済みを伝えるメッセージ
### ホスト側
- メンション付きのメッセージが送信され、通知がくる
  - 15秒後に削除される（通知だけ残り、チャット欄のログは流れない）
### 共通
- 参加表明一覧に参加者が追加される

## キャンセルボタン押したあとの動き
### 参加表明した人
- 参加表明一覧からボタン押した人が削除される
- ホストに通知メッセージが飛ぶ 
### 参加表明してない人
- ephemeralでホスト以外はキャンセルできないメッセージ
### ホスト側
- 従来どおり、キャンセルされる

## 〆ボタン押したあとの動き
すべて従来どおり