### PR TITLE
バンカラマッチの募集コマンドからウデマエの必須条件を削除

### DIFF
--- a/app/cmd/splat3/recruit/anarchy_recruit.js
+++ b/app/cmd/splat3/recruit/anarchy_recruit.js
@@ -91,16 +91,19 @@ async function anarchyRecruit(interaction) {
 
     // 'インタラクションに失敗'が出ないようにするため
     await interaction.deferReply();
-
-    const mention_id = searchRoleIdByName(interaction.guild, rank);
-    if (mention_id == null) {
-        interaction.editReply({
-            content: '設定がおかしいでし！\n「お手数ですがサポートセンターまでご連絡お願いします。」でし！',
-            ephemeral: false,
-        });
-        return;
+    let mention = '@everyone';
+    // 募集条件がランクの場合はウデマエロールにメンション
+    if (rank !== undefined && rank !== null) {
+        const mention_id = searchRoleIdByName(interaction.guild, rank);
+        if (mention_id == null) {
+            interaction.editReply({
+                content: '設定がおかしいでし！\n「お手数ですがサポートセンターまでご連絡お願いします。」でし！',
+                ephemeral: false,
+            });
+            return;
+        }
+        mention = `<@&${mention_id}>`;
     }
-    const mention = `<@&${mention_id}>`;
     try {
         const response = await fetch(schedule_url);
         const data = await response.json();

--- a/register.js
+++ b/register.js
@@ -347,8 +347,7 @@ const anarchyMatch = new SlashCommandBuilder()
                         { name: 'A', value: 'A' },
                         { name: 'S', value: 'S' },
                         { name: 'S+', value: 'S+' },
-                    )
-                    .setRequired(true),
+                    ),
             )
             .addStringOption((option) => option.setName('参加条件').setDescription('プレイ内容や参加条件など').setRequired(false))
             .addUserOption((option) =>
@@ -386,8 +385,7 @@ const anarchyMatch = new SlashCommandBuilder()
                         { name: 'A', value: 'A' },
                         { name: 'S', value: 'S' },
                         { name: 'S+', value: 'S+' },
-                    )
-                    .setRequired(true),
+                    ),
             )
             .addStringOption((option) => option.setName('参加条件').setDescription('プレイ内容や参加条件など').setRequired(false))
             .addUserOption((option) =>


### PR DESCRIPTION
- ウデマエに差があっても一緒にできるらしい
- ウデマエを指定したらウデマエロールにメンション、指定しなかったらeveryoneメンションするよう変更