### PR TITLE
フェス期間中のステージ情報対応

### DIFF
--- a/app/cmd/splat3/show.js
+++ b/app/cmd/splat3/show.js
@@ -9,88 +9,109 @@ const schedule_url = 'https://splatoon3.ink/data/schedules.json';
 const coop_schedule_url = 'https://splatoon3.ink/data/schedules.json';
 
 function sendStageInfo(interaction, data, scheduleNum) {
-    const l_args = common.getLeague(data.data.leagueSchedules.nodes, scheduleNum).split(',');
-    const c_args = common.getChallenge(data.data.bankaraSchedules.nodes, scheduleNum).split(',');
-    const o_args = common.getOpen(data.data.bankaraSchedules.nodes, scheduleNum).split(',');
-    const x_args = common.getXMatch(data.data.xSchedules.nodes, scheduleNum).split(',');
-    const l_date = l_args[0];
-    const l_rule = l_args[1];
-    const l_stage = l_args[2];
-    const l_thumbnail = rule2image(l_rule);
-    const c_date = c_args[0];
-    const c_rule = c_args[1];
-    const c_stage = c_args[2];
-    const c_thumbnail = rule2image(c_rule);
-    const o_date = o_args[0];
-    const o_rule = o_args[1];
-    const o_stage = o_args[2];
-    const o_thumbnail = rule2image(o_rule);
-    const x_date = x_args[0];
-    const x_rule = x_args[1];
-    const x_stage = x_args[2];
-    const x_thumbnail = rule2image(x_rule);
     var title;
     if (scheduleNum == 0) {
         title = '現在';
     } else {
         title = '次';
     }
-    const leagueEmbed = new MessageEmbed()
-        .setAuthor({
-            name: title + 'のリーグマッチ',
-            iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/league_icon.png',
-        })
-        .setColor('#ED2D7C')
-        .addFields({
-            name: l_date + '　' + l_rule,
-            value: l_stage,
-        })
-        .setThumbnail(l_thumbnail);
+    // フェス期間中はフェスマッチ情報を返す
+    if (common.checkFes(data, scheduleNum)) {
+        const result = common.getRegular(data, scheduleNum);
 
-    const challengeEmbed = new MessageEmbed()
-        .setAuthor({
-            name: title + 'のバンカラマッチ (チャレンジ)',
-            iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/anarchy_icon.png',
-        })
-        .setColor('#F54910')
-        .addFields({
-            name: c_date + '　' + c_rule,
-            value: c_stage,
-        })
-        .setThumbnail(c_thumbnail);
+        const nawabariEmbed = new MessageEmbed()
+            .setAuthor({
+                name: title + 'の' + result.matchName,
+                iconURL: result.iconURL,
+            })
+            .setColor(result.color)
+            .addFields({
+                name: result.date + ' ' + result.time,
+                value: result.stage1 + '／' + result.stage2,
+            })
+            .setThumbnail(result.iconURL);
 
-    const openEmbed = new MessageEmbed()
-        .setAuthor({
-            name: title + 'のバンカラマッチ (オープン)',
-            iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/anarchy_icon.png',
-        })
-        .setColor('#F54910')
-        .addFields({
-            name: o_date + '　' + o_rule,
-            value: o_stage,
-        })
-        .setThumbnail(o_thumbnail);
+        interaction.editReply({
+            embeds: [nawabariEmbed],
+        });
+    } else {
+        const l_args = common.getLeague(data.data.leagueSchedules.nodes, scheduleNum).split(',');
+        const c_args = common.getChallenge(data.data.bankaraSchedules.nodes, scheduleNum).split(',');
+        const o_args = common.getOpen(data.data.bankaraSchedules.nodes, scheduleNum).split(',');
+        const x_args = common.getXMatch(data.data.xSchedules.nodes, scheduleNum).split(',');
+        const l_date = l_args[0];
+        const l_rule = l_args[1];
+        const l_stage = l_args[2];
+        const l_thumbnail = rule2image(l_rule);
+        const c_date = c_args[0];
+        const c_rule = c_args[1];
+        const c_stage = c_args[2];
+        const c_thumbnail = rule2image(c_rule);
+        const o_date = o_args[0];
+        const o_rule = o_args[1];
+        const o_stage = o_args[2];
+        const o_thumbnail = rule2image(o_rule);
+        const x_date = x_args[0];
+        const x_rule = x_args[1];
+        const x_stage = x_args[2];
+        const x_thumbnail = rule2image(x_rule);
+        const leagueEmbed = new MessageEmbed()
+            .setAuthor({
+                name: title + 'のリーグマッチ',
+                iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/league_icon.png',
+            })
+            .setColor('#ED2D7C')
+            .addFields({
+                name: l_date + '　' + l_rule,
+                value: l_stage,
+            })
+            .setThumbnail(l_thumbnail);
 
-    const xMatchEmbed = new MessageEmbed()
-        .setAuthor({
-            name: title + 'のXマッチ',
+        const challengeEmbed = new MessageEmbed()
+            .setAuthor({
+                name: title + 'のバンカラマッチ (チャレンジ)',
+                iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/anarchy_icon.png',
+            })
+            .setColor('#F54910')
+            .addFields({
+                name: c_date + '　' + c_rule,
+                value: c_stage,
+            })
+            .setThumbnail(c_thumbnail);
 
-            iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/x_match_icon.png',
-        })
-        .setColor('#0edb9b')
-        .addFields({
-            name: x_date + '　' + x_rule,
-            value: x_stage,
-        })
-        .setThumbnail(x_thumbnail);
+        const openEmbed = new MessageEmbed()
+            .setAuthor({
+                name: title + 'のバンカラマッチ (オープン)',
+                iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/anarchy_icon.png',
+            })
+            .setColor('#F54910')
+            .addFields({
+                name: o_date + '　' + o_rule,
+                value: o_stage,
+            })
+            .setThumbnail(o_thumbnail);
 
-    interaction.editReply({
-        embeds: [openEmbed, challengeEmbed],
-    });
-    // TODO: リーグマッチとXマッチはゲーム内で実装後に表示
-    // interaction.editReply({
-    //     embeds: [leagueEmbed, openEmbed, challengeEmbed, xMatchEmbed],
-    // });
+        const xMatchEmbed = new MessageEmbed()
+            .setAuthor({
+                name: title + 'のXマッチ',
+
+                iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/x_match_icon.png',
+            })
+            .setColor('#0edb9b')
+            .addFields({
+                name: x_date + '　' + x_rule,
+                value: x_stage,
+            })
+            .setThumbnail(x_thumbnail);
+
+        interaction.editReply({
+            embeds: [openEmbed, challengeEmbed],
+        });
+        // TODO: リーグマッチとXマッチはゲーム内で実装後に表示
+        // interaction.editReply({
+        //     embeds: [leagueEmbed, openEmbed, challengeEmbed, xMatchEmbed],
+        // });
+    }
 }
 
 module.exports = async function handleShow(interaction) {
@@ -109,19 +130,19 @@ module.exports = async function handleShow(interaction) {
         } else if (subCommand === 'nawabari') {
             const response = await fetch(schedule_url);
             const data = await response.json();
-            const args = common.getRegular(data, 0).split(',');
+            const result = common.getRegular(data, 0);
 
             const nawabariEmbed = new MessageEmbed()
                 .setAuthor({
-                    name: 'レギュラーマッチ',
-                    iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/regular_icon.png',
+                    name: result.matchName,
+                    iconURL: result.iconURL,
                 })
-                .setColor('#B3FF00')
+                .setColor(result.color)
                 .addFields({
-                    name: args[0] + ' ' + args[1],
-                    value: args[3] + '／' + args[4],
+                    name: result.date + ' ' + result.time,
+                    value: result.stage1 + '／' + result.stage2,
                 })
-                .setThumbnail('https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/regular_icon.png');
+                .setThumbnail(result.iconURL);
 
             interaction.editReply({
                 embeds: [nawabariEmbed],

--- a/app/cmd/splat3/stageinfo.js
+++ b/app/cmd/splat3/stageinfo.js
@@ -2,6 +2,7 @@ const fetch = require('node-fetch');
 const app = require('app-root-path').resolve('app');
 const common = require(app + '/common.js');
 const Discord = require('discord.js');
+const { checkFes } = require('../../common');
 const schedule_url = 'https://splatoon3.ink/data/schedules.json';
 
 module.exports = function handleStageInfo(msg) {
@@ -98,7 +99,6 @@ async function stageinfo(msg) {
 }
 
 function getLeagueEmbed(league_list) {
-    let x = 0;
     const stageEmbed = new Discord.MessageEmbed().setTitle('ステージ情報');
     for (var attributename in league_list) {
         let stage;
@@ -108,14 +108,18 @@ function getLeagueEmbed(league_list) {
             common.sp3unixTime2mdwhm(league_list[attributename].startTime) +
             ' – ' +
             common.sp3unixTime2hm(league_list[attributename].endTime);
-        rule = common.sp3rule2txt(league_list[attributename].leagueMatchSetting.vsRule.name);
-        stage =
-            common.sp3stage2txt(league_list[attributename].leagueMatchSetting.vsStages[0].vsStageId) +
-            '／' +
-            common.sp3stage2txt(league_list[attributename].leagueMatchSetting.vsStages[1].vsStageId);
+        if (league_list[attributename].leagueMatchSetting == null) {
+            rule = 'フェス期間中';
+            stage = 'フェス期間中はお休みでし';
+        } else {
+            rule = common.sp3rule2txt(league_list[attributename].leagueMatchSetting.vsRule.name);
+            stage =
+                common.sp3stage2txt(league_list[attributename].leagueMatchSetting.vsStages[0].vsStageId) +
+                '／' +
+                common.sp3stage2txt(league_list[attributename].leagueMatchSetting.vsStages[1].vsStageId);
+        }
         let name = date + ' 【' + rule + '】';
         stageEmbed.addField(name, stage);
-        x = x + 1;
     }
     stageEmbed.setTimestamp();
     stageEmbed.setFooter({ text: 'StageInfo by splatoon3.ink' });
@@ -123,7 +127,6 @@ function getLeagueEmbed(league_list) {
 }
 
 function getAOEmbed(anarchy_list) {
-    let x = 0;
     const stageEmbed = new Discord.MessageEmbed().setTitle('ステージ情報');
     for (var attributename in anarchy_list) {
         let stage;
@@ -133,14 +136,18 @@ function getAOEmbed(anarchy_list) {
             common.sp3unixTime2mdwhm(anarchy_list[attributename].startTime) +
             ' – ' +
             common.sp3unixTime2hm(anarchy_list[attributename].endTime);
-        rule = common.sp3rule2txt(anarchy_list[attributename].bankaraMatchSettings[1].vsRule.name);
-        stage =
-            common.sp3stage2txt(anarchy_list[attributename].bankaraMatchSettings[1].vsStages[0].vsStageId) +
-            '／' +
-            common.sp3stage2txt(anarchy_list[attributename].bankaraMatchSettings[1].vsStages[1].vsStageId);
+        if (anarchy_list[attributename].bankaraMatchSettings == null) {
+            rule = 'フェス期間中';
+            stage = 'フェス期間中はお休みでし';
+        } else {
+            rule = common.sp3rule2txt(anarchy_list[attributename].bankaraMatchSettings[1].vsRule.name);
+            stage =
+                common.sp3stage2txt(anarchy_list[attributename].bankaraMatchSettings[1].vsStages[0].vsStageId) +
+                '／' +
+                common.sp3stage2txt(anarchy_list[attributename].bankaraMatchSettings[1].vsStages[1].vsStageId);
+        }
         let name = date + ' 【' + rule + '】';
         stageEmbed.addField(name, stage);
-        x = x + 1;
     }
     stageEmbed.setTimestamp();
     stageEmbed.setFooter({ text: 'StageInfo by splatoon3.ink' });
@@ -148,7 +155,6 @@ function getAOEmbed(anarchy_list) {
 }
 
 function getACEmbed(anarchy_list) {
-    let x = 0;
     const stageEmbed = new Discord.MessageEmbed().setTitle('ステージ情報');
     for (var attributename in anarchy_list) {
         let stage;
@@ -158,14 +164,18 @@ function getACEmbed(anarchy_list) {
             common.sp3unixTime2mdwhm(anarchy_list[attributename].startTime) +
             ' – ' +
             common.sp3unixTime2hm(anarchy_list[attributename].endTime);
-        rule = common.sp3rule2txt(anarchy_list[attributename].bankaraMatchSettings[0].vsRule.name);
-        stage =
-            common.sp3stage2txt(anarchy_list[attributename].bankaraMatchSettings[0].vsStages[0].vsStageId) +
-            '／' +
-            common.sp3stage2txt(anarchy_list[attributename].bankaraMatchSettings[0].vsStages[1].vsStageId);
+        if (anarchy_list[attributename].bankaraMatchSettings == null) {
+            rule = 'フェス期間中';
+            stage = 'フェス期間中はお休みでし';
+        } else {
+            rule = common.sp3rule2txt(anarchy_list[attributename].bankaraMatchSettings[0].vsRule.name);
+            stage =
+                common.sp3stage2txt(anarchy_list[attributename].bankaraMatchSettings[0].vsStages[0].vsStageId) +
+                '／' +
+                common.sp3stage2txt(anarchy_list[attributename].bankaraMatchSettings[0].vsStages[1].vsStageId);
+        }
         let name = date + ' 【' + rule + '】';
         stageEmbed.addField(name, stage);
-        x = x + 1;
     }
     stageEmbed.setTimestamp();
     stageEmbed.setFooter({ text: 'StageInfo by splatoon3.ink' });
@@ -173,21 +183,24 @@ function getACEmbed(anarchy_list) {
 }
 
 function getXMatchEmbed(x_list) {
-    let x = 0;
     const stageEmbed = new Discord.MessageEmbed().setTitle('ステージ情報');
     for (var attributename in x_list) {
         let stage;
         let date;
         let rule;
         date = common.sp3unixTime2mdwhm(x_list[attributename].startTime) + ' – ' + common.sp3unixTime2hm(x_list[attributename].endTime);
-        rule = common.sp3rule2txt(x_list[attributename].xMatchSetting.vsRule.name);
-        stage =
-            common.sp3stage2txt(x_list[attributename].xMatchSetting.vsStages[0].vsStageId) +
-            '／' +
-            common.sp3stage2txt(x_list[attributename].xMatchSetting.vsStages[1].vsStageId);
+        if (x_list[attributename].xMatchSetting == null) {
+            rule = 'フェス期間中';
+            stage = 'フェス期間中はお休みでし';
+        } else {
+            rule = common.sp3rule2txt(x_list[attributename].xMatchSetting.vsRule.name);
+            stage =
+                common.sp3stage2txt(x_list[attributename].xMatchSetting.vsStages[0].vsStageId) +
+                '／' +
+                common.sp3stage2txt(x_list[attributename].xMatchSetting.vsStages[1].vsStageId);
+        }
         let name = date + ' 【' + rule + '】';
         stageEmbed.addField(name, stage);
-        x = x + 1;
     }
     stageEmbed.setTimestamp();
     stageEmbed.setFooter({ text: 'StageInfo by splatoon3.ink' });

--- a/app/common.js
+++ b/app/common.js
@@ -477,11 +477,16 @@ function getLeague(data, x) {
     let date;
     let rule;
     date = sp3unixTime2ymdw(data[x].startTime) + ' ' + sp3unixTime2hm(data[x].startTime) + ' – ' + sp3unixTime2hm(data[x].endTime);
-    rule = sp3rule2txt(data[x].leagueMatchSetting.vsRule.name);
-    stage =
-        sp3stage2txt(data[x].leagueMatchSetting.vsStages[0].vsStageId) +
-        '／' +
-        sp3stage2txt(data[x].leagueMatchSetting.vsStages[1].vsStageId);
+    if (data[x].leagueMatchSettingleagueMatchSetting == null) {
+        rule = 'フェス期間中';
+        stage = 'フェス期間中はお休みでし';
+    } else {
+        rule = sp3rule2txt(data[x].leagueMatchSetting.vsRule.name);
+        stage =
+            sp3stage2txt(data[x].leagueMatchSetting.vsStages[0].vsStageId) +
+            '／' +
+            sp3stage2txt(data[x].leagueMatchSetting.vsStages[1].vsStageId);
+    }
     return date + ',' + rule + ',' + stage;
 }
 
@@ -490,11 +495,16 @@ function getOpen(data, x) {
     let date;
     let rule;
     date = sp3unixTime2ymdw(data[x].startTime) + ' ' + sp3unixTime2hm(data[x].startTime) + ' – ' + sp3unixTime2hm(data[x].endTime);
-    rule = sp3rule2txt(data[x].bankaraMatchSettings[1].vsRule.name);
-    stage =
-        sp3stage2txt(data[x].bankaraMatchSettings[1].vsStages[0].vsStageId) +
-        '／' +
-        sp3stage2txt(data[x].bankaraMatchSettings[1].vsStages[1].vsStageId);
+    if (data[x].bankaraMatchSettings == null) {
+        rule = 'フェス期間中';
+        stage = 'フェス期間中はお休みでし';
+    } else {
+        rule = sp3rule2txt(data[x].bankaraMatchSettings[1].vsRule.name);
+        stage =
+            sp3stage2txt(data[x].bankaraMatchSettings[1].vsStages[0].vsStageId) +
+            '／' +
+            sp3stage2txt(data[x].bankaraMatchSettings[1].vsStages[1].vsStageId);
+    }
     return date + ',' + rule + ',' + stage;
 }
 
@@ -503,11 +513,16 @@ function getChallenge(data, x) {
     let date;
     let rule;
     date = sp3unixTime2ymdw(data[x].startTime) + ' ' + sp3unixTime2hm(data[x].startTime) + ' – ' + sp3unixTime2hm(data[x].endTime);
-    rule = sp3rule2txt(data[x].bankaraMatchSettings[0].vsRule.name);
-    stage =
-        sp3stage2txt(data[x].bankaraMatchSettings[0].vsStages[0].vsStageId) +
-        '／' +
-        sp3stage2txt(data[x].bankaraMatchSettings[0].vsStages[1].vsStageId);
+    if (data[x].bankaraMatchSettings == null) {
+        rule = 'フェス期間中';
+        stage = 'フェス期間中はお休みでし';
+    } else {
+        rule = sp3rule2txt(data[x].bankaraMatchSettings[0].vsRule.name);
+        stage =
+            sp3stage2txt(data[x].bankaraMatchSettings[0].vsStages[0].vsStageId) +
+            '／' +
+            sp3stage2txt(data[x].bankaraMatchSettings[0].vsStages[1].vsStageId);
+    }
     return date + ',' + rule + ',' + stage;
 }
 
@@ -516,29 +531,65 @@ function getXMatch(data, x) {
     let date;
     let rule;
     date = sp3unixTime2ymdw(data[x].startTime) + ' ' + sp3unixTime2hm(data[x].startTime) + ' – ' + sp3unixTime2hm(data[x].endTime);
-    rule = sp3rule2txt(data[x].xMatchSetting.vsRule.name);
-    stage = sp3stage2txt(data[x].xMatchSetting.vsStages[0].vsStageId) + '／' + sp3stage2txt(data[x].xMatchSetting.vsStages[1].vsStageId);
+    if (data[x].xMatchSetting == null) {
+        rule = 'フェス期間中';
+        stage = 'フェス期間中はお休みでし';
+    } else {
+        rule = sp3rule2txt(data[x].xMatchSetting.vsRule.name);
+        stage =
+            sp3stage2txt(data[x].xMatchSetting.vsStages[0].vsStageId) + '／' + sp3stage2txt(data[x].xMatchSetting.vsStages[1].vsStageId);
+    }
     return date + ',' + rule + ',' + stage;
 }
 
 /**
- * データ取得用
+ * レギュラーマッチステージ情報取得
+ * フェス期間中はフェス情報を取得する
  */
 function getRegular(data, x) {
-    const regular_list = data.data.regularSchedules.nodes;
-    const r_setting = regular_list[x].regularMatchSetting;
     let stage1;
     let stage2;
     let date;
     let time;
     let rule;
+    let matchName;
+    let iconURL;
+    let color;
+    if (checkFes(data, x)) {
+        const fest_list = data.data.festSchedules.nodes;
+        const f_setting = fest_list[x].festMatchSetting;
 
-    date = sp3unixTime2ymdw(regular_list[x].startTime);
-    time = sp3unixTime2hm(regular_list[x].startTime) + ' – ' + sp3unixTime2hm(regular_list[x].endTime);
-    rule = sp3rule2txt(r_setting.vsRule.name);
-    stage1 = sp3stage2txt(r_setting.vsStages[0].vsStageId);
-    stage2 = sp3stage2txt(r_setting.vsStages[1].vsStageId);
-    return date + ',' + time + ',' + rule + ',' + stage1 + ',' + stage2;
+        date = sp3unixTime2ymdw(fest_list[x].startTime);
+        time = sp3unixTime2hm(fest_list[x].startTime) + ' – ' + sp3unixTime2hm(fest_list[x].endTime);
+        rule = sp3rule2txt(f_setting.vsRule.name);
+        stage1 = sp3stage2txt(f_setting.vsStages[0].vsStageId);
+        stage2 = sp3stage2txt(f_setting.vsStages[1].vsStageId);
+        matchName = 'フェスマッチ';
+        iconURL = 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/fes_icon.png';
+        color = '#ead147';
+    } else {
+        const regular_list = data.data.regularSchedules.nodes;
+        const r_setting = regular_list[x].regularMatchSetting;
+
+        date = sp3unixTime2ymdw(regular_list[x].startTime);
+        time = sp3unixTime2hm(regular_list[x].startTime) + ' – ' + sp3unixTime2hm(regular_list[x].endTime);
+        rule = sp3rule2txt(r_setting.vsRule.name);
+        stage1 = sp3stage2txt(r_setting.vsStages[0].vsStageId);
+        stage2 = sp3stage2txt(r_setting.vsStages[1].vsStageId);
+        matchName = 'レギュラーマッチ';
+        iconURL = 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/regular_icon.png';
+        color = '#B3FF00';
+    }
+    return {
+        date: date,
+        time: time,
+        rule: rule,
+        stage1: stage1,
+        stage2: stage2,
+        matchName: matchName,
+        iconURL: iconURL,
+        color: color,
+    };
 }
 
 /**

--- a/app/index.js
+++ b/app/index.js
@@ -43,7 +43,10 @@ const { handleFriendCode } = require(app + '/cmd/other/friendcode.js');
 client.login(process.env.DISCORD_BOT_TOKEN);
 
 client.on('messageCreate', async (msg) => {
-    if (msg.author.bot) {
+    const member = await msg.guild.members.fetch(msg.author.id, {
+        force: true, // intentsによってはGuildMemberUpdateが配信されないため
+    });
+    if (msg.author.bot || member.permissions.has('MANAGE_CHANNELS')) {
         if (msg.content.startsWith('/poll')) {
             if (msg.author.username === 'ブキチ') {
                 console.log(msg.author.username);

--- a/register.js
+++ b/register.js
@@ -85,8 +85,8 @@ const buki = new SlashCommandBuilder()
 const show = new SlashCommandBuilder()
     .setName(commandNames.show)
     .setDescription('ステージ情報を表示')
-    .addSubcommand((subcommand) => subcommand.setName('now').setDescription('現在のリグマ、ガチマのステージ情報を表示'))
-    .addSubcommand((subcommand) => subcommand.setName('next').setDescription('次のリグマ、ガチマのステージ情報を表示'))
+    .addSubcommand((subcommand) => subcommand.setName('now').setDescription('現在のバンカラマッチのステージ情報を表示'))
+    .addSubcommand((subcommand) => subcommand.setName('next').setDescription('次のバンカラマッチのステージ情報を表示'))
     .addSubcommand((subcommand) => subcommand.setName('nawabari').setDescription('現在のナワバリステージ情報を表示'))
     .addSubcommand((subcommand) => subcommand.setName('run').setDescription('現在のシフトを表示'));
 


### PR DESCRIPTION
- ステージ情報チャンネルで出力するステージ情報はフェス期間中のスケジュールはnullになるのでエラーにならないよう出力情報を変更
- show xxコマンドでは各ルールの代わりにフェス情報を表示するように修正
  - getRegularを配列でなくObjectで返すように修正
![image](https://user-images.githubusercontent.com/33051481/191926735-14a90a8c-f489-407e-be28-5eb08f61dda6.png)
![image](https://user-images.githubusercontent.com/33051481/191926773-707a9100-66e3-4a45-9483-730a9b968983.png)
![image](https://user-images.githubusercontent.com/33051481/191926807-9d988abc-cd71-48cc-877e-ed53c8e393e1.png)
![image](https://user-images.githubusercontent.com/33051481/191926825-e7fabe38-4e93-47fb-9aaf-5f8af0a309c0.png)
