### PR TITLE
fix #305

### DIFF
--- a/app/cmd/other/friendcode.js
+++ b/app/cmd/other/friendcode.js
@@ -34,16 +34,14 @@ async function selectFriendCode(interaction) {
 
     const deleteButton = new Discord.MessageActionRow();
     deleteButton.addComponents([new Discord.MessageButton().setCustomId('fchide').setLabel('削除').setStyle('DANGER')]);
-    if (result.length == 0) {
-        let fc = await getFC(id);
-        if (fc[0] != null) {
-            interaction.editReply({
-                embeds: [composeEmbed(targetUser, fc[0].code, true)],
-                components: [deleteButton],
-                ephemeral: false,
-            });
-            return;
-        }
+    let fc = await getFC(id);
+    if (fc[0] != null) {
+        interaction.editReply({
+            embeds: [composeEmbed(targetUser, fc[0].code, true)],
+            components: [deleteButton],
+            ephemeral: false,
+        });
+        return;
     }
     if (result.length > 0) {
         let embeds = [];


### PR DESCRIPTION
直近100件の自己紹介チャンネルに投稿がある場合でもフレンドコード登録していればフレンドコードを優先して表示するように修正