### PR TITLE
募集ボタン押下時にボタンを一時的に無効化

### DIFF
--- a/app/cmd/other/recruit/other_game_recruit.js
+++ b/app/cmd/other/recruit/other_game_recruit.js
@@ -1,13 +1,7 @@
 const { EmbedBuilder, PermissionsBitField } = require('discord.js');
 const { searchMessageById } = require('../../../manager/messageManager');
 const { searchMemberById } = require('../../../manager/memberManager');
-const {
-    recruitDeleteButton,
-    recruitActionRow,
-    recruitDeleteButtonWithChannel,
-    recruitActionRowWithChannel,
-    unlockChannelButton,
-} = require('../../../common/button_components.js');
+const { recruitActionRow, recruitDeleteButton, unlockChannelButton } = require('../../../common/button_components.js');
 
 module.exports = {
     otherGameRecruit: otherGameRecruit,
@@ -166,7 +160,7 @@ async function sendOtherGames(interaction, title, recruitNumText, mention, txt, 
         if (reserve_channel == null) {
             sentMessage.edit({ components: [recruitDeleteButton(sentMessage, header)] });
         } else {
-            sentMessage.edit({ components: [recruitDeleteButtonWithChannel(sentMessage, reserve_channel.id, header)] });
+            sentMessage.edit({ components: [recruitDeleteButton(sentMessage, header, reserve_channel.id)] });
             reserve_channel.permissionOverwrites.set(
                 [
                     { id: guild.roles.everyone.id, deny: [PermissionsBitField.Flags.Connect] },
@@ -183,7 +177,7 @@ async function sendOtherGames(interaction, title, recruitNumText, mention, txt, 
             if (reserve_channel == null) {
                 sentMessage.edit({ components: [recruitActionRow(header)] });
             } else {
-                sentMessage.edit({ components: [recruitActionRowWithChannel(reserve_channel.id, header)] });
+                sentMessage.edit({ components: [recruitActionRow(header, reserve_channel.id)] });
             }
         }
     } catch (error) {

--- a/app/cmd/splat2/recruit/league_recruit.js
+++ b/app/cmd/splat2/recruit/league_recruit.js
@@ -3,14 +3,7 @@ const path = require('path');
 const fetch = require('node-fetch');
 const { stage2txt, rule2txt, unixTime2hm, unixTime2ymdw } = require('../../../common');
 const { createRoundRect, drawArcImage, fillTextWithStroke } = require('../../../common/canvas_components');
-const {
-    recruitDeleteButton,
-    recruitActionRow,
-    disableButtons,
-    recruitDeleteButtonWithChannel,
-    recruitActionRowWithChannel,
-    unlockChannelButton,
-} = require('../../../common/button_components.js');
+const { recruitActionRow, disableButtons, recruitDeleteButton, unlockChannelButton } = require('../../../common/button_components.js');
 const { AttachmentBuilder, PermissionsBitField } = require('discord.js');
 const { searchRoleIdByName } = require('../../../manager/roleManager');
 
@@ -231,7 +224,7 @@ async function sendLeagueMatch(
         }
 
         if (isLock) {
-            sentMessage.edit({ components: [recruitDeleteButtonWithChannel(sentMessage, reserve_channel.id, header)] });
+            sentMessage.edit({ components: [recruitDeleteButton(sentMessage, header, reserve_channel.id)] });
             reserve_channel.permissionOverwrites.set(
                 [
                     { id: guild.roles.everyone.id, deny: [PermissionsBitField.Flags.Connect] },
@@ -265,7 +258,7 @@ async function sendLeagueMatch(
             if (isLock == false) {
                 sentMessage.edit({ components: [recruitActionRow(header)] });
             } else {
-                sentMessage.edit({ components: [recruitActionRowWithChannel(reserve_channel.id, header)] });
+                sentMessage.edit({ components: [recruitActionRow(header, reserve_channel.id)] });
             }
         }
 

--- a/app/cmd/splat2/recruit/regular_recruit.js
+++ b/app/cmd/splat2/recruit/regular_recruit.js
@@ -4,14 +4,7 @@ const fetch = require('node-fetch');
 const { stage2txt, rule2txt, unixTime2hm, unixTime2ymdw } = require('../../../common');
 const { createRoundRect, drawArcImage, fillTextWithStroke } = require('../../../common/canvas_components');
 const { searchRoleIdByName } = require('../../../manager/roleManager.js');
-const {
-    recruitDeleteButton,
-    recruitActionRow,
-    disableButtons,
-    recruitDeleteButtonWithChannel,
-    recruitActionRowWithChannel,
-    unlockChannelButton,
-} = require('../../../common/button_components.js');
+const { recruitActionRow, disableButtons, recruitDeleteButton, unlockChannelButton } = require('../../../common/button_components.js');
 const { AttachmentBuilder, PermissionsBitField } = require('discord.js');
 const schedule_url = 'https://splatoon2.ink/data/schedules.json';
 
@@ -206,8 +199,12 @@ async function sendRegularMatch(
             isLock = true;
         }
 
+        let deleteButtonMsg;
         if (isLock) {
-            sentMessage.edit({ components: [recruitDeleteButtonWithChannel(sentMessage, reserve_channel.id, header)] });
+            sentMessage.edit({ components: [recruitActionRow(header, reserve_channel.id)] });
+            deleteButtonMsg = await interaction.channel.send({
+                components: [recruitDeleteButton(sentMessage, header, reserve_channel.id)],
+            });
             reserve_channel.permissionOverwrites.set(
                 [
                     { id: guild.roles.everyone.id, deny: [PermissionsBitField.Flags.Connect] },
@@ -222,22 +219,21 @@ async function sendRegularMatch(
                 ephemeral: true,
             });
         } else {
+            sentMessage.edit({ components: [recruitActionRow(header)] });
+            deleteButtonMsg = await interaction.channel.send({
+                components: [recruitDeleteButton(sentMessage, header)],
+            });
             await interaction.followUp({
                 content: '募集完了でし！参加者が来るまで待つでし！\n15秒間は募集を取り消せるでし！',
                 ephemeral: true,
             });
-            sentMessage.edit({ components: [recruitDeleteButton(sentMessage, header)] });
         }
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
-        let cmd_message = await channel.messages.fetch({ message: sentMessage.id });
-        if (cmd_message != undefined) {
-            if (isLock == false) {
-                sentMessage.edit({ components: [recruitActionRow(header)] });
-            } else {
-                sentMessage.edit({ components: [recruitActionRowWithChannel(reserve_channel.id, header)] });
-            }
+        const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
+        if (isNotEmpty(deleteButtonCheck)) {
+            deleteButtonCheck.delete();
         }
 
         // 2時間後にボタンを無効化する

--- a/app/cmd/splat3/recruit/anarchy_recruit.js
+++ b/app/cmd/splat3/recruit/anarchy_recruit.js
@@ -3,17 +3,10 @@ const path = require('path');
 const fetch = require('node-fetch');
 const { searchMessageById } = require('../../../manager/messageManager');
 const { searchMemberById } = require('../../../manager/memberManager');
-const { checkFes, sp3stage2txt, sp3rule2txt, sp3unixTime2hm, sp3unixTime2ymdw } = require('../../../common');
+const { isNotEmpty, checkFes, sp3stage2txt, sp3rule2txt, sp3unixTime2hm, sp3unixTime2ymdw } = require('../../../common');
 const { searchChannelIdByName } = require('../../../manager/channelManager');
 const { createRoundRect, drawArcImage, fillTextWithStroke } = require('../../../common/canvas_components');
-const {
-    recruitDeleteButton,
-    recruitActionRow,
-    disableButtons,
-    recruitDeleteButtonWithChannel,
-    recruitActionRowWithChannel,
-    unlockChannelButton,
-} = require('../../../common/button_components');
+const { recruitActionRow, disableButtons, recruitDeleteButton, unlockChannelButton } = require('../../../common/button_components');
 const { AttachmentBuilder, ChannelType, PermissionsBitField } = require('discord.js');
 const { searchRoleIdByName } = require('../../../manager/roleManager');
 
@@ -257,8 +250,12 @@ async function sendAnarchyMatch(
             isLock = true;
         }
 
+        let deleteButtonMsg;
         if (isLock) {
-            sentMessage.edit({ components: [recruitDeleteButtonWithChannel(sentMessage, reserve_channel.id, header)] });
+            sentMessage.edit({ components: [recruitActionRow(header, reserve_channel.id)] });
+            deleteButtonMsg = await interaction.channel.send({
+                components: [recruitDeleteButton(sentMessage, header, reserve_channel.id)],
+            });
             reserve_channel.permissionOverwrites.set(
                 [
                     { id: guild.roles.everyone.id, deny: [PermissionsBitField.Flags.Connect] },
@@ -273,22 +270,21 @@ async function sendAnarchyMatch(
                 ephemeral: true,
             });
         } else {
+            sentMessage.edit({ components: [recruitActionRow(header)] });
+            deleteButtonMsg = await interaction.channel.send({
+                components: [recruitDeleteButton(sentMessage, header)],
+            });
             await interaction.followUp({
                 content: '募集完了でし！参加者が来るまで待つでし！\n15秒間は募集を取り消せるでし！',
                 ephemeral: true,
             });
-            sentMessage.edit({ components: [recruitDeleteButton(sentMessage, header)] });
         }
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
-        let cmd_message = await searchMessageById(guild, interaction.channel.id, sentMessage.id);
-        if (cmd_message) {
-            if (isLock == false) {
-                sentMessage.edit({ components: [recruitActionRow(header)] });
-            } else {
-                sentMessage.edit({ components: [recruitActionRowWithChannel(reserve_channel.id, header)] });
-            }
+        const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
+        if (isNotEmpty(deleteButtonCheck)) {
+            deleteButtonCheck.delete();
         }
 
         // 2時間後にボタンを無効化する

--- a/app/cmd/splat3/recruit/private_recruit.js
+++ b/app/cmd/splat3/recruit/private_recruit.js
@@ -1,6 +1,7 @@
 const { EmbedBuilder } = require('discord.js');
 const { searchMessageById } = require('../../../manager/messageManager');
 const { searchMemberById } = require('../../../manager/memberManager');
+const { isNotEmpty } = require('../../../common');
 const { recruitDeleteButton, recruitActionRow, notifyActionRow } = require('../../../common/button_components');
 
 module.exports = {
@@ -75,20 +76,22 @@ async function sendPrivateRecruit(interaction, options) {
         const sentMessage = await interaction.channel.send({
             content: mention + ` ボタンを押して参加表明するでし！`,
         });
+        // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
+        sentMessage.edit({ components: [recruitActionRow(header)] });
+        let deleteButtonMsg = await interaction.channel.send({
+            components: [recruitDeleteButton(sentMessage, header)],
+        });
+
         await interaction.followUp({
             content: '募集完了でし！参加者が来るまで気長に待つでし！\n15秒間は募集を取り消せるでし！',
             ephemeral: true,
         });
-        // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
-        sentMessage.edit({ components: [recruitDeleteButton(sentMessage, header)] });
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
-        let cmd_message = await searchMessageById(guild, interaction.channel.id, sentMessage.id);
-        if (cmd_message) {
-            sentMessage.edit({ components: [recruitActionRow(header)] });
-        } else {
-            return;
+        const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
+        if (isNotEmpty(deleteButtonCheck)) {
+            deleteButtonCheck.delete();
         }
     } catch (error) {
         console.log(error);
@@ -97,7 +100,7 @@ async function sendPrivateRecruit(interaction, options) {
 
 async function sendNotification(interaction) {
     const mention = `@everyone`;
-    const sentMessage = await interaction.channel.send({
+    const sentMessage = await interaction.editReply({
         content: mention + ` ボタンを押して参加表明するでし！`,
     });
     await interaction.followUp({
@@ -105,5 +108,5 @@ async function sendNotification(interaction) {
         ephemeral: true,
     });
     // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
-    sentMessage.edit({ components: [notifyActionRow(interaction)] });
+    sentMessage.edit({ components: [notifyActionRow(interaction.member.id)] });
 }

--- a/app/cmd/splat3/recruit/regular_recruit.js
+++ b/app/cmd/splat3/recruit/regular_recruit.js
@@ -3,17 +3,10 @@ const path = require('path');
 const fetch = require('node-fetch');
 const { searchMessageById } = require('../../../manager/messageManager');
 const { searchMemberById } = require('../../../manager/memberManager');
-const { checkFes, getRegular } = require('../../../common');
+const { isNotEmpty, checkFes, getRegular } = require('../../../common');
 const { searchChannelIdByName } = require('../../../manager/channelManager');
 const { createRoundRect, drawArcImage, fillTextWithStroke } = require('../../../common/canvas_components');
-const {
-    recruitDeleteButton,
-    recruitActionRow,
-    disableButtons,
-    recruitDeleteButtonWithChannel,
-    recruitActionRowWithChannel,
-    unlockChannelButton,
-} = require('../../../common/button_components');
+const { recruitActionRow, disableButtons, recruitDeleteButton, unlockChannelButton } = require('../../../common/button_components');
 const { AttachmentBuilder, ChannelType, PermissionsBitField } = require('discord.js');
 const schedule_url = 'https://splatoon3.ink/data/schedules.json';
 
@@ -215,8 +208,12 @@ async function sendRegularMatch(
             isLock = true;
         }
 
+        let deleteButtonMsg;
         if (isLock) {
-            sentMessage.edit({ components: [recruitDeleteButtonWithChannel(sentMessage, reserve_channel.id, header)] });
+            sentMessage.edit({ components: [recruitActionRow(header, reserve_channel.id)] });
+            deleteButtonMsg = await interaction.channel.send({
+                components: [recruitDeleteButton(sentMessage, header, reserve_channel.id)],
+            });
             reserve_channel.permissionOverwrites.set(
                 [
                     { id: guild.roles.everyone.id, deny: [PermissionsBitField.Flags.Connect] },
@@ -231,22 +228,21 @@ async function sendRegularMatch(
                 ephemeral: true,
             });
         } else {
+            sentMessage.edit({ components: [recruitActionRow(header)] });
+            deleteButtonMsg = await interaction.channel.send({
+                components: [recruitDeleteButton(sentMessage, header)],
+            });
             await interaction.followUp({
                 content: '募集完了でし！参加者が来るまで待つでし！\n15秒間は募集を取り消せるでし！',
                 ephemeral: true,
             });
-            sentMessage.edit({ components: [recruitDeleteButton(sentMessage, header)] });
         }
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
-        let cmd_message = await searchMessageById(guild, interaction.channel.id, sentMessage.id);
-        if (cmd_message) {
-            if (isLock == false) {
-                sentMessage.edit({ components: [recruitActionRow(header)] });
-            } else {
-                sentMessage.edit({ components: [recruitActionRowWithChannel(reserve_channel.id, header)] });
-            }
+        const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
+        if (isNotEmpty(deleteButtonCheck)) {
+            deleteButtonCheck.delete();
         }
 
         // 2時間後にボタンを無効化する

--- a/app/common/button_components.js
+++ b/app/common/button_components.js
@@ -1,51 +1,51 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { URLSearchParams } = require('url');
+const { isNotEmpty } = require('../common');
 
 module.exports = {
     recruitDeleteButton: recruitDeleteButton,
     recruitActionRow: recruitActionRow,
-    recruitDeleteButtonWithChannel: recruitDeleteButtonWithChannel,
-    recruitActionRowWithChannel: recruitActionRowWithChannel,
+    thinkingActionRow: thinkingActionRow,
     disableButtons: disableButtons,
     unlockChannelButton: unlockChannelButton,
     notifyActionRow: notifyActionRow,
 };
 
-function recruitDeleteButtonWithChannel(msg, channel_id, header) {
-    const joinParams = new URLSearchParams();
-    joinParams.append('d', 'jr');
-    joinParams.append('hmid', header.id);
-    joinParams.append('vid', channel_id);
-
+function recruitDeleteButton(msg, header, channel_id = null) {
     const deleteParams = new URLSearchParams();
     deleteParams.append('d', 'del');
     deleteParams.append('mid', msg.id);
     deleteParams.append('hmid', header.id);
-    deleteParams.append('vid', channel_id);
+    if (isNotEmpty(channel_id)) {
+        deleteParams.append('vid', channel_id);
+    }
 
     let button = new ActionRowBuilder();
-    button.addComponents([
-        new ButtonBuilder().setCustomId(joinParams.toString()).setLabel('参加').setStyle(ButtonStyle.Primary),
-        new ButtonBuilder().setCustomId(deleteParams.toString()).setLabel('削除').setStyle(ButtonStyle.Danger),
-    ]);
+    button.addComponents([new ButtonBuilder().setCustomId(deleteParams.toString()).setLabel('募集を削除').setStyle(ButtonStyle.Danger)]);
     return button;
 }
 
-function recruitActionRowWithChannel(channel_id, header) {
+function recruitActionRow(header, channel_id = null) {
     const joinParams = new URLSearchParams();
     joinParams.append('d', 'jr');
     joinParams.append('hmid', header.id);
-    joinParams.append('vid', channel_id);
+    if (isNotEmpty(channel_id)) {
+        joinParams.append('vid', channel_id);
+    }
 
     const cancelParams = new URLSearchParams();
     cancelParams.append('d', 'cr');
     cancelParams.append('hmid', header.id);
-    cancelParams.append('vid', channel_id);
+    if (isNotEmpty(channel_id)) {
+        cancelParams.append('vid', channel_id);
+    }
 
     const closeParams = new URLSearchParams();
     closeParams.append('d', 'close');
     closeParams.append('hmid', header.id);
-    closeParams.append('vid', channel_id);
+    if (isNotEmpty(channel_id)) {
+        closeParams.append('vid', channel_id);
+    }
 
     return new ActionRowBuilder().addComponents([
         new ButtonBuilder().setCustomId(joinParams.toString()).setLabel('参加').setStyle(ButtonStyle.Primary),
@@ -54,62 +54,61 @@ function recruitActionRowWithChannel(channel_id, header) {
     ]);
 }
 
-function recruitDeleteButton(msg, header) {
-    const joinParams = new URLSearchParams();
-    joinParams.append('d', 'jr');
-    joinParams.append('hmid', header.id);
-
-    const deleteParams = new URLSearchParams();
-    deleteParams.append('d', 'del');
-    deleteParams.append('mid', msg.id);
-    deleteParams.append('hmid', header.id);
-
-    let button = new ActionRowBuilder();
-    button.addComponents([
-        new ButtonBuilder().setCustomId(joinParams.toString()).setLabel('参加').setStyle(ButtonStyle.Primary),
-        new ButtonBuilder().setCustomId(deleteParams.toString()).setLabel('削除').setStyle(ButtonStyle.Danger),
-    ]);
-    return button;
-}
-
-function recruitActionRow(header) {
-    const joinParams = new URLSearchParams();
-    joinParams.append('d', 'jr');
-    joinParams.append('hmid', header.id);
-
-    const cancelParams = new URLSearchParams();
-    cancelParams.append('d', 'cr');
-    cancelParams.append('hmid', header.id);
-
-    const closeParams = new URLSearchParams();
-    closeParams.append('d', 'close');
-    closeParams.append('hmid', header.id);
-
-    return new ActionRowBuilder().addComponents([
-        new ButtonBuilder().setCustomId(joinParams.toString()).setLabel('参加').setStyle(ButtonStyle.Primary),
-        new ButtonBuilder().setCustomId(cancelParams.toString()).setLabel('キャンセル').setStyle(ButtonStyle.Danger),
-        new ButtonBuilder().setCustomId(closeParams.toString()).setLabel('〆').setStyle(ButtonStyle.Secondary),
-    ]);
-}
-
-function notifyActionRow(interaction) {
+function notifyActionRow(host_id) {
     const joinParams = new URLSearchParams();
     joinParams.append('d', 'njr');
-    joinParams.append('hid', interaction.member.id);
+    joinParams.append('hid', host_id);
 
     const cancelParams = new URLSearchParams();
     cancelParams.append('d', 'ncr');
-    cancelParams.append('hid', interaction.member.id);
+    cancelParams.append('hid', host_id);
 
     const closeParams = new URLSearchParams();
     closeParams.append('d', 'nclose');
-    closeParams.append('hid', interaction.member.id);
+    closeParams.append('hid', host_id);
 
     return new ActionRowBuilder().addComponents([
         new ButtonBuilder().setCustomId(joinParams.toString()).setLabel('参加').setStyle(ButtonStyle.Primary),
         new ButtonBuilder().setCustomId(cancelParams.toString()).setLabel('キャンセル').setStyle(ButtonStyle.Danger),
         new ButtonBuilder().setCustomId(closeParams.toString()).setLabel('〆').setStyle(ButtonStyle.Secondary),
     ]);
+}
+
+function thinkingActionRow(pushedButton) {
+    const buttons = new ActionRowBuilder();
+
+    if (pushedButton === 'join') {
+        buttons.addComponents([
+            new ButtonBuilder()
+                .setCustomId('join')
+                .setEmoji(process.env.RECRUIT_LOADING_EMOJI_ID)
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled(),
+            new ButtonBuilder().setCustomId('cancel').setLabel('キャンセル').setStyle(ButtonStyle.Danger).setDisabled(),
+            new ButtonBuilder().setCustomId('close').setLabel('〆').setStyle(ButtonStyle.Secondary).setDisabled(),
+        ]);
+    } else if (pushedButton === 'cancel') {
+        buttons.addComponents([
+            new ButtonBuilder().setCustomId('join').setLabel('参加').setStyle(ButtonStyle.Primary).setDisabled(),
+            new ButtonBuilder()
+                .setCustomId('cancel')
+                .setEmoji(process.env.RECRUIT_LOADING_EMOJI_ID)
+                .setStyle(ButtonStyle.Danger)
+                .setDisabled(),
+            new ButtonBuilder().setCustomId('close').setLabel('〆').setStyle(ButtonStyle.Secondary).setDisabled(),
+        ]);
+    } else if (pushedButton === 'close') {
+        buttons.addComponents([
+            new ButtonBuilder().setCustomId('join').setLabel('参加').setStyle(ButtonStyle.Primary).setDisabled(),
+            new ButtonBuilder().setCustomId('cancel').setLabel('キャンセル').setStyle(ButtonStyle.Danger).setDisabled(),
+            new ButtonBuilder()
+                .setCustomId('close')
+                .setEmoji(process.env.RECRUIT_LOADING_EMOJI_ID)
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(),
+        ]);
+    }
+    return buttons;
 }
 
 function disableButtons() {

--- a/app/event/recruit_button.js
+++ b/app/event/recruit_button.js
@@ -1,15 +1,15 @@
 const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
-const { isNotEmpty, datetimeDiff } = require('../common');
+const { isEmpty, datetimeDiff } = require('../common');
 const { insert_recruit } = require('../../db/recruit_insert');
 const { delete_recruit, deleteRecruitByMemberId } = require('../../db/recruit_delete.js');
 const { getRecruitMessageByMemberId, getRecruitAllByMessageId } = require('../../db/recruit_select.js');
 const { searchMemberById } = require('../manager/memberManager.js');
 const { searchMessageById, getFullMessageObject } = require('../manager/messageManager.js');
 const { searchChannelById } = require('../manager/channelManager.js');
+const { recruitActionRow, notifyActionRow, thinkingActionRow } = require('../common/button_components');
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const axios = require('axios');
 const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
-let in_process = [];
 
 module.exports = {
     join: join,
@@ -30,11 +30,6 @@ async function sendLogWebhook(log_content) {
     );
 }
 
-function inProcessClear(id) {
-    in_process = in_process.filter(function (item) {
-        return item !== id;
-    });
-}
 /**
  *
  * @param {unknown} err
@@ -58,8 +53,6 @@ async function handleError(err, { interaction }) {
     //     });
     console.log(err);
     // }
-    // NOTE: 処理中リストから削除する
-    inProcessClear(interaction.member.user.id);
 }
 /**
  *
@@ -70,16 +63,7 @@ async function handleError(err, { interaction }) {
 async function join(interaction, params) {
     /** @type {Discord.Snowflake} */
     try {
-        // NOTE: ボタン処理中のリストにinteractionユーザーがいる場合は処理しない
-        if (in_process.includes(interaction.member.user.id)) {
-            console.log({ in_process });
-            return;
-        }
-        await interaction.deferReply({
-            ephemeral: true,
-        });
-        // NOTE: ボタン処理中のリストにinteractionユーザーを追加
-        in_process.push(interaction.member.user.id);
+        await interaction.update({ components: [thinkingActionRow('join')] });
 
         const guild = await interaction.guild.fetch();
         // interaction.member.user.idでなければならない。なぜならば、APIInteractionGuildMemberはid を直接持たないからである。
@@ -88,7 +72,10 @@ async function join(interaction, params) {
         const header_message = await getFullMessageObject(guild, interaction.channel, header_msg_id);
         const host = header_message.interaction.user;
         const host_id = host.id;
-        const channelId = params.get('vid');
+        let channelId = params.get('vid');
+        if (isEmpty(channelId)) {
+            channelId = null;
+        }
 
         await sendLogWebhook(`${host.tag}[${host.id}]の募集で${member.displayName}たんが参加ボタンを押したでし`);
 
@@ -97,23 +84,25 @@ async function join(interaction, params) {
                 content: `募集主は参加表明できないでし！`,
                 ephemeral: true,
             });
-            // NOTE: ボタンの処理が終わったら処理中リストから削除する
-            inProcessClear(interaction.member.user.id);
+
+            await interaction.editReply({ components: [recruitActionRow(header_message, channelId)] });
+
             return;
         } else {
             // 参加済みかチェック
             const member_data = await getRecruitMessageByMemberId(interaction.message.id, member.user.id);
             if (member_data.length > 0) {
-                // NOTE: 削除ボタンの切り替わり前に参加ボタン押されると
-                // 編集処理が中断されるので、もう一度押したときに参加表明一覧を更新する
-                await editMemberListMessage(interaction);
+                // // NOTE: 削除ボタンの切り替わり前に参加ボタン押されると
+                // // 編集処理が中断されるので、もう一度押したときに参加表明一覧を更新する
+                // await editMemberListMessage(interaction);
 
                 await interaction.followUp({
                     content: `すでに参加ボタンを押してるでし！`,
                     ephemeral: true,
                 });
-                // NOTE: ボタンの処理が終わったら処理中リストから削除する
-                inProcessClear(interaction.member.user.id);
+
+                await interaction.editReply({ components: [recruitActionRow(header_message, channelId)] });
+
                 return;
             }
 
@@ -146,7 +135,7 @@ async function join(interaction, params) {
                 });
             }
 
-            if (channelId == undefined) {
+            if (channelId == null) {
                 await interaction.followUp({
                     content: `<@${host_id}>からの返答を待つでし！\n条件を満たさない場合は参加を断られる場合があるでし！`,
                     // components: [channelLinkButtons(interaction.guildId, thread_message.url)], TODO: スレッド内へのリンクボタンを作る
@@ -160,10 +149,11 @@ async function join(interaction, params) {
                 });
             }
 
-            await editMemberListMessage(interaction);
+            await interaction.editReply({
+                content: await MemberListMessage(interaction),
+                components: [recruitActionRow(header_message, channelId)],
+            });
 
-            // NOTE: ボタンの処理が終わったら処理中リストから削除する
-            inProcessClear(interaction.member.user.id);
             // 5分後にホストへの通知を削除
             if (notify_to_host_message != null) {
                 await sleep(300000);
@@ -184,16 +174,7 @@ async function join(interaction, params) {
 async function cancel(interaction, params) {
     /** @type {Discord.Snowflake} */
     try {
-        // NOTE: ボタン処理中のリストにinteractionユーザーがいる場合は処理しない
-        if (in_process.includes(interaction.member.user.id)) {
-            console.log({ in_process });
-            return;
-        }
-        await interaction.deferReply({
-            ephemeral: false,
-        });
-        // NOTE: ボタン処理中のリストにinteractionユーザーを追加
-        in_process.push(interaction.member.user.id);
+        await interaction.update({ components: [thinkingActionRow('cancel')] });
 
         const guild = await interaction.guild.fetch();
         const member = await searchMemberById(guild, interaction.member.user.id);
@@ -201,9 +182,12 @@ async function cancel(interaction, params) {
         const header_message = await getFullMessageObject(guild, interaction.channel, header_msg_id);
         const host = header_message.interaction.user;
         const host_id = host.id;
-        const channelId = params.get('vid');
         const embed = new EmbedBuilder().setDescription(`<@${host_id}>たんの募集〆`);
-        const header_msg = await searchMessageById(guild, interaction.channel.id, interaction.message.id);
+        const cmd_message = interaction.message;
+        let channelId = params.get('vid');
+        if (isEmpty(channelId)) {
+            channelId = null;
+        }
 
         await sendLogWebhook(`${host.tag}[${host.id}]の募集で${member.displayName}たんがキャンセルボタンを押したでし`);
 
@@ -211,17 +195,17 @@ async function cancel(interaction, params) {
             // recruitテーブルから削除
             await delete_recruit(interaction.message.id);
 
-            if (channelId != undefined) {
+            if (channelId != null) {
                 let channel = await searchChannelById(guild, channelId);
                 channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
                 channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
             }
 
-            await header_msg.edit({
+            await cmd_message.edit({
                 content: `<@${host_id}>たんの募集はキャンセルされたでし！`,
                 components: [disableButtons()],
             });
-            await interaction.editReply({ embeds: [embed] });
+            await interaction.followUp({ embeds: [embed], ephemeral: false });
         } else {
             // NOTE: 参加表明済みかチェックして、参加表明済みならキャンセル可能
             const member_data = await getRecruitMessageByMemberId(interaction.message.id, member.user.id);
@@ -230,21 +214,21 @@ async function cancel(interaction, params) {
                 await deleteRecruitByMemberId(interaction.message.id, interaction.member.id);
 
                 // ホストに通知
-                await editMemberListMessage(interaction);
-                await interaction.deleteReply();
                 await interaction.message.reply({
                     content: `<@${host_id}> <@${interaction.member.id}>たんがキャンセルしたでし！`,
                 });
+                await interaction.editReply({
+                    content: await MemberListMessage(interaction),
+                    components: [recruitActionRow(header_message, channelId)],
+                });
             } else {
-                await interaction.deleteReply();
                 await interaction.followUp({
                     content: `他人の募集は勝手にキャンセルできないでし！！`,
                     ephemeral: true,
                 });
+                await interaction.editReply({ components: [recruitActionRow(header_message, channelId)] });
             }
         }
-        // NOTE: ボタンの処理が終わったら処理中リストから削除する
-        inProcessClear(interaction.member.user.id);
     } catch (err) {
         handleError(err, { interaction });
     }
@@ -253,17 +237,10 @@ async function cancel(interaction, params) {
 async function del(interaction, params) {
     /** @type {Discord.Snowflake} */
     try {
-        // NOTE: ボタン処理中のリストにinteractionユーザーがいる場合は処理しない
-        if (in_process.includes(interaction.member.user.id)) {
-            console.log({ in_process });
-            return;
-        }
-        // Discord APIの処理待ち時に削除ボタン連打されるのを防ぐため
+        // 処理待ち
         await interaction.deferReply({
             ephemeral: true,
         });
-        // NOTE: ボタン処理中のリストにinteractionユーザーを追加
-        in_process.push(interaction.member.user.id);
 
         const guild = await interaction.guild.fetch();
         const member = await searchMemberById(guild, interaction.member.user.id);
@@ -273,15 +250,20 @@ async function del(interaction, params) {
         const header_message = await getFullMessageObject(guild, interaction.channel, header_msg_id);
         const host = header_message.interaction.user;
         const host_id = host.id;
-        const channelId = params.get('vid');
+        let channelId = params.get('vid');
+        if (isEmpty(channelId)) {
+            channelId = null;
+        }
         if (member.user.id == host_id) {
-            if (channelId != undefined) {
+            if (channelId != null) {
                 let channel = await searchChannelById(guild, channelId);
                 channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
                 channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
             }
+            await interaction.message.delete();
             await cmd_message.delete();
             await header_message.delete();
+
             // recruitテーブルから削除
             await delete_recruit(interaction.message.id);
             await interaction.editReply({
@@ -291,8 +273,6 @@ async function del(interaction, params) {
         } else {
             await interaction.editReply({ content: '他人の募集は消せる訳無いでし！！！', ephemeral: true });
         }
-        // NOTE: ボタンの処理が終わったら処理中リストから削除する
-        inProcessClear(interaction.member.user.id);
     } catch (err) {
         handleError(err, { interaction });
     }
@@ -307,16 +287,7 @@ async function del(interaction, params) {
 async function close(interaction, params) {
     /** @type {Discord.Snowflake} */
     try {
-        // NOTE: ボタン処理中のリストにinteractionユーザーがいる場合は処理しない
-        if (in_process.includes(interaction.member.user.id)) {
-            console.log({ in_process });
-            return;
-        }
-        await interaction.deferReply({
-            ephemeral: false,
-        });
-        // NOTE: ボタン処理中のリストにinteractionユーザーを追加
-        in_process.push(interaction.member.user.id);
+        await interaction.update({ components: [thinkingActionRow('close')] });
 
         const guild = await interaction.guild.fetch();
         const member = await searchMemberById(guild, interaction.member.user.id);
@@ -325,9 +296,12 @@ async function close(interaction, params) {
         const helpEmbed = await getHelpEmbed(guild, header_message.channel.id);
         const host = header_message.interaction.user;
         const host_id = host.id;
-        const channelId = params.get('vid');
         const embed = new EmbedBuilder().setDescription(`<@${host_id}>たんの募集〆`);
-        const header_msg = await searchMessageById(guild, interaction.channel.id, interaction.message.id);
+        const cmd_message = interaction.message;
+        let channelId = params.get('vid');
+        if (isEmpty(channelId)) {
+            channelId = null;
+        }
 
         await sendLogWebhook(`${host.tag}[${host.id}]の募集で${member.displayName}たんが〆ボタンを押したでし`);
 
@@ -338,16 +312,16 @@ async function close(interaction, params) {
             // recruitテーブルから削除
             await delete_recruit(interaction.message.id);
 
-            if (channelId != undefined) {
+            if (channelId != null) {
                 let channel = await searchChannelById(guild, channelId);
                 channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
                 channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
             }
-            await header_msg.edit({
+            await cmd_message.edit({
                 content: `<@${host_id}>たんの募集は〆！\n${member_list}`,
                 components: [disableButtons()],
             });
-            await interaction.editReply({ embeds: [embed] });
+            await interaction.followUp({ embeds: [embed], ephemeral: false });
             await interaction.channel.send({ embeds: [helpEmbed] });
         } else if (datetimeDiff(new Date(), header_message.createdAt) > 120) {
             const recruit_data = await getRecruitAllByMessageId(interaction.message.id);
@@ -355,27 +329,25 @@ async function close(interaction, params) {
             // recruitテーブルから削除
             deleteRecruitByMemberId(interaction.message.id, interaction.member.id);
 
-            if (channelId != undefined) {
+            if (channelId != null) {
                 let channel = await searchChannelById(guild, channelId);
                 channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
                 channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
             }
-            await header_msg.edit({
+            await cmd_message.edit({
                 content: `<@${host_id}>たんの募集は〆！\n${member_list}`,
                 components: [disableButtons()],
             });
             const embed = new EmbedBuilder().setDescription(`<@${host_id}>たんの募集〆 \n <@${interaction.member.user.id}>たんが代理〆`);
-            await interaction.editReply({ embeds: [embed] });
+            await interaction.followUp({ embeds: [embed], ephemeral: false });
             await interaction.channel.send({ embeds: [helpEmbed] });
         } else {
-            await interaction.deleteReply();
             await interaction.followUp({
                 content: `募集主以外は募集を〆られないでし。`,
                 ephemeral: true,
             });
+            await interaction.editReply({ components: [recruitActionRow(header_message, channelId)] });
         }
-        // NOTE: ボタンの処理が終わったら処理中リストから削除する
-        inProcessClear(interaction.member.user.id);
     } catch (err) {
         handleError(err, { interaction });
     }
@@ -384,16 +356,7 @@ async function close(interaction, params) {
 async function joinNotify(interaction, params) {
     /** @type {Discord.Snowflake} */
     try {
-        // NOTE: ボタン処理中のリストにinteractionユーザーがいる場合は処理しない
-        if (in_process.includes(interaction.member.user.id)) {
-            console.log({ in_process });
-            return;
-        }
-        await interaction.deferReply({
-            ephemeral: true,
-        });
-        // NOTE: ボタン処理中のリストにinteractionユーザーを追加
-        in_process.push(interaction.member.user.id);
+        await interaction.update({ components: [thinkingActionRow('join')] });
 
         const guild = await interaction.guild.fetch();
         // interaction.member.user.idでなければならない。なぜならば、APIInteractionGuildMemberはid を直接持たないからである。
@@ -404,8 +367,9 @@ async function joinNotify(interaction, params) {
                 content: `募集主は参加表明できないでし！`,
                 ephemeral: true,
             });
-            // NOTE: ボタンの処理が終わったら処理中リストから削除する
-            inProcessClear(interaction.member.user.id);
+
+            await interaction.editReply({ components: [notifyActionRow(host_id)] });
+
             return;
         } else {
             // 参加済みかチェック
@@ -415,8 +379,9 @@ async function joinNotify(interaction, params) {
                     content: `すでに参加ボタンを押してるでし！`,
                     ephemeral: true,
                 });
-                // NOTE: ボタンの処理が終わったら処理中リストから削除する
-                inProcessClear(interaction.member.user.id);
+
+                await interaction.editReply({ components: [notifyActionRow(host_id)] });
+
                 return;
             }
 
@@ -450,9 +415,11 @@ async function joinNotify(interaction, params) {
                 ephemeral: true,
             });
 
-            await editMemberListMessage(interaction);
-            // NOTE: ボタンの処理が終わったら処理中リストから削除する
-            inProcessClear(interaction.member.user.id);
+            await interaction.editReply({
+                content: await MemberListMessage(interaction),
+                components: [notifyActionRow(host_id)],
+            });
+
             // 5分後にホストへの通知を削除
             if (notify_to_host_message != null) {
                 await sleep(300000);
@@ -467,31 +434,22 @@ async function joinNotify(interaction, params) {
 async function cancelNotify(interaction, params) {
     /** @type {Discord.Snowflake} */
     try {
-        // NOTE: ボタン処理中のリストにinteractionユーザーがいる場合は処理しない
-        if (in_process.includes(interaction.member.user.id)) {
-            console.log({ in_process });
-            return;
-        }
-        await interaction.deferReply({
-            ephemeral: false,
-        });
-        // NOTE: ボタン処理中のリストにinteractionユーザーを追加
-        in_process.push(interaction.member.user.id);
+        await interaction.update({ components: [thinkingActionRow('cancel')] });
 
         const guild = await interaction.guild.fetch();
         const member = await searchMemberById(guild, interaction.member.user.id);
         const host_id = params.get('hid');
         const embed = new EmbedBuilder().setDescription(`<@${host_id}>たんの募集〆`);
-        const header_msg = await searchMessageById(guild, interaction.channel.id, interaction.message.id);
+        const cmd_message = interaction.message;
 
         if (member.user.id == host_id) {
             // recruitテーブルから削除
             await delete_recruit(interaction.message.id);
-            await header_msg.edit({
+            await cmd_message.edit({
                 content: `<@${host_id}>たんの募集はキャンセルされたでし！`,
                 components: [disableButtons()],
             });
-            await interaction.editReply({ embeds: [embed] });
+            await interaction.followUp({ embeds: [embed], ephemeral: false });
         } else {
             // NOTE: 参加表明済みかチェックして、参加表明済みならキャンセル可能
             const member_data = await getRecruitMessageByMemberId(interaction.message.id, member.user.id);
@@ -500,21 +458,21 @@ async function cancelNotify(interaction, params) {
                 await deleteRecruitByMemberId(interaction.message.id, interaction.member.id);
 
                 // ホストに通知
-                await editMemberListMessage(interaction);
-                await interaction.deleteReply();
                 await interaction.message.reply({
                     content: `<@${host_id}> <@${interaction.member.id}>たんがキャンセルしたでし！`,
                 });
+                await interaction.editReply({
+                    content: await MemberListMessage(interaction),
+                    components: [notifyActionRow(host_id)],
+                });
             } else {
-                await interaction.deleteReply();
                 await interaction.followUp({
                     content: `他人の募集は勝手にキャンセルできないでし！！`,
                     ephemeral: true,
                 });
+                await interaction.editReply({ components: [notifyActionRow(host_id)] });
             }
         }
-        // NOTE: ボタンの処理が終わったら処理中リストから削除する
-        inProcessClear(interaction.member.user.id);
     } catch (err) {
         handleError(err, { interaction });
     }
@@ -523,56 +481,48 @@ async function cancelNotify(interaction, params) {
 async function closeNotify(interaction, params) {
     /** @type {Discord.Snowflake} */
     try {
-        // NOTE: ボタン処理中のリストにinteractionユーザーがいる場合は処理しない
-        if (in_process.includes(interaction.member.user.id)) {
-            console.log({ in_process });
-            return;
-        }
-        await interaction.deferReply({
-            ephemeral: false,
-        });
-        // NOTE: ボタン処理中のリストにinteractionユーザーを追加
-        in_process.push(interaction.member.user.id);
+        await interaction.update({ components: [thinkingActionRow('close')] });
 
         const guild = await interaction.guild.fetch();
         const member = await searchMemberById(guild, interaction.member.user.id);
         const host_id = params.get('hid');
         const embed = new EmbedBuilder().setDescription(`<@${host_id}>たんの募集〆`);
         const helpEmbed = await getHelpEmbed(guild, interaction.channel.id);
-        const header_msg = await searchMessageById(guild, interaction.channel.id, interaction.message.id);
+        const cmd_message = interaction.message;
 
         if (member.user.id === host_id) {
             const recruit_data = await getRecruitAllByMessageId(interaction.message.id);
             const member_list = getMemberMentions(recruit_data);
-            await header_msg.edit({
+            await cmd_message.edit({
                 content: `<@${host_id}>たんの募集は〆！\n${member_list}`,
                 components: [disableButtons()],
             });
             // recruitテーブルから削除
             await delete_recruit(interaction.message.id);
-            await interaction.editReply({ embeds: [embed] });
+            await interaction.followUp({ embeds: [embed], ephemeral: false });
             await interaction.channel.send({ embeds: [helpEmbed] });
+
+            return;
         } else if (datetimeDiff(new Date(), interaction.message.createdAt) > 120) {
             const recruit_data = await getRecruitAllByMessageId(interaction.message.id);
             const member_list = getMemberMentions(recruit_data);
-            await header_msg.edit({
+            await cmd_message.edit({
                 content: `<@${host_id}>たんの募集は〆！\n${member_list}`,
                 components: [disableButtons()],
             });
             // recruitテーブルから削除
             deleteRecruitByMemberId(interaction.message.id);
             const embed = new EmbedBuilder().setDescription(`<@${host_id}>たんの募集〆 \n <@${interaction.member.user.id}>たんが代理〆`);
-            await interaction.editReply({ embeds: [embed] });
+            await interaction.followUp({ embeds: [embed], ephemeral: false });
             await interaction.channel.send({ embeds: [helpEmbed] });
         } else {
-            await interaction.deleteReply();
             await interaction.followUp({
                 content: `募集主以外は募集を〆られないでし。`,
                 ephemeral: true,
             });
         }
-        // NOTE: ボタンの処理が終わったら処理中リストから削除する
-        inProcessClear(interaction.member.user.id);
+
+        await interaction.editReply({ components: [notifyActionRow(host_id)] });
     } catch (err) {
         handleError(err, { interaction });
     }
@@ -665,13 +615,9 @@ function getMemberMentions(members) {
     return mentionString;
 }
 
-async function editMemberListMessage(interaction) {
-    const guild = await interaction.guild.fetch();
+async function MemberListMessage(interaction) {
     const recruit_data = await getRecruitAllByMessageId(interaction.message.id);
     const member_list = getMemberMentions(recruit_data);
-    const interaction_message = await searchMessageById(guild, interaction.channel, interaction.message.id);
-    const message_first_row = interaction_message.content.split('\n')[0];
-    interaction_message.edit({
-        content: message_first_row + '\n' + member_list,
-    });
+    const message_first_row = interaction.message.content.split('\n')[0];
+    return message_first_row + '\n' + member_list;
 }

--- a/app/event/recruit_button.js
+++ b/app/event/recruit_button.js
@@ -92,10 +92,6 @@ async function join(interaction, params) {
             // 参加済みかチェック
             const member_data = await getRecruitMessageByMemberId(interaction.message.id, member.user.id);
             if (member_data.length > 0) {
-                // // NOTE: 削除ボタンの切り替わり前に参加ボタン押されると
-                // // 編集処理が中断されるので、もう一度押したときに参加表明一覧を更新する
-                // await editMemberListMessage(interaction);
-
                 await interaction.followUp({
                     content: `すでに参加ボタンを押してるでし！`,
                     ephemeral: true,
@@ -150,7 +146,7 @@ async function join(interaction, params) {
             }
 
             await interaction.editReply({
-                content: await MemberListMessage(interaction),
+                content: await memberListMessage(interaction),
                 components: [recruitActionRow(header_message, channelId)],
             });
 
@@ -218,7 +214,7 @@ async function cancel(interaction, params) {
                     content: `<@${host_id}> <@${interaction.member.id}>たんがキャンセルしたでし！`,
                 });
                 await interaction.editReply({
-                    content: await MemberListMessage(interaction),
+                    content: await memberListMessage(interaction),
                     components: [recruitActionRow(header_message, channelId)],
                 });
             } else {
@@ -416,7 +412,7 @@ async function joinNotify(interaction, params) {
             });
 
             await interaction.editReply({
-                content: await MemberListMessage(interaction),
+                content: await memberListMessage(interaction),
                 components: [notifyActionRow(host_id)],
             });
 
@@ -462,7 +458,7 @@ async function cancelNotify(interaction, params) {
                     content: `<@${host_id}> <@${interaction.member.id}>たんがキャンセルしたでし！`,
                 });
                 await interaction.editReply({
-                    content: await MemberListMessage(interaction),
+                    content: await memberListMessage(interaction),
                     components: [notifyActionRow(host_id)],
                 });
             } else {
@@ -615,7 +611,7 @@ function getMemberMentions(members) {
     return mentionString;
 }
 
-async function MemberListMessage(interaction) {
+async function memberListMessage(interaction) {
     const recruit_data = await getRecruitAllByMessageId(interaction.message.id);
     const member_list = getMemberMentions(recruit_data);
     const message_first_row = interaction.message.content.split('\n')[0];


### PR DESCRIPTION
-  プラベ募集は以前のボタンと互換性なし
- ロードボタン用のアニメーション絵文字を指定する環境変数追加
- 一部オブジェクトをinteractionから直接拾うように変更(interaction.messageとかはそのまま取れそうなので)
- 一部処理をまとめてAPI叩く回数を少し減らした