### PR TITLE
募集中のメッセージをピン留め

### DIFF
--- a/app/cmd/other/recruit/other_game_recruit.js
+++ b/app/cmd/other/recruit/other_game_recruit.js
@@ -192,6 +192,8 @@ async function sendOtherGames(interaction, title, recruitNumText, mention, txt, 
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
+        // ピン留め
+        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();

--- a/app/cmd/other/recruit/other_game_recruit.js
+++ b/app/cmd/other/recruit/other_game_recruit.js
@@ -197,6 +197,8 @@ async function sendOtherGames(interaction, title, recruitNumText, mention, txt, 
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();
+            // ピン留め
+            header.pin();
         }
     } catch (error) {
         console.log(error);

--- a/app/cmd/other/recruit/other_game_recruit.js
+++ b/app/cmd/other/recruit/other_game_recruit.js
@@ -192,8 +192,6 @@ async function sendOtherGames(interaction, title, recruitNumText, mention, txt, 
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
-        // ピン留め
-        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();

--- a/app/cmd/splat2/recruit/league_recruit.js
+++ b/app/cmd/splat2/recruit/league_recruit.js
@@ -253,6 +253,8 @@ async function sendLeagueMatch(
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
+        // ピン留め
+        header.pin();
         let cmd_message = await channel.messages.fetch({ message: sentMessage.id });
         if (cmd_message != undefined) {
             if (isLock == false) {

--- a/app/cmd/splat2/recruit/league_recruit.js
+++ b/app/cmd/splat2/recruit/league_recruit.js
@@ -271,6 +271,9 @@ async function sendLeagueMatch(
             content: `${host_mention}たんの募集は〆！`,
             components: [disableButtons()],
         });
+        // ピン留め解除
+        header.unpin();
+
         if (reserve_channel != null) {
             reserve_channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
             reserve_channel.permissionOverwrites.delete(host_member.user, 'UnLock Voice Channel');

--- a/app/cmd/splat2/recruit/private_recruit.js
+++ b/app/cmd/splat2/recruit/private_recruit.js
@@ -88,6 +88,8 @@ async function sendPrivateRecruit(interaction, options) {
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
+        // ピン留め
+        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();

--- a/app/cmd/splat2/recruit/regular_recruit.js
+++ b/app/cmd/splat2/recruit/regular_recruit.js
@@ -231,6 +231,8 @@ async function sendRegularMatch(
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
+        // ピン留め
+        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();

--- a/app/cmd/splat2/recruit/regular_recruit.js
+++ b/app/cmd/splat2/recruit/regular_recruit.js
@@ -245,6 +245,8 @@ async function sendRegularMatch(
             content: `${host_mention}たんの募集は〆！`,
             components: [disableButtons()],
         });
+        // ピン留め解除
+        header.unpin();
         if (reserve_channel != null) {
             reserve_channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
             reserve_channel.permissionOverwrites.delete(host_member.user, 'UnLock Voice Channel');

--- a/app/cmd/splat2/recruit/salmon_recruit.js
+++ b/app/cmd/splat2/recruit/salmon_recruit.js
@@ -188,6 +188,8 @@ async function sendSalmonRun(interaction, channel, txt, recruit_num, condition, 
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
+        // ピン留め
+        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();

--- a/app/cmd/splat3/recruit/anarchy_recruit.js
+++ b/app/cmd/splat3/recruit/anarchy_recruit.js
@@ -285,10 +285,8 @@ async function sendAnarchyMatch(
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();
-        }
-
-        // ピン留め
-        header.pin();
+            // ピン留め
+            header.pin();
 
         // 2時間後にボタンを無効化する
         await sleep(7200000 - 15000);

--- a/app/cmd/splat3/recruit/anarchy_recruit.js
+++ b/app/cmd/splat3/recruit/anarchy_recruit.js
@@ -287,6 +287,9 @@ async function sendAnarchyMatch(
             deleteButtonCheck.delete();
         }
 
+        // ピン留め
+        header.pin();
+
         // 2時間後にボタンを無効化する
         await sleep(7200000 - 15000);
         const host_mention = `<@${host_member.user.id}>`;

--- a/app/cmd/splat3/recruit/anarchy_recruit.js
+++ b/app/cmd/splat3/recruit/anarchy_recruit.js
@@ -287,7 +287,7 @@ async function sendAnarchyMatch(
             deleteButtonCheck.delete();
             // ピン留め
             header.pin();
-
+        }
         // 2時間後にボタンを無効化する
         await sleep(7200000 - 15000);
         const host_mention = `<@${host_member.user.id}>`;
@@ -295,6 +295,8 @@ async function sendAnarchyMatch(
             content: `${host_mention}たんの募集は〆！`,
             components: [disableButtons()],
         });
+        // ピン留め解除
+        header.unpin();
         if (isLock) {
             reserve_channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
             reserve_channel.permissionOverwrites.delete(host_member.user, 'UnLock Voice Channel');

--- a/app/cmd/splat3/recruit/fes_recruit.js
+++ b/app/cmd/splat3/recruit/fes_recruit.js
@@ -254,6 +254,8 @@ async function sendFesMatch(interaction, channel, team, txt, recruit_num, condit
             content: `${host_mention}たんの募集は〆！`,
             components: [disableButtons()],
         });
+        // ピン留め解除
+        header.unpin();
         if (isLock) {
             reserve_channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
             reserve_channel.permissionOverwrites.delete(host_member.user, 'UnLock Voice Channel');

--- a/app/cmd/splat3/recruit/fes_recruit.js
+++ b/app/cmd/splat3/recruit/fes_recruit.js
@@ -241,8 +241,6 @@ async function sendFesMatch(interaction, channel, team, txt, recruit_num, condit
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
-        // ピン留め
-        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();

--- a/app/cmd/splat3/recruit/fes_recruit.js
+++ b/app/cmd/splat3/recruit/fes_recruit.js
@@ -246,8 +246,8 @@ async function sendFesMatch(interaction, channel, team, txt, recruit_num, condit
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();
-        }
-
+            // ピン留め
+            header.pin();
         // 2時間後にボタンを無効化する
         await sleep(7200000 - 15000);
         const host_mention = `<@${host_member.user.id}>`;

--- a/app/cmd/splat3/recruit/fes_recruit.js
+++ b/app/cmd/splat3/recruit/fes_recruit.js
@@ -241,6 +241,8 @@ async function sendFesMatch(interaction, channel, team, txt, recruit_num, condit
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
+        // ピン留め
+        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();

--- a/app/cmd/splat3/recruit/fes_recruit.js
+++ b/app/cmd/splat3/recruit/fes_recruit.js
@@ -246,6 +246,7 @@ async function sendFesMatch(interaction, channel, team, txt, recruit_num, condit
             deleteButtonCheck.delete();
             // ピン留め
             header.pin();
+        }
         // 2時間後にボタンを無効化する
         await sleep(7200000 - 15000);
         const host_mention = `<@${host_member.user.id}>`;

--- a/app/cmd/splat3/recruit/private_recruit.js
+++ b/app/cmd/splat3/recruit/private_recruit.js
@@ -3,6 +3,7 @@ const { searchMessageById } = require('../../../manager/messageManager');
 const { searchMemberById } = require('../../../manager/memberManager');
 const { isNotEmpty } = require('../../../common');
 const { recruitDeleteButton, recruitActionRow, notifyActionRow } = require('../../../common/button_components');
+const e = require('express');
 
 module.exports = {
     privateRecruit: privateRecruit,
@@ -89,11 +90,11 @@ async function sendPrivateRecruit(interaction, options) {
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
-        // ピン留め
-        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();
+            // ピン留め
+            header.pin();
         }
     } catch (error) {
         console.log(error);

--- a/app/cmd/splat3/recruit/private_recruit.js
+++ b/app/cmd/splat3/recruit/private_recruit.js
@@ -89,6 +89,8 @@ async function sendPrivateRecruit(interaction, options) {
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
+        // ピン留め
+        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();
@@ -103,6 +105,8 @@ async function sendNotification(interaction) {
     const sentMessage = await interaction.editReply({
         content: mention + ` ボタンを押して参加表明するでし！`,
     });
+    // ピン留め
+    sentMessage.pin();
     await interaction.followUp({
         content: '募集完了でし！参加者が来るまで気長に待つでし！',
         ephemeral: true,

--- a/app/cmd/splat3/recruit/regular_recruit.js
+++ b/app/cmd/splat3/recruit/regular_recruit.js
@@ -240,6 +240,8 @@ async function sendRegularMatch(
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
+        // ピン留め
+        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();

--- a/app/cmd/splat3/recruit/regular_recruit.js
+++ b/app/cmd/splat3/recruit/regular_recruit.js
@@ -245,6 +245,8 @@ async function sendRegularMatch(
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();
+            // ピン留め
+            header.pin();
         }
 
         // 2時間後にボタンを無効化する

--- a/app/cmd/splat3/recruit/regular_recruit.js
+++ b/app/cmd/splat3/recruit/regular_recruit.js
@@ -240,8 +240,6 @@ async function sendRegularMatch(
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
-        // ピン留め
-        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();

--- a/app/cmd/splat3/recruit/regular_recruit.js
+++ b/app/cmd/splat3/recruit/regular_recruit.js
@@ -254,6 +254,8 @@ async function sendRegularMatch(
             content: `${host_mention}たんの募集は〆！`,
             components: [disableButtons()],
         });
+        // ピン留め解除
+        header.unpin();
         if (isLock) {
             reserve_channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
             reserve_channel.permissionOverwrites.delete(host_member.user, 'UnLock Voice Channel');

--- a/app/cmd/splat3/recruit/salmon_recruit.js
+++ b/app/cmd/splat3/recruit/salmon_recruit.js
@@ -199,8 +199,6 @@ async function sendSalmonRun(interaction, channel, txt, recruit_num, condition, 
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
-        // ピン留め
-        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();

--- a/app/cmd/splat3/recruit/salmon_recruit.js
+++ b/app/cmd/splat3/recruit/salmon_recruit.js
@@ -204,6 +204,8 @@ async function sendSalmonRun(interaction, channel, txt, recruit_num, condition, 
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();
+            // ピン留め
+            header.pin();
         }
 
         // 2時間後にVCロックを解除する

--- a/app/cmd/splat3/recruit/salmon_recruit.js
+++ b/app/cmd/splat3/recruit/salmon_recruit.js
@@ -199,6 +199,8 @@ async function sendSalmonRun(interaction, channel, txt, recruit_num, condition, 
 
         // 15秒後に削除ボタンを消す
         await sleep(15000);
+        // ピン留め
+        header.pin();
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();

--- a/app/event/recruit_button.js
+++ b/app/event/recruit_button.js
@@ -188,6 +188,9 @@ async function cancel(interaction, params) {
         await sendLogWebhook(`${host.tag}[${host.id}]の募集で${member.displayName}たんがキャンセルボタンを押したでし`);
 
         if (member.user.id == host_id) {
+            // ピン留め解除
+            header_message.unpin();
+
             // recruitテーブルから削除
             await delete_recruit(interaction.message.id);
 
@@ -304,6 +307,8 @@ async function close(interaction, params) {
         if (member.user.id === host_id) {
             const recruit_data = await getRecruitAllByMessageId(interaction.message.id);
             const member_list = getMemberMentions(recruit_data);
+            // ピン留め解除
+            header_message.unpin();
 
             // recruitテーブルから削除
             await delete_recruit(interaction.message.id);
@@ -439,6 +444,8 @@ async function cancelNotify(interaction, params) {
         const cmd_message = interaction.message;
 
         if (member.user.id == host_id) {
+            // ピン留め解除
+            cmd_message.unpin();
             // recruitテーブルから削除
             await delete_recruit(interaction.message.id);
             await cmd_message.edit({
@@ -493,6 +500,8 @@ async function closeNotify(interaction, params) {
                 content: `<@${host_id}>たんの募集は〆！\n${member_list}`,
                 components: [disableButtons()],
             });
+            // ピン留め解除
+            header_message.unpin();
             // recruitテーブルから削除
             await delete_recruit(interaction.message.id);
             await interaction.followUp({ embeds: [embed], ephemeral: false });


### PR DESCRIPTION
募集が被ったときにまだ〆てない募集をわかりやすくするためにピン留めする
スレッドだとスレッド内でのやりとりに気づきにくいため、募集チャンネル内でのやりとりはそのままにし、継続中の募集があるかどうかをピン留めで確認できるようにする。

- 募集時(15秒経過後)にピン留め
- キャンセル、〆ボタン押したときにピン留め解除

![image](https://user-images.githubusercontent.com/33051481/195612173-96bb0ae2-d576-4d81-a99a-651b7a701936.png)
