### PR TITLE
update: サーバー起動時に使ってない方のコマンドを削除

### DIFF
--- a/register.js
+++ b/register.js
@@ -731,12 +731,24 @@ module.exports = async function registerSlashCommands() {
     const mode = process.env.SLASH_COMMAND_REGISTER_MODE;
     if (mode === 'guild') {
         await rest
+            .put(Routes.applicationCommands(process.env.DISCORD_BOT_ID), { body: [] })
+            .then(() => logger.info('Successfully deleted application global commands.'))
+            .catch((error) => {
+                logger.error(error);
+            });
+        await rest
             .put(Routes.applicationGuildCommands(process.env.DISCORD_BOT_ID, process.env.SERVER_ID), { body: commands })
             .then(() => logger.info('Successfully registered application guild commands.'))
             .catch((error) => {
                 logger.error(error);
             });
     } else if (mode === 'global') {
+        await rest
+            .put(Routes.applicationGuildCommands(process.env.DISCORD_BOT_ID, process.env.SERVER_ID), { body: [] })
+            .then(() => logger.info('Successfully deleted application guild commands.'))
+            .catch((error) => {
+                logger.error(error);
+            });
         await rest
             .put(Routes.applicationCommands(process.env.DISCORD_BOT_ID), { body: commands })
             .then(() => logger.info('Successfully registered application global commands.'))


### PR DESCRIPTION
- stgに2重にコマンド登録されてたので削除用
- guild, globalのスラコマ登録前に使ってない方のコマンドを空で上書き