### PR TITLE
fix: 募集削除ボタンのエラー修正

### DIFF
--- a/app/event/recruit_button.js
+++ b/app/event/recruit_button.js
@@ -262,7 +262,11 @@ async function del(interaction, params) {
                 channel.permissionOverwrites.delete(guild.roles.everyone, 'UnLock Voice Channel');
                 channel.permissionOverwrites.delete(interaction.member, 'UnLock Voice Channel');
             }
-            await interaction.message.delete();
+            try {
+                await interaction.message.delete();
+            } catch (error) {
+                logger.warn('button already deleted');
+            }
             await cmd_message.delete();
             await header_message.delete();
 


### PR DESCRIPTION
募集削除ボタンの処理中に募集が経ってら15秒経過した場合に募集ボタン自体が削除できないエラー出てたので、
try-catchで無視するように変更