### PR TITLE
fix: 自動〆の処理変更と募集メッセージの変更

### DIFF
--- a/app/cmd/other/recruit/other_game_recruit.js
+++ b/app/cmd/other/recruit/other_game_recruit.js
@@ -61,7 +61,7 @@ function monsterHunterRise(interaction, roles) {
     let title = 'MONSTER HUNTER RISE';
     let recruitNumText = interaction.options.getString('募集人数');
     let mention = role_id.toString();
-    let txt = `<@${interaction.member.id}>` + 'たんがモンハンライズ参加者募集中でし！\n';
+    let txt = `<@${interaction.member.id}>` + '**たんのモンハンライズ募集**\n';
     let color = '#b71008';
     const image = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/MonsterHunterRiseSunBreak.jpg';
     const logo = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/MonsterHunterRiseSunBreak_logo.png';
@@ -73,7 +73,7 @@ function apexLegends(interaction, roles) {
     let title = 'Apex Legends';
     let recruitNumText = interaction.options.getString('募集人数');
     let mention = role_id.toString();
-    let txt = `<@${interaction.member.id}>` + 'たんがApexLegendsの参加者募集中でし！\n';
+    let txt = `<@${interaction.member.id}>` + '**たんのApexLegends募集**\n';
     let color = '#F30100';
     const image = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/ApexLegends.jpg';
     const logo = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/ApexLegends_logo.png';
@@ -85,7 +85,7 @@ function overwatch(interaction, roles) {
     let title = 'Overwatch2';
     let recruitNumText = interaction.options.getString('募集人数');
     let mention = role_id.toString();
-    const txt = `<@${interaction.member.id}>` + 'たんがOverwatch2の参加者募集中でし！\n';
+    const txt = `<@${interaction.member.id}>` + '**たんのOverwatch2募集**\n';
     let color = '#ED6516';
     const image = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/Overwatch2.png';
     const logo = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/Overwatch_logo.png';
@@ -97,7 +97,7 @@ function valorant(interaction, roles) {
     let title = 'VALORANT';
     let recruitNumText = interaction.options.getString('募集人数');
     let mention = role_id.toString();
-    const txt = `<@${interaction.member.id}>` + 'たんがVALORANT参加者募集中でし！\n';
+    const txt = `<@${interaction.member.id}>` + '**たんのVALORANT募集**\n';
     let color = '#FF4654';
     const image = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/valorant.jpg';
     const logo = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/valorant_logo.png';
@@ -109,7 +109,7 @@ function others(interaction, roles) {
     let title = interaction.options.getString('ゲームタイトル');
     let recruitNumText = interaction.options.getString('募集人数');
     let mention = role_id.toString();
-    const txt = `<@${interaction.member.id}>` + `たんが${title}参加者募集中でし！\n`;
+    const txt = `<@${interaction.member.id}>` + `**たんの${title}募集**\n`;
     let color = '#379C30';
     const image = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/others.jpg';
     const logo = 'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/games/others_logo.png';
@@ -194,13 +194,14 @@ async function sendOtherGames(interaction, title, recruitNumText, mention, txt, 
             });
         }
 
+        // ピン留め
+        header.pin();
+
         // 15秒後に削除ボタンを消す
         await sleep(15000);
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();
-            // ピン留め
-            header.pin();
         } else {
             return;
         }

--- a/app/cmd/splat2/recruit/league_recruit.js
+++ b/app/cmd/splat2/recruit/league_recruit.js
@@ -1,9 +1,11 @@
 const Canvas = require('canvas');
 const path = require('path');
 const fetch = require('node-fetch');
+const RecruitService = require('../../../../db/recruit_service');
+const { getMemberMentions } = require('../../../event/recruit_button');
 const { stage2txt, rule2txt, unixTime2hm, unixTime2ymdw } = require('../../../common');
 const { createRoundRect, drawArcImage, fillTextWithStroke } = require('../../../common/canvas_components');
-const { recruitActionRow, disableButtons, recruitDeleteButton, unlockChannelButton } = require('../../../common/button_components.js');
+const { recruitActionRow, setButtonDisable, recruitDeleteButton, unlockChannelButton } = require('../../../common/button_components.js');
 const { AttachmentBuilder, PermissionsBitField } = require('discord.js');
 const { searchRoleIdByName } = require('../../../manager/roleManager');
 const log4js = require('log4js');
@@ -270,10 +272,12 @@ async function sendLeagueMatch(
 
         // 2時間後にボタンを無効化する
         await sleep(7200000 - 15000);
+        const recruit_data = await RecruitService.getRecruitAllByMessageId(sentMessage.id);
+        const member_list = getMemberMentions(recruit_data);
         const host_mention = `<@${host_member.user.id}>`;
         sentMessage.edit({
-            content: `${host_mention}たんの募集は〆！`,
-            components: [disableButtons()],
+            content: `${host_mention}たんの募集は〆！\n${member_list}`,
+            components: await setButtonDisable(sentMessage),
         });
         // ピン留め解除
         header.unpin();

--- a/app/cmd/splat2/recruit/regular_recruit.js
+++ b/app/cmd/splat2/recruit/regular_recruit.js
@@ -1,10 +1,12 @@
 const Canvas = require('canvas');
 const path = require('path');
 const fetch = require('node-fetch');
+const RecruitService = require('../../../../db/recruit_service');
+const { getMemberMentions } = require('../../../event/recruit_button');
 const { stage2txt, rule2txt, unixTime2hm, unixTime2ymdw } = require('../../../common');
 const { createRoundRect, drawArcImage, fillTextWithStroke } = require('../../../common/canvas_components');
 const { searchRoleIdByName } = require('../../../manager/roleManager.js');
-const { recruitActionRow, disableButtons, recruitDeleteButton, unlockChannelButton } = require('../../../common/button_components.js');
+const { recruitActionRow, setButtonDisable, recruitDeleteButton, unlockChannelButton } = require('../../../common/button_components.js');
 const { AttachmentBuilder, PermissionsBitField } = require('discord.js');
 const log4js = require('log4js');
 
@@ -247,10 +249,12 @@ async function sendRegularMatch(
 
         // 2時間後にボタンを無効化する
         await sleep(7200000 - 15000);
+        const recruit_data = await RecruitService.getRecruitAllByMessageId(sentMessage.id);
+        const member_list = getMemberMentions(recruit_data);
         const host_mention = `<@${host_member.user.id}>`;
         sentMessage.edit({
-            content: `${host_mention}たんの募集は〆！`,
-            components: [disableButtons()],
+            content: `${host_mention}たんの募集は〆！\n${member_list}`,
+            components: await setButtonDisable(sentMessage),
         });
         // ピン留め解除
         header.unpin();

--- a/app/cmd/splat3/recruit/private_recruit.js
+++ b/app/cmd/splat3/recruit/private_recruit.js
@@ -72,7 +72,7 @@ async function sendPrivateRecruit(interaction, options) {
 
     try {
         const header = await interaction.editReply({
-            content: `<@${interaction.member.id}>たんがプライベートマッチ募集中でし！`,
+            content: `<@${interaction.member.id}>**たんのプライベートマッチ募集**`,
             embeds: [embed],
             ephemeral: false,
         });
@@ -92,13 +92,14 @@ async function sendPrivateRecruit(interaction, options) {
             ephemeral: true,
         });
 
+        // ピン留め
+        header.pin();
+
         // 15秒後に削除ボタンを消す
         await sleep(15000);
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();
-            // ピン留め
-            header.pin();
         } else {
             return;
         }

--- a/app/cmd/splat3/recruit/regular_recruit.js
+++ b/app/cmd/splat3/recruit/regular_recruit.js
@@ -1,12 +1,14 @@
 const Canvas = require('canvas');
 const path = require('path');
 const fetch = require('node-fetch');
+const RecruitService = require('../../../../db/recruit_service');
+const { getMemberMentions } = require('../../../event/recruit_button');
 const { searchMessageById } = require('../../../manager/messageManager');
 const { searchMemberById } = require('../../../manager/memberManager');
 const { isNotEmpty, checkFes, getRegular } = require('../../../common');
 const { searchChannelIdByName } = require('../../../manager/channelManager');
 const { createRoundRect, drawArcImage, fillTextWithStroke } = require('../../../common/canvas_components');
-const { recruitActionRow, disableButtons, recruitDeleteButton, unlockChannelButton } = require('../../../common/button_components');
+const { recruitActionRow, setButtonDisable, recruitDeleteButton, unlockChannelButton } = require('../../../common/button_components');
 const { AttachmentBuilder, ChannelType, PermissionsBitField } = require('discord.js');
 const log4js = require('log4js');
 
@@ -104,7 +106,7 @@ async function regularRecruit(interaction) {
             return;
         }
         const regularResult = getRegular(data, type);
-        let txt = `<@${host_member.user.id}>` + 'たんがナワバリ募集中でし！\n';
+        let txt = `<@${host_member.user.id}>` + '**たんのナワバリ募集**\n';
         let members = [];
 
         if (user1 != null) {
@@ -243,23 +245,32 @@ async function sendRegularMatch(
             });
         }
 
+        // ピン留め
+        header.pin();
+
         // 15秒後に削除ボタンを消す
         await sleep(15000);
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();
-            // ピン留め
-            header.pin();
         } else {
             return;
         }
 
         // 2時間後にボタンを無効化する
         await sleep(7200000 - 15000);
+        const checkMessage = await searchMessageById(guild, interaction.channel.id, sentMessage.id);
+        const message_first_row = checkMessage.content.split('\n')[0];
+        if (message_first_row.indexOf('〆') !== -1 || message_first_row.indexOf('キャンセル') !== -1) {
+            return;
+        }
+        const recruit_data = await RecruitService.getRecruitAllByMessageId(checkMessage.id);
+        const member_list = getMemberMentions(recruit_data);
         const host_mention = `<@${host_member.user.id}>`;
-        sentMessage.edit({
-            content: `${host_mention}たんの募集は〆！`,
-            components: [disableButtons()],
+
+        checkMessage.edit({
+            content: '`[自動〆]`\n' + `${host_mention}たんの募集は〆！\n${member_list}`,
+            components: await setButtonDisable(checkMessage),
         });
         // ピン留め解除
         header.unpin();

--- a/app/cmd/splat3/recruit/salmon_recruit.js
+++ b/app/cmd/splat3/recruit/salmon_recruit.js
@@ -91,7 +91,7 @@ async function salmonRecruit(interaction) {
     try {
         const response = await fetch(coop_schedule_url);
         const data = await response.json();
-        let txt = `<@${host_member.user.id}>` + 'たんがバイト中でし！\n';
+        let txt = `<@${host_member.user.id}>` + '**たんのバイト募集**\n';
 
         if (user1 != null && user2 != null) {
             txt = txt + `<@${user1.id}>` + 'たんと' + `<@${user2.id}>` + 'たんの参加が既に決定しているでし！';
@@ -202,13 +202,14 @@ async function sendSalmonRun(interaction, channel, txt, recruit_num, condition, 
             });
         }
 
+        // ピン留め
+        header.pin();
+
         // 15秒後に削除ボタンを消す
         await sleep(15000);
         const deleteButtonCheck = await searchMessageById(guild, interaction.channel.id, deleteButtonMsg.id);
         if (isNotEmpty(deleteButtonCheck)) {
             deleteButtonCheck.delete();
-            // ピン留め
-            header.pin();
         } else {
             return;
         }

--- a/app/common/button_components.js
+++ b/app/common/button_components.js
@@ -5,7 +5,6 @@ const { isNotEmpty } = require('../common');
 module.exports = {
     recruitDeleteButton: recruitDeleteButton,
     recruitActionRow: recruitActionRow,
-    disableButtons: disableButtons,
     unlockChannelButton: unlockChannelButton,
     notifyActionRow: notifyActionRow,
     setButtonEnable: setButtonEnable,
@@ -75,15 +74,6 @@ function notifyActionRow(host_id) {
         new ButtonBuilder().setCustomId(cancelParams.toString()).setLabel('キャンセル').setStyle(ButtonStyle.Danger),
         new ButtonBuilder().setCustomId(closeParams.toString()).setLabel('〆').setStyle(ButtonStyle.Secondary),
     ]);
-}
-
-function disableButtons() {
-    let buttons = new ActionRowBuilder().addComponents([
-        new ButtonBuilder().setCustomId('join').setLabel('参加').setStyle(ButtonStyle.Primary).setDisabled(),
-        new ButtonBuilder().setCustomId('cancel').setLabel('キャンセル').setStyle(ButtonStyle.Danger).setDisabled(),
-        new ButtonBuilder().setCustomId('close').setLabel('〆').setStyle(ButtonStyle.Secondary).setDisabled(),
-    ]);
-    return buttons;
 }
 
 function unlockChannelButton(channel_id) {

--- a/app/event/recruit_button.js
+++ b/app/event/recruit_button.js
@@ -23,6 +23,7 @@ module.exports = {
     closeNotify: closeNotify,
     unlock: unlock,
     sendLogWebhook: sendLogWebhook,
+    getMemberMentions: getMemberMentions,
 };
 
 async function sendLogWebhook(log_content) {


### PR DESCRIPTION
- 募集がしまっててもキャンセルされても募集から2時間後に自動〆のメッセージで上書きされるのを修正
- 募集のヘッダー部分のメッセージを募集がしまっても不自然に見えないように変更
- 募集時すぐピンどめするように変更(募集がすぐに閉じられるorキャンセルされたときに残ってしまうため)
- 自動〆時にメンバーリストが出なかったのを修正
- 自動〆時はメンバーリストに自動〆であることがわかるように明記