### PR TITLE
showコマンド、ステージ情報にXマッチを追加 、サーモンランのシフト情報を２つ先まで表示

### DIFF
--- a/app/cmd/splat3/show.js
+++ b/app/cmd/splat3/show.js
@@ -165,7 +165,10 @@ module.exports = async function handleShow(interaction) {
                     let weapon2 = coopSetting.weapons[1].image.url;
                     let weapon3 = coopSetting.weapons[2].image.url;
                     let weapon4 = coopSetting.weapons[3].image.url;
-                    let weaponsImage = new AttachmentBuilder(await salmonWeaponCanvas(weapon1, weapon2, weapon3, weapon4), 'weapons.png');
+                    let weaponsImage = new AttachmentBuilder(await salmonWeaponCanvas(weapon1, weapon2, weapon3, weapon4), {
+                        name: 'weapons.png',
+                        description: '',
+                    });
                     let stageImage = coopSetting.coopStage.thumbnailImage.url;
 
                     const salmonEmbed = new EmbedBuilder()
@@ -174,18 +177,15 @@ module.exports = async function handleShow(interaction) {
                             iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/salmon_black_icon.png',
                         })
                         .setTitle(date)
-                        .setColor('#ff5500')
+                        .setColor('#FC892C')
                         .addFields({
                             name: 'ステージ',
                             value: coop_stage,
                         })
-                        .setImage(stageImage)
+                        .setImage('attachment://weapons.png')
                         .setThumbnail('https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/salmon_black_icon.png');
-
                     await interaction.channel.send({
                         embeds: [salmonEmbed],
-                    });
-                    await interaction.channel.send({
                         files: [weaponsImage],
                     });
                 }

--- a/app/cmd/splat3/show.js
+++ b/app/cmd/splat3/show.js
@@ -109,9 +109,9 @@ async function sendStageInfo(interaction, data, scheduleNum) {
             .setThumbnail(x_thumbnail);
 
         await interaction.editReply({
-            embeds: [challengeEmbed, openEmbed],
+            embeds: [xMatchEmbed, challengeEmbed, openEmbed],
         });
-        // TODO: リーグマッチとXマッチはゲーム内で実装後に表示
+        // TODO: リーグマッチはゲーム内で実装後に表示
         // await interaction.editReply({
         //     embeds: [leagueEmbed, openEmbed, challengeEmbed, xMatchEmbed],
         // });
@@ -155,37 +155,40 @@ module.exports = async function handleShow(interaction) {
             try {
                 const response = await fetch(coop_schedule_url);
                 const data = await response.json();
-                const salmon_data = data.data.coopGroupingSchedule.regularSchedules.nodes[0];
-                const coopSetting = salmon_data.setting;
-                let date = sp3unixTime2mdwhm(salmon_data.startTime) + ' – ' + sp3unixTime2mdwhm(salmon_data.endTime);
-                let coop_stage = sp3coop_stage2txt(coopSetting.coopStage.coopStageId);
-                let weapon1 = coopSetting.weapons[0].image.url;
-                let weapon2 = coopSetting.weapons[1].image.url;
-                let weapon3 = coopSetting.weapons[2].image.url;
-                let weapon4 = coopSetting.weapons[3].image.url;
-                let weaponsImage = new AttachmentBuilder(await salmonWeaponCanvas(weapon1, weapon2, weapon3, weapon4), 'weapons.png');
-                let stageImage = coopSetting.coopStage.thumbnailImage.url;
+                await interaction.editReply({ content: '3つ先まで表示するでし！' });
+                for (let i = 0; i < 3; i++) {
+                    const salmon_data = data.data.coopGroupingSchedule.regularSchedules.nodes[i];
+                    const coopSetting = salmon_data.setting;
+                    let date = sp3unixTime2mdwhm(salmon_data.startTime) + ' – ' + sp3unixTime2mdwhm(salmon_data.endTime);
+                    let coop_stage = sp3coop_stage2txt(coopSetting.coopStage.coopStageId);
+                    let weapon1 = coopSetting.weapons[0].image.url;
+                    let weapon2 = coopSetting.weapons[1].image.url;
+                    let weapon3 = coopSetting.weapons[2].image.url;
+                    let weapon4 = coopSetting.weapons[3].image.url;
+                    let weaponsImage = new AttachmentBuilder(await salmonWeaponCanvas(weapon1, weapon2, weapon3, weapon4), 'weapons.png');
+                    let stageImage = coopSetting.coopStage.thumbnailImage.url;
 
-                const salmonEmbed = new EmbedBuilder()
-                    .setAuthor({
-                        name: 'SALMON RUN',
-                        iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/salmon_black_icon.png',
-                    })
-                    .setTitle(date)
-                    .setColor('#ff5500')
-                    .addFields({
-                        name: 'ステージ',
-                        value: coop_stage,
-                    })
-                    .setImage(stageImage)
-                    .setThumbnail('https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/salmon_black_icon.png');
+                    const salmonEmbed = new EmbedBuilder()
+                        .setAuthor({
+                            name: 'SALMON RUN',
+                            iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/salmon_black_icon.png',
+                        })
+                        .setTitle(date)
+                        .setColor('#ff5500')
+                        .addFields({
+                            name: 'ステージ',
+                            value: coop_stage,
+                        })
+                        .setImage(stageImage)
+                        .setThumbnail('https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/salmon_black_icon.png');
 
-                await interaction.editReply({
-                    embeds: [salmonEmbed],
-                });
-                await interaction.channel.send({
-                    files: [weaponsImage],
-                });
+                    await interaction.channel.send({
+                        embeds: [salmonEmbed],
+                    });
+                    await interaction.channel.send({
+                        files: [weaponsImage],
+                    });
+                }
             } catch (error) {
                 await interaction.followUp('なんかエラーでてるわ');
                 logger.error(error);

--- a/app/cmd/splat3/show.js
+++ b/app/cmd/splat3/show.js
@@ -155,8 +155,8 @@ module.exports = async function handleShow(interaction) {
             try {
                 const response = await fetch(coop_schedule_url);
                 const data = await response.json();
-                await interaction.editReply({ content: '3つ先まで表示するでし！' });
-                for (let i = 0; i < 3; i++) {
+                await interaction.editReply({ content: '2つ先まで表示するでし！' });
+                for (let i = 0; i < 2; i++) {
                     const salmon_data = data.data.coopGroupingSchedule.regularSchedules.nodes[i];
                     const coopSetting = salmon_data.setting;
                     let date = sp3unixTime2mdwhm(salmon_data.startTime) + ' – ' + sp3unixTime2mdwhm(salmon_data.endTime);

--- a/app/cmd/splat3/show.js
+++ b/app/cmd/splat3/show.js
@@ -210,7 +210,7 @@ async function salmonWeaponCanvas(weapon1, weapon2, weapon3, weapon4) {
     const weapon_ctx = weaponCanvas.getContext('2d');
 
     createRoundRect(weapon_ctx, 1, 1, canvas_width - 2, canvas_height - 2, 0);
-    weapon_ctx.fillStyle = '#2F3136';
+    weapon_ctx.fillStyle = '#2F313600';
     weapon_ctx.fill();
 
     fillTextWithStroke(weapon_ctx, '武器', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 45);

--- a/app/cmd/splat3/stageinfo.js
+++ b/app/cmd/splat3/stageinfo.js
@@ -71,6 +71,14 @@ async function stageinfo(msg) {
         // embedStr_league.setColor('#ED2D7C');
         // msg.channel.send({ embeds: [embedStr_league] });
 
+        const embedStr_x = getXMatchEmbed(data.data.xSchedules.nodes);
+        embedStr_x.setAuthor({
+            name: 'Xマッチ',
+            iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/x_match_icon.png',
+        });
+        embedStr_x.setColor('#0edb9b');
+        msg.channel.send({ embeds: [embedStr_x] });
+
         const embedStr_challenge = getACEmbed(data.data.bankaraSchedules.nodes);
         embedStr_challenge.setAuthor({
             name: 'バンカラマッチ (チャレンジ)',
@@ -86,14 +94,6 @@ async function stageinfo(msg) {
         });
         embedStr_open.setColor('#F54910');
         msg.channel.send({ embeds: [embedStr_open] });
-
-        // const embedStr_x = getXMatchEmbed(data.data.xSchedules.nodes);
-        // embedStr_x.setAuthor({
-        //     name: 'Xマッチ',
-        //     iconURL: 'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/x_match_icon.png',
-        // });
-        // embedStr_x.setColor('#0edb9b');
-        // msg.channel.send({ embeds: [embedStr_x] });
     } catch (error) {
         msg.channel.send('なんかエラーでてるわ');
         logger.error(error);

--- a/register.js
+++ b/register.js
@@ -85,7 +85,7 @@ const show = new SlashCommandBuilder()
     .addSubcommand((subcommand) => subcommand.setName('now').setDescription('現在のX,バンカラマッチのステージ情報を表示'))
     .addSubcommand((subcommand) => subcommand.setName('next').setDescription('次のX,バンカラマッチのステージ情報を表示'))
     .addSubcommand((subcommand) => subcommand.setName('nawabari').setDescription('現在のナワバリのステージ情報を表示'))
-    .addSubcommand((subcommand) => subcommand.setName('run').setDescription('3つ先までのシフトを表示'));
+    .addSubcommand((subcommand) => subcommand.setName('run').setDescription('2つ先までのシフトを表示'));
 
 const help = new SlashCommandBuilder()
     .setName(commandNames.help)

--- a/register.js
+++ b/register.js
@@ -82,10 +82,10 @@ const buki = new SlashCommandBuilder()
 const show = new SlashCommandBuilder()
     .setName(commandNames.show)
     .setDescription('ステージ情報を表示')
-    .addSubcommand((subcommand) => subcommand.setName('now').setDescription('現在のバンカラマッチのステージ情報を表示'))
-    .addSubcommand((subcommand) => subcommand.setName('next').setDescription('次のバンカラマッチのステージ情報を表示'))
-    .addSubcommand((subcommand) => subcommand.setName('nawabari').setDescription('現在のナワバリステージ情報を表示'))
-    .addSubcommand((subcommand) => subcommand.setName('run').setDescription('現在のシフトを表示'));
+    .addSubcommand((subcommand) => subcommand.setName('now').setDescription('現在のX,バンカラマッチのステージ情報を表示'))
+    .addSubcommand((subcommand) => subcommand.setName('next').setDescription('次のX,バンカラマッチのステージ情報を表示'))
+    .addSubcommand((subcommand) => subcommand.setName('nawabari').setDescription('現在のナワバリのステージ情報を表示'))
+    .addSubcommand((subcommand) => subcommand.setName('run').setDescription('3つ先までのシフトを表示'));
 
 const help = new SlashCommandBuilder()
     .setName(commandNames.help)


### PR DESCRIPTION
Fixes #436
- ステージ情報チャンネル用コマンド `stageinfo` でXマッチを表示
- `show now` `show next` でXマッチを表示
- `show run` で2つ先のシフトまで表示