### PR TITLE
fix: dispanderのエラー修正

### DIFF
--- a/app/event/dispandar.js
+++ b/app/event/dispandar.js
@@ -1,4 +1,4 @@
-const common = require('../common');
+const { isNotEmpty, composeEmbed } = require('../common');
 const log4js = require('log4js');
 
 log4js.configure(process.env.LOG4JS_CONFIG_PATH);
@@ -16,12 +16,13 @@ async function dispand(message) {
         var messages = await extractMessages(message);
         var url;
 
-        if (common.isNotEmpty(messages)) {
+        if (isNotEmpty(messages)) {
             for (var m in messages) {
                 if (message.content) {
                     url = message.content.match(regexDiscordMessageUrl);
+                    embed = await composeEmbed(messages[m], url[0]);
                     await message.channel.send({
-                        embeds: [await common.composeEmbed(messages[m], url[0])],
+                        embeds: [embed],
                     });
                 }
                 for (var embed in messages[m].embeds) {
@@ -49,7 +50,7 @@ async function extractMessages(message) {
         return;
     }
     const fetchedMessage = await searchMessageById(guild, matches.groups.channel, matches.groups.message);
-    if (common.isNotEmpty(fetchedMessage)) {
+    if (isNotEmpty(fetchedMessage)) {
         messages.push(fetchedMessage);
     } else {
         message.reply('メッセージが見つからなかったでし！');

--- a/app/manager/memberManager.js
+++ b/app/manager/memberManager.js
@@ -1,13 +1,13 @@
+module.exports = {
+    searchMemberById: searchMemberById,
+    getMemberColor: getMemberColor,
+};
+
 const { isNotEmpty, isEmpty } = require('../common');
 const log4js = require('log4js');
 
 log4js.configure(process.env.LOG4JS_CONFIG_PATH);
 const logger = log4js.getLogger('MemberManager');
-
-module.exports = {
-    searchMemberById: searchMemberById,
-    getMemberColor: getMemberColor,
-};
 
 /**
  * ユーザーIDからメンバーを検索する．ない場合はnullを返す．
@@ -16,11 +16,15 @@ module.exports = {
  * @returns メンバーオブジェクト
  */
 async function searchMemberById(guild, userId) {
-    // APIからのメンバーオブジェクト(discord.jsのGuildMemberでないもの)がそのまま渡ってくることがあるのでfetchすることで確実にGuildMemberとする。
-    const members = await guild.members.fetch();
-    let member = members.find((member) => member.id === userId);
+    try {
+        // APIからのメンバーオブジェクト(discord.jsのGuildMemberでないもの)がそのまま渡ってくることがあるのでfetchすることで確実にGuildMemberとする。
+        const members = await guild.members.fetch();
+        let member = members.find((member) => member.id === userId);
 
-    return member;
+        return member;
+    } catch (error) {
+        logger.error(error);
+    }
 }
 
 /**


### PR DESCRIPTION
- エラー理由
common.js内でMemberManager.jsを呼び出した時に最初にcommonから別のモジュールをインポートしようとして循環インポートになったため。
- 修正内容
module.exportsを先頭にもってくることで読み込みタイミングを変えた

[参考リンク](https://qiita.com/gologo13/items/b026f7debdd80c08d499)