### PR TITLE
fix: コマンドで環境変数削除後に再起動しないとうまく動作しない問題を修正

### DIFF
--- a/app/cmd/admin-cmd/environment_variables/delete_variables.js
+++ b/app/cmd/admin-cmd/environment_variables/delete_variables.js
@@ -52,7 +52,7 @@ async function deleteEnvValue(key) {
             const targetLineIndex = envVars.indexOf(targetLine);
             // keyとvalueを置き換え
             envVars.splice(targetLineIndex, 1);
-            // ファイル書き込み (os標準の改行コードで保存)
+            // ファイル書き込み
             await fs.writeFile(ENV_FILE_PATH, envVars.join('\n'));
             return true;
         } else {

--- a/app/cmd/admin-cmd/environment_variables/delete_variables.js
+++ b/app/cmd/admin-cmd/environment_variables/delete_variables.js
@@ -44,14 +44,14 @@ async function deleteEnvValue(key) {
     try {
         const envFile = await fs.readFile(ENV_FILE_PATH, 'utf-8');
         // 複数の改行コードに対応
-        const envVars = envFile.split(/\r\n|\n/);
+        const envVars = envFile.split(/\r\n|\n|\r/);
         const targetLine = envVars.find((line) => line.split('=')[0] === key);
         if (targetLine !== undefined) {
             const targetLineIndex = envVars.indexOf(targetLine);
             // keyとvalueを置き換え
             envVars.splice(targetLineIndex, 1);
             // ファイル書き込み (os標準の改行コードで保存)
-            await fs.writeFile(ENV_FILE_PATH, envVars.join(os.EOL));
+            await fs.writeFile(ENV_FILE_PATH, envVars.join('\n'));
             return true;
         } else {
             return false;

--- a/app/cmd/admin-cmd/environment_variables/delete_variables.js
+++ b/app/cmd/admin-cmd/environment_variables/delete_variables.js
@@ -28,8 +28,7 @@ async function deleteVariables(interaction) {
         env_file = new AttachmentBuilder('./.env', { name: 'env.txt' });
 
         // 現在のprocess.env更新
-        process.env[key] = undefined;
-
+        process.env[key] = '';
         await interaction.editReply({ content: '削除したでし！', files: [env_file] });
     } catch (error) {
         logger.error(error);

--- a/app/cmd/admin-cmd/environment_variables/delete_variables.js
+++ b/app/cmd/admin-cmd/environment_variables/delete_variables.js
@@ -1,6 +1,5 @@
 const { AttachmentBuilder } = require('discord.js');
 const log4js = require('log4js');
-const os = require('os');
 const fs = require('fs').promises;
 const path = require('path');
 
@@ -27,9 +26,12 @@ async function deleteVariables(interaction) {
 
         env_file = new AttachmentBuilder('./.env', { name: 'env.txt' });
 
-        // 現在のprocess.env更新
+        // 現在のprocess.env更新 (process.envは消せないので空文字で上書きすることで対応)
         process.env[key] = '';
-        await interaction.editReply({ content: '削除したでし！', files: [env_file] });
+        await interaction.editReply({
+            content: '削除したでし！\n挙動がおかしくなる場合があるので再起動を推奨するでし！',
+            files: [env_file],
+        });
     } catch (error) {
         logger.error(error);
     }

--- a/app/cmd/admin-cmd/environment_variables/delete_variables.js
+++ b/app/cmd/admin-cmd/environment_variables/delete_variables.js
@@ -26,10 +26,11 @@ async function deleteVariables(interaction) {
 
         env_file = new AttachmentBuilder('./.env', { name: 'env.txt' });
 
-        // 現在のprocess.env更新 (process.envは消せないので空文字で上書きすることで対応)
-        process.env[key] = '';
+        // 現在のprocess.env更新 (process.envから直接削除)
+        delete process.env[key];
+
         await interaction.editReply({
-            content: '削除したでし！\n挙動がおかしくなる場合があるので再起動を推奨するでし！',
+            content: '削除したでし！',
             files: [env_file],
         });
     } catch (error) {

--- a/app/cmd/admin-cmd/environment_variables/set_variables.js
+++ b/app/cmd/admin-cmd/environment_variables/set_variables.js
@@ -1,6 +1,5 @@
 const { AttachmentBuilder } = require('discord.js');
 const log4js = require('log4js');
-const os = require('os');
 const fs = require('fs').promises;
 const path = require('path');
 
@@ -24,8 +23,8 @@ async function setVariables(interaction) {
 
         env_file = new AttachmentBuilder('./.env', { name: 'env.txt' });
 
-        // 現在のprocess.env更新
-        process.env[key] = value;
+        // dotenv更新 (override trueにしないと上書きされない)
+        require('dotenv').config({ override: true });
 
         await interaction.editReply({ content: '設定したでし！', files: [env_file] });
     } catch (error) {

--- a/app/cmd/admin-cmd/environment_variables/set_variables.js
+++ b/app/cmd/admin-cmd/environment_variables/set_variables.js
@@ -50,7 +50,7 @@ async function setEnvValue(key, value) {
             // 新しくkeyとvalueを設定
             envVars.push(`${key}=${value}`);
         }
-        // ファイル書き込み (os標準の改行コードで保存)
+        // ファイル書き込み
         await fs.writeFile(ENV_FILE_PATH, envVars.join('\n'));
     } catch (error) {
         logger.error(error);

--- a/app/cmd/admin-cmd/environment_variables/set_variables.js
+++ b/app/cmd/admin-cmd/environment_variables/set_variables.js
@@ -41,7 +41,7 @@ async function setVariables(interaction) {
 async function setEnvValue(key, value) {
     try {
         const envFile = await fs.readFile(ENV_FILE_PATH, 'utf-8');
-        const envVars = envFile.split(/\r\n|\n/);
+        const envVars = envFile.split(/\r\n|\n|\r/);
         const targetLine = envVars.find((line) => line.split('=')[0] === key);
         if (targetLine !== undefined) {
             const targetLineIndex = envVars.indexOf(targetLine);
@@ -52,7 +52,7 @@ async function setEnvValue(key, value) {
             envVars.push(`${key}=${value}`);
         }
         // ファイル書き込み (os標準の改行コードで保存)
-        await fs.writeFile(ENV_FILE_PATH, envVars.join(os.EOL));
+        await fs.writeFile(ENV_FILE_PATH, envVars.join('\n'));
     } catch (error) {
         logger.error(error);
     }


### PR DESCRIPTION
- 対象のprocess.envにundefindを代入するのではなく、process.envから直接削除するように変更
- valueが'hogehoge'の場合process.envの値が''hogehoge''になってしまうのを修正
- 保存時の改行コードを `\n` ( LF ) に統一 ( GCPだと改行入る問題の対応 ) <- 直ってるかは不明
- 読み込み時の改行コードは CR or LF or CRLF