### PR TITLE
feat:リアクションされたユーザーと絵文字をテーブルに記録する機能を追加

### DIFF
--- a/app/event/reactions.js
+++ b/app/event/reactions.js
@@ -1,0 +1,38 @@
+const ReactionsService = require('../../db/reactions_service');
+const TotalReactionsService = require('../../db/total_reactions_service');
+const TotalReactions = require('../../db/model/total_reactions');
+const { isEmpty } = require('../common');
+
+module.exports = async function emojiCountUp(reaction) {
+    let user_id = reaction.message.author.id;
+    let emoji_id = reaction._emoji.id;
+    let emoji_name = reaction._emoji.name;
+    let channel_id = reaction.message.channelId;
+    let year = new Date().getFullYear();
+    // reactions,total_reactionsテーブルがなければ作る
+    await TotalReactionsService.createTableIfNotExists();
+    await ReactionsService.createTableIfNotExists();
+    // total_reactionからseq取得、なければ新規作成
+    let result = await getTotalReaction(emoji_id, emoji_name);
+    let count = await getReactionCount(user_id, result.reaction_seq, channel_id, year);
+    await TotalReactionsService.update(result.reaction_seq, result.count + 1);
+    await ReactionsService.save(user_id, result.reaction_seq, channel_id, year, count);
+};
+
+async function getReactionCount(user_id, reaction_seq, channel_id, year) {
+    let count = 1;
+    let result = await ReactionsService.getReactionCountByPK(user_id, reaction_seq, channel_id, year);
+    if (result[0] != null) {
+        count = result[0].count + 1;
+    }
+    return count;
+}
+
+async function getTotalReaction(emoji_id, emoji_name) {
+    let result = await TotalReactionsService.getTotalReactionByEmoji(emoji_id, emoji_name);
+    if (isEmpty(result)) {
+        await TotalReactionsService.save(emoji_id, emoji_name, 0);
+        result = await TotalReactionsService.getTotalReactionByEmoji(emoji_id, emoji_name);
+    }
+    return result[0];
+}

--- a/app/index.js
+++ b/app/index.js
@@ -1,5 +1,5 @@
 // Discord bot implements
-const { Client, GatewayIntentBits, PermissionsBitField, ActivityType } = require('discord.js');
+const { Client, GatewayIntentBits, PermissionsBitField, ActivityType, Partials } = require('discord.js');
 const { URLSearchParams } = require('url');
 const client = new Client({
     intents: [
@@ -12,6 +12,7 @@ const client = new Client({
         GatewayIntentBits.GuildMembers,
         GatewayIntentBits.MessageContent,
     ],
+    partials: [Partials.User, Partials.GuildMember, Partials.Message, Partials.Reaction],
 });
 
 const Handler = require('./handler.js');
@@ -30,6 +31,7 @@ const { ButtonEnable } = require('./cmd/admin-cmd/enableButton');
 const { voiceMention } = require('./cmd/other/voice_mention.js');
 const removeRookie = require('./event/rookie/remove_rookie.js');
 const chatCountUp = require('./event/members.js');
+const emojiCountUp = require('./event/reactions.js');
 const { guildMemberAddEvent } = require('./event/rookie/set_rookie.js');
 const deleteToken = require('./event/delete_token.js');
 const recruitButton = require('./event/recruit_button.js');
@@ -178,6 +180,7 @@ client.on('messageReactionAdd', async (reaction, user) => {
                 return;
             }
         }
+        await emojiCountUp(reaction);
     } catch (error) {
         loggerMRA.error(error);
     }

--- a/db/model/reactions.js
+++ b/db/model/reactions.js
@@ -1,0 +1,9 @@
+module.exports = class Reactions {
+    constructor(reaction_seq, user_id, channel_id, year, count) {
+        this.user_id = user_id;
+        this.reaction_seq = reaction_seq;
+        this.channel_id = channel_id;
+        this.year = year;
+        this.count = count;
+    }
+};

--- a/db/model/total_reactions.js
+++ b/db/model/total_reactions.js
@@ -1,0 +1,8 @@
+module.exports = class TotalReactions {
+    constructor(reaction_seq, emoji_id, emoji_name, count) {
+        this.reaction_seq = reaction_seq;
+        this.emoji_id = emoji_id;
+        this.emoji_name = emoji_name;
+        this.count = count;
+    }
+};

--- a/db/reactions_service.js
+++ b/db/reactions_service.js
@@ -1,0 +1,92 @@
+const DBCommon = require('./db.js');
+const Reactions = require('./model/reactions');
+const log4js = require('log4js');
+
+log4js.configure(process.env.LOG4JS_CONFIG_PATH);
+const logger = log4js.getLogger('database');
+
+module.exports = class ReactionsService {
+    static async createTableIfNotExists() {
+        try {
+            DBCommon.init();
+            await DBCommon.run(`CREATE TABLE IF NOT EXISTS reactions (
+                user_id text,
+                reaction_seq integer,
+                year text,
+                channel_id text,
+                count integer,
+                PRIMARY KEY (user_id, reaction_seq, channel_id, year)
+                    )`);
+            DBCommon.close();
+        } catch (err) {
+            logger.error(err);
+        }
+    }
+
+    static async save(user_id, reaction_seq, channel_id, year, count) {
+        try {
+            DBCommon.init();
+            await DBCommon.run(
+                `insert or replace into reactions (user_id, reaction_seq, channel_id, year, count)  values ($1, $2, $3, $4, $5)`,
+                [user_id, reaction_seq, channel_id, year, count],
+            );
+            DBCommon.close();
+        } catch (err) {
+            logger.error(err);
+        }
+    }
+
+    static async getReactionCountByPK(user_id, reaction_seq, channel_id, year) {
+        const db = DBCommon.open();
+        const result = [];
+        return new Promise((resolve, reject) => {
+            db.serialize(() => {
+                db.all(
+                    `select * from reactions where user_id = ${user_id} and reaction_seq = ${reaction_seq} and channel_id = '${channel_id}' and year = '${year}'`,
+                    (err, rows) => {
+                        if (err) return reject(err);
+                        rows.forEach((row) => {
+                            result.push(new Reactions(row['user_id'], row['reaction_seq'], row['channel_id'], row['year'], row['count']));
+                        });
+                        DBCommon.close();
+                        return resolve(result);
+                    },
+                );
+            });
+        });
+    }
+
+    static async getReactionCountByUserId(user_id) {
+        const db = DBCommon.open();
+        const result = [];
+        return new Promise((resolve, reject) => {
+            db.serialize(() => {
+                db.all(`select * from reactions where user_id = ${user_id}`, (err, rows) => {
+                    if (err) return reject(err);
+                    rows.forEach((row) => {
+                        result.push(new Reactions(row['user_id'], row['reaction_seq'], row['channel_id'], row['year'], row['count']));
+                    });
+                    DBCommon.close();
+                    return resolve(result);
+                });
+            });
+        });
+    }
+
+    static async getReactionCountByReactionSeq(reaction_seq) {
+        const db = DBCommon.open();
+        const result = [];
+        return new Promise((resolve, reject) => {
+            db.serialize(() => {
+                db.all(`select * from reactions where reaction_seq = ${reaction_seq}`, (err, rows) => {
+                    if (err) return reject(err);
+                    rows.forEach((row) => {
+                        result.push(new Reactions(row['user_id'], row['reaction_seq'], row['channel_id'], row['year'], row['count']));
+                    });
+                    DBCommon.close();
+                    return resolve(result);
+                });
+            });
+        });
+    }
+};

--- a/db/total_reactions_service.js
+++ b/db/total_reactions_service.js
@@ -1,0 +1,64 @@
+const DBCommon = require('./db.js');
+const TotalReactions = require('./model/total_reactions');
+const log4js = require('log4js');
+
+log4js.configure(process.env.LOG4JS_CONFIG_PATH);
+const logger = log4js.getLogger('database');
+
+module.exports = class TotalReactionsService {
+    static async createTableIfNotExists() {
+        try {
+            DBCommon.init();
+            await DBCommon.run(`CREATE TABLE IF NOT EXISTS total_reactions (
+                reaction_seq integer PRIMARY KEY AUTOINCREMENT,
+                emoji_id text,
+                emoji_name text,
+                count integer
+                    )`);
+            DBCommon.close();
+        } catch (err) {
+            logger.error(err);
+        }
+    }
+
+    static async save(emoji_id, emoji_name, count) {
+        try {
+            DBCommon.init();
+            await DBCommon.run(`insert or replace into total_reactions (emoji_id, emoji_name, count)  values ($1, $2, $3)`, [
+                emoji_id,
+                emoji_name,
+                count,
+            ]);
+            DBCommon.close();
+        } catch (err) {
+            logger.error(err);
+        }
+    }
+
+    static async update(reaction_seq, count) {
+        try {
+            DBCommon.init();
+            await DBCommon.run(`update total_reactions set count = ${count}  where reaction_seq = ${reaction_seq}`);
+            DBCommon.close();
+        } catch (err) {
+            logger.error(err);
+        }
+    }
+
+    static async getTotalReactionByEmoji(emoji_id, emoji_name) {
+        const db = DBCommon.open();
+        const result = [];
+        return new Promise((resolve, reject) => {
+            db.serialize(() => {
+                db.all(`select * from total_reactions where emoji_id = '${emoji_id}' or emoji_name = '${emoji_name}'`, (err, rows) => {
+                    if (err) return reject(err);
+                    rows.forEach((row) => {
+                        result.push(new TotalReactions(row['reaction_seq'], row['emoji_id'], row['emoji_name'], row['count']));
+                    });
+                    DBCommon.close();
+                    return resolve(result);
+                });
+            });
+        });
+    }
+};


### PR DESCRIPTION
以下を追加
- リアクションされたユーザーごとに絵文字やチャンネルごとに回数を記録するテーブル
- リアクションごとのseq管理と合計回数を記録するテーブル