### PR TITLE
update: ボタン有効化コマンドをコンテキストメニューに移動

### DIFF
--- a/app/cmd/admin-cmd/enableButton.js
+++ b/app/cmd/admin-cmd/enableButton.js
@@ -1,7 +1,7 @@
+const { PermissionsBitField } = require('discord.js');
 const { setButtonEnable } = require('../../common/button_components');
-const { searchMessageById } = require('../../manager/messageManager');
 const log4js = require('log4js');
-const { isNotEmpty, isEmpty } = require('../../common');
+const { isEmpty } = require('../../common');
 
 module.exports = {
     ButtonEnable: ButtonEnable,
@@ -11,17 +11,14 @@ async function ButtonEnable(interaction) {
     log4js.configure(process.env.LOG4JS_CONFIG_PATH);
     const logger = log4js.getLogger('interaction');
 
+    if (!interaction.member.permissions.has(PermissionsBitField.Flags.ManageChannels)) {
+        return await interaction.reply({ content: '操作を実行する権限がないでし！', ephemeral: true });
+    }
+
     try {
         await interaction.deferReply({ ephemeral: false });
 
-        const messageId = interaction.options.getString('メッセージid');
-        let channelId;
-        if (isNotEmpty(interaction.options.getChannel('チャンネル'))) {
-            channelId = interaction.options.getChannel('チャンネル').id;
-        } else {
-            channelId = interaction.channel.id;
-        }
-        const message = await searchMessageById(interaction.guild, channelId, messageId);
+        const message = interaction.targetMessage;
 
         if (isEmpty(message)) {
             await interaction.editReply({

--- a/app/index.js
+++ b/app/index.js
@@ -268,6 +268,12 @@ async function onInteraction(interaction) {
             }
         }
 
+        if (interaction.isMessageContextMenuCommand()) {
+            if (interaction.commandName == commandNames.buttonEnabler) {
+                ButtonEnable(interaction);
+            }
+        }
+
         if (interaction.isCommand()) {
             const { commandName } = interaction;
 
@@ -308,8 +314,6 @@ async function onInteraction(interaction) {
                 await handleFriendCode(interaction);
             } else if (commandName === commandNames.experience) {
                 handleIkabuExperience(interaction);
-            } else if (commandName === commandNames.buttonEnable) {
-                ButtonEnable(interaction);
             } else if (commandName === commandNames.voiceChannelMention) {
                 voiceMention(interaction);
             } else if (commandName === commandNames.variablesSettings) {

--- a/constant.js
+++ b/constant.js
@@ -25,7 +25,7 @@ module.exports = {
         fesB: 'マンタロー陣営',
         fesC: 'ウツホ陣営',
         private: 'プラベ募集',
-        buttonEnable: 'ボタン有効化',
+        buttonEnabler: 'ボタンを有効化する',
         voiceChannelMention: 'ボイスメンション',
         variablesSettings: '環境変数設定',
     },

--- a/register.js
+++ b/register.js
@@ -1,5 +1,5 @@
-const { SlashCommandBuilder } = require(`@discordjs/builders`);
-const { ChannelType } = require('discord-api-types/v10');
+const { SlashCommandBuilder, ContextMenuCommandBuilder } = require(`@discordjs/builders`);
+const { ChannelType, ApplicationCommandType } = require('discord-api-types/v10');
 const { commandNames } = require('./constant.js');
 const log4js = require('log4js');
 
@@ -689,13 +689,7 @@ const teamDivider = new SlashCommandBuilder()
             .addBooleanOption((option) => option.setName('勝利数と勝率を隠す').setDescription('勝利数と勝率を隠すことができます。')),
     );
 
-const buttonEnable = new SlashCommandBuilder()
-    .setName(commandNames.buttonEnable)
-    .setDescription('ボタンを有効化します。(エラー落ちしたとき用)')
-    .addStringOption((option) => option.setName('メッセージid').setDescription('有効化するボタンのメッセージIDを入力').setRequired(true))
-    .addChannelOption((option) =>
-        option.setName('チャンネル').setDescription('有効化するボタンが投稿されているチャンネルを選択').setRequired(false),
-    );
+const buttonEnabler = new ContextMenuCommandBuilder().setName(commandNames.buttonEnabler).setType(ApplicationCommandType.Message);
 
 const voiceChannelMention = new SlashCommandBuilder()
     .setName(commandNames.voiceChannelMention)
@@ -760,7 +754,7 @@ const commands = [
     fesA,
     fesB,
     fesC,
-    buttonEnable,
+    buttonEnabler,
     voiceChannelMention,
     variablesSettings,
 ];


### PR DESCRIPTION
使うときは該当ボタンのあるメッセージを右クリック
アプリ > ボタンを有効化する

スラコマ版は削除

一応チャンネル管理権限見るように設定したけど、
連携サービスから表示対象選べたのでそっちで使用者制限かけましょう