### PR TITLE
fix: webhook, 退部済みユーザーのdispander表示を修正

### DIFF
--- a/app/common/others.js
+++ b/app/common/others.js
@@ -29,10 +29,17 @@ async function composeEmbed(message, url) {
         embed.setTitle('引用元へジャンプ');
         embed.setURL(url);
     }
-    embed.setAuthor({
-        name: member.displayName,
-        iconURL: member.displayAvatarURL(),
-    });
+    if (isNotEmpty(member)) {
+        embed.setAuthor({
+            name: member.displayName,
+            iconURL: member.displayAvatarURL(),
+        });
+    } else {
+        embed.setAuthor({
+            name: '不明なユーザー',
+            iconURL: 'https://cdn.discordapp.com/embed/avatars/0.png',
+        });
+    }
     embed.setFooter({
         text: message.channel.name,
         iconURL: message.guild.iconURL(),


### PR DESCRIPTION
webhookや退部したユーザーのようにmemberが取れない時に不明なユーザーとしてembedを作成するように変更