### PR TITLE
fix: 環境変数に入れていないguildのuserUpdateエラーの修正

### DIFF
--- a/src/db/members_service.ts
+++ b/src/db/members_service.ts
@@ -68,4 +68,16 @@ export class MembersService {
         DBCommon.close();
         return members;
     }
+
+    static async getMemberGuildsByUserId(userId: string) {
+        const db = DBCommon.open();
+        db.all = util.promisify(db.all); // https://stackoverflow.com/questions/56122812/async-await-sqlite-in-javascript
+        const results = await db.all(`select * from members where user_id = ${userId}`);
+        const members: string[] = [];
+        for (let i = 0; i < results.length; i++) {
+            members.push(results[i].guild_id);
+        }
+        DBCommon.close();
+        return members;
+    }
 }


### PR DESCRIPTION
- GMU & UU デバッグ用ログの追加 ( searchAPIする必要ない説の検証)
- userUpdate時はDBにないプロフィールの登録をしないように変更(GMUは登録あり)
- userUpdate時はDBからguildId取得