### PR TITLE
feat: Sticky更新時に取得できない募集データ削除 & ボタンコマンド独立

### DIFF
--- a/src/app/common/others.ts
+++ b/src/app/common/others.ts
@@ -114,6 +114,12 @@ export function createMentionsFromIdList(idList: string[]) {
     return mentionList;
 }
 
+// オブジェクト型でどれか一つのプロパティを必須にする
+export type RequireOne<T, K extends keyof T = keyof T> = K extends keyof T ? PartialRequire<T, K> : never;
+type PartialRequire<O, K extends keyof O> = {
+    [P in K]-?: O[P];
+} & O;
+
 /**
  * メッセージから順番に取得したメンションを配列で返す
  * @param message メッセージ

--- a/src/app/common/sticky_message.ts
+++ b/src/app/common/sticky_message.ts
@@ -1,0 +1,28 @@
+import { Guild, MessagePayload, MessageCreateOptions } from 'discord.js';
+
+import { searchChannelById } from './manager/channel_manager';
+import { searchMessageById } from './manager/message_manager';
+import { exists } from './others';
+import { StickyService } from '../../db/sticky_service';
+import { log4js_obj } from '../../log4js_settings';
+
+const logger = log4js_obj.getLogger('message');
+
+export async function sendStickyMessage(guild: Guild, channelId: string, content: string | MessagePayload | MessageCreateOptions) {
+    const lastStickyMsgId = await StickyService.getMessageId(guild.id, channelId);
+    if (lastStickyMsgId.length !== 0) {
+        const lastStickyMsg = await searchMessageById(guild, channelId, lastStickyMsgId[0]);
+        if (exists(lastStickyMsg)) {
+            try {
+                await lastStickyMsg.delete();
+            } catch (error) {
+                logger.warn(`last sticky message not found! [${lastStickyMsgId}]`);
+            }
+        }
+    }
+    const channel = await searchChannelById(guild, channelId);
+    if (exists(channel) && channel.isTextBased()) {
+        const stickyMessage = await channel.send(content);
+        await StickyService.registerMessageId(guild.id, channelId, stickyMessage.id);
+    }
+}

--- a/src/app/feat-recruit/interactions/buttons/cancel_notify_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/cancel_notify_event.ts
@@ -1,4 +1,4 @@
-import { BaseGuildTextChannel, ButtonInteraction, EmbedBuilder } from 'discord.js';
+import { ButtonInteraction, EmbedBuilder } from 'discord.js';
 
 import { memberListMessage } from './other_events.js';
 import { sendRecruitButtonLog } from '../.././../logs/buttons/recruit_button_log';
@@ -8,9 +8,14 @@ import { RecruitService } from '../../../../db/recruit_service.js';
 import { log4js_obj } from '../../../../log4js_settings.js';
 import { disableThinkingButton, recoveryThinkingButton, setButtonDisable } from '../../../common/button_components';
 import { searchDBMemberById } from '../../../common/manager/member_manager.js';
-import { assertExistCheck, getCommandHelpEmbed } from '../../../common/others.js';
-import { createNewRecruitButton } from '../../buttons/create_recruit_buttons.js';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages.js';
+import { assertExistCheck, exists } from '../../../common/others.js';
+import { sendStickyMessage } from '../../../common/sticky_message.js';
+import {
+    availableRecruitString,
+    getStickyChannelId,
+    sendCloseEmbedSticky,
+    sendRecruitSticky,
+} from '../../sticky/recruit_sticky_messages.js';
 
 const logger = log4js_obj.getLogger('recruitButton');
 
@@ -91,14 +96,14 @@ export async function cancelNotify(interaction: ButtonInteraction) {
             });
             await interaction.followUp({ embeds: [embed], ephemeral: false });
 
-            if (recruitChannel instanceof BaseGuildTextChannel) {
-                const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-                const helpEmbed = getCommandHelpEmbed(recruitChannel.name);
-                await sendStickyMessage(guild, recruitChannel.id, {
-                    content: content,
-                    embeds: [helpEmbed],
-                    components: [createNewRecruitButton(recruitChannel.name)],
-                });
+            if (recruitChannel.isThread()) {
+                // フォーラムやスレッドの場合は、テキストの募集チャンネルにSticky Messageを送信する
+                const stickyChannelId = getStickyChannelId(recruitData[0]);
+                if (exists(stickyChannelId)) {
+                    await sendRecruitSticky({ channelOpt: { guild: guild, channelId: stickyChannelId } });
+                }
+            } else {
+                await sendCloseEmbedSticky(guild, recruitChannel);
             }
         } else {
             // 参加済みかチェック
@@ -115,8 +120,8 @@ export async function cancelNotify(interaction: ButtonInteraction) {
                     components: recoveryThinkingButton(interaction, 'キャンセル'),
                 });
 
-                if (recruitChannel instanceof BaseGuildTextChannel) {
-                    const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
+                if (recruitChannel.isTextBased()) {
+                    const content = await availableRecruitString(guild, recruitChannel.id);
                     await sendStickyMessage(guild, recruitChannel.id, content);
                 }
             } else {

--- a/src/app/feat-recruit/interactions/buttons/close_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/close_event.ts
@@ -84,7 +84,7 @@ export async function close(interaction: ButtonInteraction, params: URLSearchPar
         const recruitChannel = interaction.channel;
 
         if (confirmedMemberIDList.includes(member.userId)) {
-            const memberList = getMemberMentions(recruitData[0], participantsData);
+            const memberList = getMemberMentions(recruitData[0].recruitNum, participantsData);
 
             await regenerateCanvas(guild, recruitChannel.id, image1MsgId, RecruitOpCode.close);
 
@@ -119,7 +119,7 @@ export async function close(interaction: ButtonInteraction, params: URLSearchPar
                 await sendCloseEmbedSticky(guild, recruitChannel);
             }
         } else if (datetimeDiff(new Date(), image1Message.createdAt) > 120) {
-            const memberList = getMemberMentions(recruitData[0], participantsData);
+            const memberList = getMemberMentions(recruitData[0].recruitNum, participantsData);
 
             await regenerateCanvas(guild, recruitChannel.id, image1MsgId, RecruitOpCode.close);
 

--- a/src/app/feat-recruit/interactions/buttons/close_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/close_event.ts
@@ -1,4 +1,4 @@
-import { BaseGuildTextChannel, ButtonInteraction, EmbedBuilder } from 'discord.js';
+import { ButtonInteraction, EmbedBuilder } from 'discord.js';
 
 import { getMemberMentions } from './other_events.js';
 import { Participant } from '../../../../db/model/participant.js';
@@ -9,11 +9,10 @@ import { disableThinkingButton, recoveryThinkingButton, setButtonDisable } from 
 import { searchChannelById } from '../../../common/manager/channel_manager.js';
 import { searchAPIMemberById, searchDBMemberById } from '../../../common/manager/member_manager.js';
 import { searchMessageById } from '../../../common/manager/message_manager.js';
-import { assertExistCheck, datetimeDiff, exists, getCommandHelpEmbed } from '../../../common/others.js';
+import { assertExistCheck, datetimeDiff, exists } from '../../../common/others.js';
 import { sendRecruitButtonLog } from '../../../logs/buttons/recruit_button_log.js';
-import { createNewRecruitButton } from '../../buttons/create_recruit_buttons.js';
 import { regenerateCanvas, RecruitOpCode } from '../../canvases/regenerate_canvas.js';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages.js';
+import { getStickyChannelId, sendCloseEmbedSticky, sendRecruitSticky } from '../../sticky/recruit_sticky_messages.js';
 
 const logger = log4js_obj.getLogger('recruitButton');
 
@@ -110,14 +109,14 @@ export async function close(interaction: ButtonInteraction, params: URLSearchPar
             });
             await interaction.followUp({ embeds: [embed], ephemeral: false });
 
-            if (recruitChannel instanceof BaseGuildTextChannel) {
-                const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-                const helpEmbed = getCommandHelpEmbed(recruitChannel.name);
-                await sendStickyMessage(guild, recruitChannel.id, {
-                    content: content,
-                    embeds: [helpEmbed],
-                    components: [createNewRecruitButton(recruitChannel.name)],
-                });
+            if (recruitChannel.isThread()) {
+                // フォーラムやスレッドの場合は、テキストの募集チャンネルにSticky Messageを送信する
+                const stickyChannelId = getStickyChannelId(recruitData[0]);
+                if (exists(stickyChannelId)) {
+                    await sendRecruitSticky({ channelOpt: { guild: guild, channelId: stickyChannelId } });
+                }
+            } else {
+                await sendCloseEmbedSticky(guild, recruitChannel);
             }
         } else if (datetimeDiff(new Date(), image1Message.createdAt) > 120) {
             const memberList = getMemberMentions(recruitData[0], participantsData);
@@ -146,14 +145,14 @@ export async function close(interaction: ButtonInteraction, params: URLSearchPar
             const embed = new EmbedBuilder().setDescription(`<@${recruiterId}>たんの募集〆 \n <@${member.userId}>たんが代理〆`);
             await interaction.followUp({ embeds: [embed], ephemeral: false });
 
-            if (recruitChannel instanceof BaseGuildTextChannel) {
-                const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-                const helpEmbed = getCommandHelpEmbed(recruitChannel.name);
-                await sendStickyMessage(guild, recruitChannel.id, {
-                    content: content,
-                    embeds: [helpEmbed],
-                    components: [createNewRecruitButton(recruitChannel.name)],
-                });
+            if (recruitChannel.isThread()) {
+                // フォーラムやスレッドの場合は、テキストの募集チャンネルにSticky Messageを送信する
+                const stickyChannelId = getStickyChannelId(recruitData[0]);
+                if (exists(stickyChannelId)) {
+                    await sendRecruitSticky({ channelOpt: { guild: guild, channelId: stickyChannelId } });
+                }
+            } else {
+                await sendCloseEmbedSticky(guild, recruitChannel);
             }
         } else {
             await interaction.followUp({

--- a/src/app/feat-recruit/interactions/buttons/close_notify_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/close_notify_event.ts
@@ -77,7 +77,7 @@ export async function closeNotify(interaction: ButtonInteraction) {
         const recruitChannel = interaction.channel;
 
         if (member.userId === recruiterId) {
-            const memberList = getMemberMentions(recruitData[0], participantsData);
+            const memberList = getMemberMentions(recruitData[0].recruitNum, participantsData);
 
             // recruitテーブルから削除
             await RecruitService.deleteRecruit(guild.id, embedMessageId);
@@ -102,7 +102,7 @@ export async function closeNotify(interaction: ButtonInteraction) {
                 await sendCloseEmbedSticky(guild, recruitChannel);
             }
         } else if (datetimeDiff(new Date(), interaction.message.createdAt) > 120) {
-            const memberList = getMemberMentions(recruitData[0], participantsData);
+            const memberList = getMemberMentions(recruitData[0].recruitNum, participantsData);
 
             // recruitテーブルから削除
             await RecruitService.deleteRecruit(guild.id, embedMessageId);

--- a/src/app/feat-recruit/interactions/buttons/delete_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/delete_event.ts
@@ -9,6 +9,7 @@ import { setButtonDisable } from '../../../common/button_components';
 import { searchDBMemberById } from '../../../common/manager/member_manager.js';
 import { searchMessageById } from '../../../common/manager/message_manager.js';
 import { assertExistCheck, exists } from '../../../common/others.js';
+import { getStickyChannelId, sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 
 const logger = log4js_obj.getLogger('recruitButton');
 
@@ -101,6 +102,8 @@ export async function del(interaction: ButtonInteraction, params: URLSearchParam
                 }
             }
 
+            const recruitData = await RecruitService.getRecruit(guild.id, image1MsgId);
+
             // recruitテーブルから削除
             await RecruitService.deleteRecruit(guild.id, image1MsgId);
 
@@ -110,6 +113,10 @@ export async function del(interaction: ButtonInteraction, params: URLSearchParam
             await interaction.editReply({
                 content: '募集を削除したでし！\n次回は内容をしっかり確認してから送信するでし！',
             });
+
+            // テキストの募集チャンネルにSticky Messageを送信
+            const stickyChannelId = getStickyChannelId(recruitData[0]) ?? interaction.channel.id;
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: stickyChannelId } });
         } else {
             await interaction.editReply({
                 content: '他人の募集は消せる訳無いでし！！！',

--- a/src/app/feat-recruit/interactions/buttons/join_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/join_event.ts
@@ -1,4 +1,4 @@
-import { BaseGuildTextChannel, ButtonInteraction, ChannelType, EmbedBuilder } from 'discord.js';
+import { ButtonInteraction, ChannelType, EmbedBuilder } from 'discord.js';
 
 import { memberListMessage } from './other_events.js';
 import { Participant } from '../../../../db/model/participant.js';
@@ -14,7 +14,7 @@ import { assertExistCheck, createMentionsFromIdList, exists, notExists, sleep } 
 import { sendRecruitButtonLog } from '../../../logs/buttons/recruit_button_log.js';
 import { channelLinkButtons, messageLinkButtons, nsoRoomLinkButton } from '../../buttons/create_recruit_buttons.js';
 import { RecruitOpCode, regenerateCanvas } from '../../canvases/regenerate_canvas.js';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages.js';
+import { getStickyChannelId, sendRecruitSticky } from '../../sticky/recruit_sticky_messages.js';
 
 const logger = log4js_obj.getLogger('recruitButton');
 
@@ -143,10 +143,9 @@ export async function join(interaction: ButtonInteraction, params: URLSearchPara
                 embeds: [embed],
             });
 
-            if (recruitChannel instanceof BaseGuildTextChannel) {
-                const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-                await sendStickyMessage(guild, recruitChannel.id, content);
-            }
+            // テキストの募集チャンネルにSticky Messageを送信
+            const stickyChannelId = getStickyChannelId(recruitData[0]) ?? recruitChannel.id;
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: stickyChannelId } });
 
             if (notExists(channelId)) {
                 await interaction.followUp({

--- a/src/app/feat-recruit/interactions/buttons/join_notify_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/join_notify_event.ts
@@ -1,4 +1,4 @@
-import { BaseGuildTextChannel, ButtonInteraction, ChannelType, EmbedBuilder } from 'discord.js';
+import { ButtonInteraction, ChannelType, EmbedBuilder } from 'discord.js';
 
 import { memberListMessage } from './other_events.js';
 import { sendRecruitButtonLog } from '../.././../logs/buttons/recruit_button_log';
@@ -12,7 +12,7 @@ import { searchAPIMemberById, searchDBMemberById } from '../../../common/manager
 import { searchMessageById } from '../../../common/manager/message_manager.js';
 import { assertExistCheck, exists, sleep } from '../../../common/others.js';
 import { messageLinkButtons } from '../../buttons/create_recruit_buttons';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages.js';
+import { getStickyChannelId, sendRecruitSticky } from '../../sticky/recruit_sticky_messages.js';
 
 const logger = log4js_obj.getLogger('recruitButton');
 
@@ -132,10 +132,9 @@ export async function joinNotify(interaction: ButtonInteraction) {
                 embeds: [embed],
             });
 
-            if (recruitChannel instanceof BaseGuildTextChannel) {
-                const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-                await sendStickyMessage(guild, recruitChannel.id, content);
-            }
+            // テキストの募集チャンネルにSticky Messageを送信
+            const stickyChannelId = getStickyChannelId(recruitData[0]) ?? recruitChannel.id;
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: stickyChannelId } });
 
             await interaction.followUp({
                 content: `<@${recruiterId}>からの返答を待つでし！\n条件を満たさない場合は参加を断られる場合があるでし！`,

--- a/src/app/feat-recruit/interactions/buttons/other_events.ts
+++ b/src/app/feat-recruit/interactions/buttons/other_events.ts
@@ -1,7 +1,6 @@
 import { ButtonInteraction } from 'discord.js';
 
 import { Participant } from '../../../../db/model/participant.js';
-import { Recruit } from '../../../../db/model/recruit.js';
 import { ParticipantService } from '../../../../db/participants_service.js';
 import { RecruitService } from '../../../../db/recruit_service.js';
 import { log4js_obj } from '../../../../log4js_settings.js';
@@ -34,7 +33,7 @@ export async function unlock(interaction: ButtonInteraction, params: URLSearchPa
     }
 }
 
-export function getMemberMentions(recruit: Recruit, participants: Participant[]) {
+export function getMemberMentions(recruitNum: number, participants: Participant[]) {
     const applicantList = []; // 参加希望者リスト
     for (const participant of participants) {
         if (participant.userType === 2) {
@@ -42,8 +41,8 @@ export function getMemberMentions(recruit: Recruit, participants: Participant[])
         }
     }
     let counter = `\`[${applicantList.length}]\``;
-    if (recruit.recruitNum !== -1) {
-        counter = `\`[${applicantList.length}/${recruit.recruitNum}]\``;
+    if (recruitNum !== -1) {
+        counter = `\`[${applicantList.length}/${recruitNum}]\``;
     }
     let mentionString = '**【参加表明一覧】**' + counter;
     for (const applicant of applicantList) {
@@ -57,7 +56,7 @@ export async function memberListMessage(interaction: ButtonInteraction, messageI
     const guild = await interaction.guild.fetch();
     const recruit = await RecruitService.getRecruit(guild.id, messageId);
     const participants = await ParticipantService.getAllParticipants(guild.id, messageId);
-    const memberList = getMemberMentions(recruit[0], participants);
+    const memberList = getMemberMentions(recruit[0].recruitNum, participants);
     const msgFirstRow = interaction.message.content.split('\n')[0];
     return msgFirstRow + '\n' + memberList;
 }

--- a/src/app/feat-recruit/interactions/commands/anarchy_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/anarchy_recruit.ts
@@ -286,6 +286,7 @@ async function sendAnarchyMatch(
         // DBに募集情報を登録
         await RecruitService.registerRecruit(
             guild.id,
+            recruitChannel.id,
             image1Message.id,
             hostMember.id,
             recruitNum,

--- a/src/app/feat-recruit/interactions/commands/anarchy_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/anarchy_recruit.ts
@@ -1,6 +1,5 @@
 import {
     AttachmentBuilder,
-    BaseGuildTextChannel,
     ChannelType,
     ChatInputCommandInteraction,
     GuildMember,
@@ -21,11 +20,11 @@ import { searchChannelIdByName } from '../../../common/manager/channel_manager';
 import { searchAPIMemberById, searchDBMemberById } from '../../../common/manager/member_manager';
 import { searchMessageById } from '../../../common/manager/message_manager';
 import { searchRoleIdByName } from '../../../common/manager/role_manager';
-import { assertExistCheck, exists, getCommandHelpEmbed, notExists, sleep } from '../../../common/others';
-import { createNewRecruitButton, recruitActionRow, recruitDeleteButton, unlockChannelButton } from '../../buttons/create_recruit_buttons';
+import { assertExistCheck, exists, notExists, sleep } from '../../../common/others';
+import { recruitActionRow, recruitDeleteButton, unlockChannelButton } from '../../buttons/create_recruit_buttons';
 import { recruitAnarchyCanvas, ruleAnarchyCanvas } from '../../canvases/anarchy_canvas';
 import { RecruitOpCode, regenerateCanvas } from '../../canvases/regenerate_canvas';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { sendCloseEmbedSticky, sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 import { getMemberMentions } from '../buttons/other_events';
 
 const logger = log4js_obj.getLogger('recruit');
@@ -347,9 +346,8 @@ async function sendAnarchyMatch(
         }
 
         // 募集リスト更新
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const sticky = await availableRecruitString(guild, recruitChannel.id, RecruitType.AnarchyRecruit);
-            await sendStickyMessage(guild, recruitChannel.id, sticky);
+        if (recruitChannel.isTextBased()) {
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: recruitChannel.id } });
         }
 
         // 15秒後に削除ボタンを消す
@@ -391,15 +389,7 @@ async function sendAnarchyMatch(
             reservedChannel.permissionOverwrites.delete(hostMember.user, 'UnLock Voice Channel');
         }
 
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-            const helpEmbed = getCommandHelpEmbed(recruitChannel.name);
-            await sendStickyMessage(guild, recruitChannel.id, {
-                content: content,
-                embeds: [helpEmbed],
-                components: [createNewRecruitButton(recruitChannel.name)],
-            });
-        }
+        await sendCloseEmbedSticky(guild, recruitChannel);
     } catch (error) {
         logger.error(error);
     }

--- a/src/app/feat-recruit/interactions/commands/anarchy_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/anarchy_recruit.ts
@@ -306,7 +306,7 @@ async function sendAnarchyMatch(
 
         const image2Message = await recruitChannel.send({ files: [rule] });
         const sentMessage = await recruitChannel.send({
-            content: mention + ' ボタンを押して参加表明するでし！',
+            content: mention + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
         });
 
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
@@ -370,7 +370,7 @@ async function sendAnarchyMatch(
             return;
         }
         const participants = await ParticipantService.getAllParticipants(guild.id, image1Message.id);
-        const memberList = getMemberMentions(recruitData[0], participants);
+        const memberList = getMemberMentions(recruitData[0].recruitNum, participants);
         const hostMention = `<@${hostMember.user.id}>`;
 
         await regenerateCanvas(guild, interaction.channelId, image1Message.id, RecruitOpCode.close);

--- a/src/app/feat-recruit/interactions/commands/button_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/button_recruit.ts
@@ -1,0 +1,86 @@
+import { ChatInputCommandInteraction, CacheType } from 'discord.js';
+
+import { Participant } from '../../../../db/model/participant';
+import { RecruitType } from '../../../../db/model/recruit';
+import { ParticipantService } from '../../../../db/participants_service';
+import { RecruitService } from '../../../../db/recruit_service';
+import { searchChannelById } from '../../../common/manager/channel_manager';
+import { searchDBMemberById } from '../../../common/manager/member_manager';
+import { assertExistCheck, exists, notExists } from '../../../common/others';
+import { notifyActionRow } from '../../buttons/create_recruit_buttons';
+import { sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
+import { getMemberMentions } from '../buttons/other_events';
+
+export async function buttonRecruit(interaction: ChatInputCommandInteraction<CacheType>) {
+    if (!interaction.inGuild()) return;
+
+    assertExistCheck(interaction.guild, 'guild');
+    assertExistCheck(interaction.channel, 'channel');
+
+    const guild = await interaction.guild.fetch();
+    const recruiter = await searchDBMemberById(guild, interaction.member.user.id);
+    const recruitChannel = await searchChannelById(guild, interaction.channel.id);
+    if (notExists(recruitChannel) || !recruitChannel.isTextBased()) return;
+    const recruitNum = interaction.options.getInteger('募集人数') ?? -1;
+
+    let rChannelName = recruitChannel.name;
+    if (recruitChannel.isThread() && exists(recruitChannel.parent)) {
+        rChannelName = recruitChannel.parent.name;
+    }
+
+    let recruitType;
+    // チャンネル名から募集種別を判定
+    if (rChannelName.includes('プラベ')) {
+        recruitType = RecruitType.PrivateRecruit;
+    } else if (rChannelName.includes('別ゲー')) {
+        recruitType = RecruitType.OtherGameRecruit;
+    } else {
+        recruitType = RecruitType.OtherGameRecruit;
+    }
+
+    let mention = '';
+    if (recruitType === RecruitType.PrivateRecruit) {
+        mention = `<@&${process.env.ROLE_ID_RECRUIT_PRIVATE}>`;
+    } else if (recruitType === RecruitType.OtherGameRecruit) {
+        mention = `<@&${process.env.ROLE_ID_RECRUIT_OTHERGAMES}>`;
+    }
+
+    assertExistCheck(recruiter, 'recruiter');
+
+    await interaction.deferReply({ ephemeral: true });
+
+    const sentMessage = await recruitChannel.send({
+        content: mention + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
+    });
+    // DBに募集情報を登録
+    await RecruitService.registerRecruit(
+        guild.id,
+        recruitChannel.id,
+        sentMessage.id,
+        recruiter.userId,
+        recruitNum,
+        'dummy',
+        null,
+        recruitType,
+    );
+
+    // DBに参加者情報を登録
+    await ParticipantService.registerParticipantFromObj(
+        sentMessage.id,
+        new Participant(recruiter.userId, recruiter.displayName, recruiter.iconUrl, 0, new Date()),
+    );
+
+    // 募集リスト更新
+    if (recruitType === RecruitType.PrivateRecruit) {
+        assertExistCheck(process.env.CHANNEL_ID_RECRUIT_PRIVATE, 'CHANNEL_ID_RECRUIT_PRIVATE');
+        await sendRecruitSticky({ channelOpt: { guild: guild, channelId: process.env.CHANNEL_ID_RECRUIT_PRIVATE } });
+    } else if (recruitType === RecruitType.OtherGameRecruit) {
+        assertExistCheck(process.env.CHANNEL_ID_RECRUIT_OTHERGAMES, 'CHANNEL_ID_RECRUIT_OTHERGAMES');
+        await sendRecruitSticky({ channelOpt: { guild: guild, channelId: process.env.CHANNEL_ID_RECRUIT_OTHERGAMES } });
+    }
+
+    await interaction.editReply({
+        content: '募集完了でし！参加者が来るまで気長に待つでし！',
+    });
+    sentMessage.edit({ components: [notifyActionRow()] });
+}

--- a/src/app/feat-recruit/interactions/commands/event_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/event_recruit.ts
@@ -216,7 +216,7 @@ async function sendEventMatch(
 
         const image2Message = await recruitChannel.send({ files: [rule] });
         const sentMessage = await recruitChannel.send({
-            content: mention + ' ボタンを押して参加表明するでし！',
+            content: mention + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
         });
 
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
@@ -280,7 +280,7 @@ async function sendEventMatch(
             return;
         }
         const participants = await ParticipantService.getAllParticipants(guild.id, image1Message.id);
-        const memberList = getMemberMentions(recruitData[0], participants);
+        const memberList = getMemberMentions(recruitData[0].recruitNum, participants);
         const hostMention = `<@${hostMember.user.id}>`;
 
         await regenerateCanvas(guild, interaction.channelId, image1Message.id, RecruitOpCode.close);

--- a/src/app/feat-recruit/interactions/commands/event_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/event_recruit.ts
@@ -1,12 +1,4 @@
-import {
-    AttachmentBuilder,
-    BaseGuildTextChannel,
-    ChatInputCommandInteraction,
-    GuildMember,
-    PermissionsBitField,
-    User,
-    VoiceChannel,
-} from 'discord.js';
+import { AttachmentBuilder, ChatInputCommandInteraction, GuildMember, PermissionsBitField, User, VoiceChannel } from 'discord.js';
 
 import { Participant } from '../../../../db/model/participant';
 import { RecruitType } from '../../../../db/model/recruit';
@@ -17,11 +9,11 @@ import { EventMatchInfo, getSchedule, getEventData } from '../../../common/apis/
 import { setButtonDisable } from '../../../common/button_components';
 import { searchAPIMemberById, searchDBMemberById } from '../../../common/manager/member_manager';
 import { searchMessageById } from '../../../common/manager/message_manager';
-import { assertExistCheck, exists, getCommandHelpEmbed, notExists, sleep } from '../../../common/others';
-import { createNewRecruitButton, recruitActionRow, recruitDeleteButton, unlockChannelButton } from '../../buttons/create_recruit_buttons';
+import { assertExistCheck, exists, notExists, sleep } from '../../../common/others';
+import { recruitActionRow, recruitDeleteButton, unlockChannelButton } from '../../buttons/create_recruit_buttons';
 import { recruitEventCanvas, ruleEventCanvas } from '../../canvases/event_canvas';
 import { RecruitOpCode, regenerateCanvas } from '../../canvases/regenerate_canvas';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { sendCloseEmbedSticky, sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 import { getMemberMentions } from '../buttons/other_events';
 
 const logger = log4js_obj.getLogger('recruit');
@@ -264,9 +256,8 @@ async function sendEventMatch(
         }
 
         // 募集リスト更新
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const sticky = await availableRecruitString(guild, recruitChannel.id, RecruitType.EventRecruit);
-            await sendStickyMessage(guild, recruitChannel.id, sticky);
+        if (recruitChannel.isTextBased()) {
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: recruitChannel.id } });
         }
 
         // 15秒後に削除ボタンを消す
@@ -308,15 +299,7 @@ async function sendEventMatch(
             reservedChannel.permissionOverwrites.delete(hostMember.user, 'UnLock Voice Channel');
         }
 
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-            const helpEmbed = getCommandHelpEmbed(recruitChannel.name);
-            await sendStickyMessage(guild, recruitChannel.id, {
-                content: content,
-                embeds: [helpEmbed],
-                components: [createNewRecruitButton(recruitChannel.name)],
-            });
-        }
+        await sendCloseEmbedSticky(guild, recruitChannel);
     } catch (error) {
         logger.error(error);
     }

--- a/src/app/feat-recruit/interactions/commands/event_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/event_recruit.ts
@@ -203,6 +203,7 @@ async function sendEventMatch(
         // DBに募集情報を登録
         await RecruitService.registerRecruit(
             guild.id,
+            recruitChannel.id,
             image1Message.id,
             hostMember.id,
             recruitNum,

--- a/src/app/feat-recruit/interactions/commands/fes_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/fes_recruit.ts
@@ -240,6 +240,7 @@ async function sendFesMatch(
         // DBに募集情報を登録
         await RecruitService.registerRecruit(
             guild.id,
+            recruitChannel.id,
             image1Message.id,
             hostMember.id,
             recruitNum,

--- a/src/app/feat-recruit/interactions/commands/fes_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/fes_recruit.ts
@@ -260,7 +260,7 @@ async function sendFesMatch(
 
         const image2Message = await recruitChannel.send({ files: [rule] });
         const sentMessage = await recruitChannel.send({
-            content: `<@&${mentionId}>` + ' ボタンを押して参加表明するでし！',
+            content: `<@&${mentionId}>` + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
         });
 
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
@@ -323,7 +323,7 @@ async function sendFesMatch(
             return;
         }
         const participants = await ParticipantService.getAllParticipants(guild.id, image1Message.id);
-        const memberList = getMemberMentions(recruitData[0], participants);
+        const memberList = getMemberMentions(recruitData[0].recruitNum, participants);
         const hostMention = `<@${hostMember.user.id}>`;
 
         await regenerateCanvas(guild, interaction.channelId, image1Message.id, RecruitOpCode.close);

--- a/src/app/feat-recruit/interactions/commands/fes_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/fes_recruit.ts
@@ -1,6 +1,5 @@
 import {
     AttachmentBuilder,
-    BaseGuildTextChannel,
     CacheType,
     ChatInputCommandInteraction,
     GuildMember,
@@ -19,11 +18,11 @@ import { setButtonDisable } from '../../../common/button_components';
 import { searchAPIMemberById, searchDBMemberById } from '../../../common/manager/member_manager';
 import { searchMessageById } from '../../../common/manager/message_manager';
 import { searchRoleById, searchRoleIdByName } from '../../../common/manager/role_manager';
-import { assertExistCheck, exists, getCommandHelpEmbed, notExists, sleep } from '../../../common/others';
-import { createNewRecruitButton, recruitActionRow, recruitDeleteButton, unlockChannelButton } from '../../buttons/create_recruit_buttons';
+import { assertExistCheck, exists, notExists, sleep } from '../../../common/others';
+import { recruitActionRow, recruitDeleteButton, unlockChannelButton } from '../../buttons/create_recruit_buttons';
 import { recruitFesCanvas, ruleFesCanvas } from '../../canvases/fes_canvas';
 import { RecruitOpCode, regenerateCanvas } from '../../canvases/regenerate_canvas';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { sendCloseEmbedSticky, sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 import { getMemberMentions } from '../buttons/other_events';
 const logger = log4js_obj.getLogger('recruit');
 
@@ -300,9 +299,8 @@ async function sendFesMatch(
         }
 
         // 募集リスト更新
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const sticky = await availableRecruitString(guild, recruitChannel.id, RecruitType.FestivalRecruit);
-            await sendStickyMessage(guild, recruitChannel.id, sticky);
+        if (recruitChannel.isTextBased()) {
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: recruitChannel.id } });
         }
 
         // 15秒後に削除ボタンを消す
@@ -344,15 +342,7 @@ async function sendFesMatch(
             reservedChannel.permissionOverwrites.delete(hostMember.user, 'UnLock Voice Channel');
         }
 
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-            const helpEmbed = getCommandHelpEmbed(recruitChannel.name);
-            await sendStickyMessage(guild, recruitChannel.id, {
-                content: content,
-                embeds: [helpEmbed],
-                components: [createNewRecruitButton(recruitChannel.name)],
-            });
-        }
+        await sendCloseEmbedSticky(guild, recruitChannel);
     } catch (error) {
         logger.error(error);
     }

--- a/src/app/feat-recruit/interactions/commands/other_game_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/other_game_recruit.ts
@@ -1,5 +1,4 @@
 import {
-    BaseGuildTextChannel,
     ChatInputCommandInteraction,
     Collection,
     ColorResolvable,
@@ -21,7 +20,7 @@ import { searchAPIMemberById, searchDBMemberById } from '../../../common/manager
 import { searchMessageById } from '../../../common/manager/message_manager';
 import { assertExistCheck, exists, sleep } from '../../../common/others';
 import { embedRecruitDeleteButton, recruitActionRow, unlockChannelButton } from '../../buttons/create_recruit_buttons';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 
 const logger = log4js_obj.getLogger('recruit');
 
@@ -313,9 +312,8 @@ async function sendOtherGames(
         }
 
         // 募集リスト更新
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const sticky = await availableRecruitString(guild, recruitChannel.id, RecruitType.OtherGameRecruit);
-            await sendStickyMessage(guild, recruitChannel.id, sticky);
+        if (recruitChannel.isTextBased()) {
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: recruitChannel.id } });
         }
 
         // 15秒後に削除ボタンを消す

--- a/src/app/feat-recruit/interactions/commands/other_game_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/other_game_recruit.ts
@@ -257,6 +257,7 @@ async function sendOtherGames(
         // DBに募集情報を登録
         await RecruitService.registerRecruit(
             guild.id,
+            recruitChannel.id,
             embedMessage.id,
             recruiter.userId,
             recruitNum,

--- a/src/app/feat-recruit/interactions/commands/private_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/private_recruit.ts
@@ -97,6 +97,7 @@ async function sendPrivateRecruit(
         // DBに募集情報を登録
         await RecruitService.registerRecruit(
             guild.id,
+            recruitChannel.id,
             embedMessage.id,
             recruiter.userId,
             recruitNum,
@@ -165,7 +166,16 @@ async function sendNotification(interaction: ChatInputCommandInteraction) {
         content: mention + ' ボタンを押して参加表明するでし！',
     });
     // DBに募集情報を登録
-    await RecruitService.registerRecruit(guild.id, sentMessage.id, recruiter.userId, -1, 'dummy', null, RecruitType.ButtonNotify);
+    await RecruitService.registerRecruit(
+        guild.id,
+        recruitChannel.id,
+        sentMessage.id,
+        recruiter.userId,
+        -1,
+        'dummy',
+        null,
+        RecruitType.ButtonNotify,
+    );
 
     // DBに参加者情報を登録
     await ParticipantService.registerParticipantFromObj(

--- a/src/app/feat-recruit/interactions/commands/private_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/private_recruit.ts
@@ -1,6 +1,5 @@
-import { CacheType, ChatInputCommandInteraction, CommandInteractionOptionResolver, EmbedBuilder } from 'discord.js';
+import { CacheType, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
 
-import { sendNotification } from './button_recruit';
 import { Participant } from '../../../../db/model/participant';
 import { RecruitType } from '../../../../db/model/recruit';
 import { ParticipantService } from '../../../../db/participants_service';
@@ -11,27 +10,16 @@ import { searchMessageById } from '../../../common/manager/message_manager';
 import { assertExistCheck, exists, sleep } from '../../../common/others';
 import { embedRecruitDeleteButton, recruitActionRow } from '../../buttons/create_recruit_buttons';
 import { sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
+import { getMemberMentions } from '../buttons/other_events';
 
 const logger = log4js_obj.getLogger('recruit');
 
-export async function privateRecruit(interaction: ChatInputCommandInteraction) {
-    const options = interaction.options;
-
-    if (options.getSubcommand() === 'recruit') {
-        await sendPrivateRecruit(interaction, options);
-    } else if (options.getSubcommand() === 'button') {
-        await sendNotification(interaction);
-    }
-}
-
-async function sendPrivateRecruit(
-    interaction: ChatInputCommandInteraction,
-    options: Omit<CommandInteractionOptionResolver<CacheType>, 'getMessage' | 'getFocused'>,
-) {
+export async function privateRecruit(interaction: ChatInputCommandInteraction<CacheType>) {
     if (!interaction.inGuild()) return;
 
-    const startTime = interaction.options.getString('開始時刻') ?? 'ERROR';
-    const time = interaction.options.getString('所要時間') ?? 'ERROR';
+    const options = interaction.options;
+    const startTime = options.getString('開始時刻') ?? 'ERROR';
+    const time = options.getString('所要時間') ?? 'ERROR';
     const recruitNumText = options.getString('募集人数') ?? 'ERROR';
     const condition = options.getString('内容または参加条件') ?? 'なし';
     const roomUrl = options.getString('ヘヤタテurl');
@@ -116,7 +104,7 @@ async function sendPrivateRecruit(
 
         const mention = `<@&${process.env.ROLE_ID_RECRUIT_PRIVATE}>`;
         const sentMessage = await recruitChannel.send({
-            content: mention + ' ボタンを押して参加表明するでし！',
+            content: mention + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
         });
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
         sentMessage.edit({ components: [recruitActionRow(embedMessage)] });

--- a/src/app/feat-recruit/interactions/commands/regular_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/regular_recruit.ts
@@ -265,7 +265,7 @@ async function sendRegularMatch(
 
         const image2Message = await recruitChannel.send({ files: [rule] });
         const sentMessage = await recruitChannel.send({
-            content: mention + ' ボタンを押して参加表明するでし！',
+            content: mention + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
         });
 
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る
@@ -329,7 +329,7 @@ async function sendRegularMatch(
             return;
         }
         const participants = await ParticipantService.getAllParticipants(guild.id, image1Message.id);
-        const memberList = getMemberMentions(recruitData[0], participants);
+        const memberList = getMemberMentions(recruitData[0].recruitNum, participants);
         const hostMention = `<@${hostMember.user.id}>`;
 
         await regenerateCanvas(guild, interaction.channelId, image1Message.id, RecruitOpCode.close);

--- a/src/app/feat-recruit/interactions/commands/regular_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/regular_recruit.ts
@@ -1,6 +1,5 @@
 import {
     AttachmentBuilder,
-    BaseGuildTextChannel,
     ChannelType,
     ChatInputCommandInteraction,
     GuildMember,
@@ -19,11 +18,11 @@ import { setButtonDisable } from '../../../common/button_components';
 import { searchChannelIdByName } from '../../../common/manager/channel_manager';
 import { searchAPIMemberById, searchDBMemberById } from '../../../common/manager/member_manager';
 import { searchMessageById } from '../../../common/manager/message_manager';
-import { assertExistCheck, exists, getCommandHelpEmbed, notExists, sleep } from '../../../common/others';
-import { createNewRecruitButton, recruitActionRow, recruitDeleteButton, unlockChannelButton } from '../../buttons/create_recruit_buttons';
+import { assertExistCheck, exists, notExists, sleep } from '../../../common/others';
+import { recruitActionRow, recruitDeleteButton, unlockChannelButton } from '../../buttons/create_recruit_buttons';
 import { RecruitOpCode, regenerateCanvas } from '../../canvases/regenerate_canvas';
 import { recruitRegularCanvas, ruleRegularCanvas } from '../../canvases/regular_canvas';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { sendCloseEmbedSticky, sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 import { getMemberMentions } from '../buttons/other_events';
 
 const logger = log4js_obj.getLogger('recruit');
@@ -306,9 +305,8 @@ async function sendRegularMatch(
         }
 
         // 募集リスト更新
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const sticky = await availableRecruitString(guild, recruitChannel.id, RecruitType.RegularRecruit);
-            await sendStickyMessage(guild, recruitChannel.id, sticky);
+        if (recruitChannel.isTextBased()) {
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: recruitChannel.id } });
         }
 
         // 15秒後に削除ボタンを消す
@@ -350,15 +348,7 @@ async function sendRegularMatch(
             reservedChannel.permissionOverwrites.delete(hostMember.user, 'UnLock Voice Channel');
         }
 
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-            const helpEmbed = getCommandHelpEmbed(recruitChannel.name);
-            await sendStickyMessage(guild, recruitChannel.id, {
-                content: content,
-                embeds: [helpEmbed],
-                components: [createNewRecruitButton(recruitChannel.name)],
-            });
-        }
+        await sendCloseEmbedSticky(guild, recruitChannel);
     } catch (error) {
         logger.error(error);
     }

--- a/src/app/feat-recruit/interactions/commands/regular_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/regular_recruit.ts
@@ -243,6 +243,7 @@ async function sendRegularMatch(
         // DBに募集情報を登録
         await RecruitService.registerRecruit(
             guild.id,
+            recruitChannel.id,
             image1Message.id,
             hostMember.id,
             recruitNum,

--- a/src/app/feat-recruit/interactions/commands/salmon_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/salmon_recruit.ts
@@ -1,12 +1,4 @@
-import {
-    AttachmentBuilder,
-    BaseGuildTextChannel,
-    ChatInputCommandInteraction,
-    GuildMember,
-    PermissionsBitField,
-    User,
-    VoiceChannel,
-} from 'discord.js';
+import { AttachmentBuilder, ChatInputCommandInteraction, GuildMember, PermissionsBitField, User, VoiceChannel } from 'discord.js';
 
 import { Participant } from '../../../../db/model/participant';
 import { RecruitType } from '../../../../db/model/recruit';
@@ -22,7 +14,7 @@ import { recruitActionRow, recruitDeleteButton, unlockChannelButton } from '../.
 import { recruitBigRunCanvas, ruleBigRunCanvas } from '../../canvases/big_run_canvas';
 import { RecruitOpCode } from '../../canvases/regenerate_canvas';
 import { recruitSalmonCanvas, ruleSalmonCanvas } from '../../canvases/salmon_canvas';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 
 const logger = log4js_obj.getLogger('recruit');
 
@@ -316,9 +308,8 @@ async function sendSalmonRun(
         }
 
         // 募集リスト更新
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const sticky = await availableRecruitString(guild, recruitChannel.id, RecruitType.SalmonRecruit);
-            await sendStickyMessage(guild, recruitChannel.id, sticky);
+        if (recruitChannel.isTextBased()) {
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: recruitChannel.id } });
         }
 
         // 15秒後に削除ボタンを消す

--- a/src/app/feat-recruit/interactions/commands/salmon_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/salmon_recruit.ts
@@ -255,7 +255,16 @@ async function sendSalmonRun(
         });
 
         // DBに募集情報を登録
-        await RecruitService.registerRecruit(guild.id, image1Message.id, hostMember.id, recruitNum, condition, channelName, type);
+        await RecruitService.registerRecruit(
+            guild.id,
+            recruitChannel.id,
+            image1Message.id,
+            hostMember.id,
+            recruitNum,
+            condition,
+            channelName,
+            type,
+        );
 
         // DBに参加者情報を登録
         await ParticipantService.registerParticipantFromObj(image1Message.id, hostPt);

--- a/src/app/feat-recruit/interactions/commands/salmon_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/salmon_recruit.ts
@@ -15,6 +15,7 @@ import { recruitBigRunCanvas, ruleBigRunCanvas } from '../../canvases/big_run_ca
 import { RecruitOpCode } from '../../canvases/regenerate_canvas';
 import { recruitSalmonCanvas, ruleSalmonCanvas } from '../../canvases/salmon_canvas';
 import { sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
+import { getMemberMentions } from '../buttons/other_events';
 
 const logger = log4js_obj.getLogger('recruit');
 
@@ -269,7 +270,7 @@ async function sendSalmonRun(
 
         const image2Message = await recruitChannel.send({ files: [rule] });
         const sentMessage = await recruitChannel.send({
-            content: mention + ' ボタンを押して参加表明するでし！',
+            content: mention + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
         });
 
         // 募集文を削除してもボタンが動くように、bot投稿メッセージのメッセージIDでボタン作る

--- a/src/app/feat-recruit/interactions/modals/anarchy_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/anarchy_recruit_modal.ts
@@ -144,7 +144,7 @@ export async function sendAnarchyMatch(
 
         const image2Message = await recruitChannel.send({ files: [rule] });
         const buttonMessage = await recruitChannel.send({
-            content: mention + ' ボタンを押して参加表明するでし！',
+            content: mention + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
         });
 
         buttonMessage.edit({ components: [recruitActionRow(image1Message)] });
@@ -179,7 +179,7 @@ export async function sendAnarchyMatch(
         }
 
         const participants = await ParticipantService.getAllParticipants(guild.id, image1Message.id);
-        const memberList = getMemberMentions(recruitData[0], participants);
+        const memberList = getMemberMentions(recruitData[0].recruitNum, participants);
         const hostMention = `<@${member.userId}>`;
 
         await regenerateCanvas(guild, recruitChannel.id, image1Message.id, RecruitOpCode.close);

--- a/src/app/feat-recruit/interactions/modals/anarchy_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/anarchy_recruit_modal.ts
@@ -1,4 +1,4 @@
-import { AttachmentBuilder, BaseGuildTextChannel, ModalSubmitInteraction } from 'discord.js';
+import { AttachmentBuilder, ModalSubmitInteraction } from 'discord.js';
 
 import { placeHold } from '../../../../constant';
 import { Member } from '../../../../db/model/member';
@@ -9,11 +9,11 @@ import { RecruitService } from '../../../../db/recruit_service';
 import { log4js_obj } from '../../../../log4js_settings';
 import { setButtonDisable } from '../../../common/button_components';
 import { searchMessageById } from '../../../common/manager/message_manager';
-import { assertExistCheck, exists, getCommandHelpEmbed, sleep } from '../../../common/others';
-import { createNewRecruitButton, recruitActionRow, recruitDeleteButton } from '../../buttons/create_recruit_buttons';
+import { assertExistCheck, exists, sleep } from '../../../common/others';
+import { recruitActionRow, recruitDeleteButton } from '../../buttons/create_recruit_buttons';
 import { recruitAnarchyCanvas, ruleAnarchyCanvas } from '../../canvases/anarchy_canvas';
 import { RecruitOpCode, regenerateCanvas } from '../../canvases/regenerate_canvas';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { sendCloseEmbedSticky, sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 import { getMemberMentions } from '../buttons/other_events';
 
 const logger = log4js_obj.getLogger('recruit');
@@ -158,9 +158,8 @@ export async function sendAnarchyMatch(
         });
 
         // 募集リスト更新
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const sticky = await availableRecruitString(guild, recruitChannel.id, RecruitType.AnarchyRecruit);
-            await sendStickyMessage(guild, recruitChannel.id, sticky);
+        if (recruitChannel.isTextBased()) {
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: recruitChannel.id } });
         }
 
         // 15秒後に削除ボタンを消す
@@ -194,15 +193,7 @@ export async function sendAnarchyMatch(
             components: setButtonDisable(buttonMessage),
         });
 
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-            const helpEmbed = getCommandHelpEmbed(recruitChannel.name);
-            await sendStickyMessage(guild, recruitChannel.id, {
-                content: content,
-                embeds: [helpEmbed],
-                components: [createNewRecruitButton(recruitChannel.name)],
-            });
-        }
+        await sendCloseEmbedSticky(guild, recruitChannel);
     } catch (error) {
         logger.error(error);
     }

--- a/src/app/feat-recruit/interactions/modals/anarchy_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/anarchy_recruit_modal.ts
@@ -123,6 +123,7 @@ export async function sendAnarchyMatch(
         // DBに募集情報を登録
         await RecruitService.registerRecruit(
             guild.id,
+            recruitChannel.id,
             image1Message.id,
             member.userId,
             recruitNum,

--- a/src/app/feat-recruit/interactions/modals/event_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/event_recruit_modal.ts
@@ -76,6 +76,7 @@ export async function sendEventMatch(
         // DBに募集情報を登録
         await RecruitService.registerRecruit(
             guild.id,
+            recruitChannel.id,
             image1Message.id,
             member.userId,
             recruitNum,

--- a/src/app/feat-recruit/interactions/modals/event_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/event_recruit_modal.ts
@@ -96,7 +96,7 @@ export async function sendEventMatch(
 
         const image2Message = await recruitChannel.send({ files: [rule] });
         const buttonMessage = await recruitChannel.send({
-            content: mention + ' ボタンを押して参加表明するでし！',
+            content: mention + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
         });
 
         buttonMessage.edit({ components: [recruitActionRow(image1Message)] });
@@ -131,7 +131,7 @@ export async function sendEventMatch(
         }
 
         const participants = await ParticipantService.getAllParticipants(guild.id, image1Message.id);
-        const memberList = getMemberMentions(recruitData[0], participants);
+        const memberList = getMemberMentions(recruitData[0].recruitNum, participants);
         const hostMention = `<@${member.userId}>`;
 
         await regenerateCanvas(guild, recruitChannel.id, image1Message.id, RecruitOpCode.close);

--- a/src/app/feat-recruit/interactions/modals/event_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/event_recruit_modal.ts
@@ -1,4 +1,4 @@
-import { AttachmentBuilder, BaseGuildTextChannel, ModalSubmitInteraction } from 'discord.js';
+import { AttachmentBuilder, ModalSubmitInteraction } from 'discord.js';
 
 import { Member } from '../../../../db/model/member';
 import { Participant } from '../../../../db/model/participant';
@@ -9,11 +9,11 @@ import { log4js_obj } from '../../../../log4js_settings';
 import { EventMatchInfo } from '../../../common/apis/splatoon3_ink';
 import { setButtonDisable } from '../../../common/button_components';
 import { searchMessageById } from '../../../common/manager/message_manager';
-import { assertExistCheck, exists, getCommandHelpEmbed, sleep } from '../../../common/others';
-import { createNewRecruitButton, recruitActionRow, recruitDeleteButton } from '../../buttons/create_recruit_buttons';
+import { assertExistCheck, exists, sleep } from '../../../common/others';
+import { recruitActionRow, recruitDeleteButton } from '../../buttons/create_recruit_buttons';
 import { recruitEventCanvas, ruleEventCanvas } from '../../canvases/event_canvas';
 import { RecruitOpCode, regenerateCanvas } from '../../canvases/regenerate_canvas';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { sendCloseEmbedSticky, sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 import { getMemberMentions } from '../buttons/other_events';
 
 const logger = log4js_obj.getLogger('recruit');
@@ -110,9 +110,8 @@ export async function sendEventMatch(
         });
 
         // 募集リスト更新
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const sticky = await availableRecruitString(guild, recruitChannel.id, RecruitType.AnarchyRecruit);
-            await sendStickyMessage(guild, recruitChannel.id, sticky);
+        if (recruitChannel.isTextBased()) {
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: recruitChannel.id } });
         }
 
         // 15秒後に削除ボタンを消す
@@ -146,15 +145,7 @@ export async function sendEventMatch(
             components: setButtonDisable(buttonMessage),
         });
 
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-            const helpEmbed = getCommandHelpEmbed(recruitChannel.name);
-            await sendStickyMessage(guild, recruitChannel.id, {
-                content: content,
-                embeds: [helpEmbed],
-                components: [createNewRecruitButton(recruitChannel.name)],
-            });
-        }
+        await sendCloseEmbedSticky(guild, recruitChannel);
     } catch (error) {
         logger.error(error);
     }

--- a/src/app/feat-recruit/interactions/modals/fes_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/fes_recruit_modal.ts
@@ -91,6 +91,7 @@ export async function sendFesMatch(
         // DBに募集情報を登録
         await RecruitService.registerRecruit(
             guild.id,
+            recruitChannel.id,
             image1Message.id,
             member.userId,
             recruitNum,

--- a/src/app/feat-recruit/interactions/modals/fes_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/fes_recruit_modal.ts
@@ -112,7 +112,7 @@ export async function sendFesMatch(
 
         const image2Message = await recruitChannel.send({ files: [rule] });
         const buttonMessage = await recruitChannel.send({
-            content: `<@&${mentionId}>` + ' ボタンを押して参加表明するでし！',
+            content: `<@&${mentionId}>` + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
         });
 
         buttonMessage.edit({ components: [recruitActionRow(image1Message)] });
@@ -149,7 +149,7 @@ export async function sendFesMatch(
         }
 
         const participants = await ParticipantService.getAllParticipants(guild.id, image1Message.id);
-        const memberList = getMemberMentions(recruitData[0], participants);
+        const memberList = getMemberMentions(recruitData[0].recruitNum, participants);
         const hostMention = `<@${member.userId}>`;
 
         await regenerateCanvas(guild, recruitChannel.id, image1Message.id, RecruitOpCode.close);

--- a/src/app/feat-recruit/interactions/modals/fes_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/fes_recruit_modal.ts
@@ -1,4 +1,4 @@
-import { AttachmentBuilder, BaseGuildTextChannel, ModalSubmitInteraction } from 'discord.js';
+import { AttachmentBuilder, ModalSubmitInteraction } from 'discord.js';
 
 import { Member } from '../../../../db/model/member';
 import { Participant } from '../../../../db/model/participant';
@@ -9,11 +9,11 @@ import { log4js_obj } from '../../../../log4js_settings';
 import { setButtonDisable } from '../../../common/button_components';
 import { searchMessageById } from '../../../common/manager/message_manager';
 import { searchRoleById, searchRoleIdByName } from '../../../common/manager/role_manager';
-import { assertExistCheck, exists, getCommandHelpEmbed, notExists, sleep } from '../../../common/others';
-import { createNewRecruitButton, recruitActionRow, recruitDeleteButton } from '../../buttons/create_recruit_buttons';
+import { assertExistCheck, exists, notExists, sleep } from '../../../common/others';
+import { recruitActionRow, recruitDeleteButton } from '../../buttons/create_recruit_buttons';
 import { recruitFesCanvas, ruleFesCanvas } from '../../canvases/fes_canvas';
 import { RecruitOpCode, regenerateCanvas } from '../../canvases/regenerate_canvas';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { sendCloseEmbedSticky, sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 import { getMemberMentions } from '../buttons/other_events';
 
 const logger = log4js_obj.getLogger('recruit');
@@ -128,9 +128,8 @@ export async function sendFesMatch(
         });
 
         // 募集リスト更新
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const sticky = await availableRecruitString(guild, recruitChannel.id, RecruitType.FestivalRecruit);
-            await sendStickyMessage(guild, recruitChannel.id, sticky);
+        if (recruitChannel.isTextBased()) {
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: recruitChannel.id } });
         }
 
         // 15秒後に削除ボタンを消す
@@ -164,15 +163,7 @@ export async function sendFesMatch(
             components: setButtonDisable(buttonMessage),
         });
 
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-            const helpEmbed = getCommandHelpEmbed(recruitChannel.name);
-            await sendStickyMessage(guild, recruitChannel.id, {
-                content: content,
-                embeds: [helpEmbed],
-                components: [createNewRecruitButton(recruitChannel.name)],
-            });
-        }
+        await sendCloseEmbedSticky(guild, recruitChannel);
     } catch (error) {
         logger.error(error);
     }

--- a/src/app/feat-recruit/interactions/modals/recruit_edit.ts
+++ b/src/app/feat-recruit/interactions/modals/recruit_edit.ts
@@ -5,10 +5,11 @@ import { ParticipantService } from '../../../../db/participants_service';
 import { RecruitService } from '../../../../db/recruit_service';
 import { log4js_obj } from '../../../../log4js_settings';
 import { assertExistCheck, notExists } from '../../../common/others';
+import { sendStickyMessage } from '../../../common/sticky_message';
 import { sendEditRecruitLog } from '../../../logs/modals/recruit_modal_log';
 import { RecruitOpCode, regenerateCanvas } from '../../canvases/regenerate_canvas';
 import { regenerateEmbed } from '../../embeds/regenerate_embed';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { availableRecruitString } from '../../sticky/recruit_sticky_messages';
 
 const logger = log4js_obj.getLogger('interaction');
 
@@ -72,7 +73,7 @@ export async function recruitEdit(interaction: ModalSubmitInteraction, params: U
         await sendEditRecruitLog(guild, oldRecruitData[0], newRecruitData[0], interaction.createdAt);
 
         if (interaction.channel instanceof BaseGuildTextChannel) {
-            const content = await availableRecruitString(guild, channelId, newRecruitData[0].recruitType);
+            const content = await availableRecruitString(guild, interaction.channel.id);
             await sendStickyMessage(guild, channelId, content);
         }
 

--- a/src/app/feat-recruit/interactions/modals/regular_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/regular_recruit_modal.ts
@@ -110,7 +110,7 @@ export async function sendRegularMatch(
 
         const image2Message = await recruitChannel.send({ files: [rule] });
         const buttonMessage = await recruitChannel.send({
-            content: mention + ' ボタンを押して参加表明するでし！',
+            content: mention + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
         });
 
         buttonMessage.edit({ components: [recruitActionRow(image1Message)] });
@@ -145,7 +145,7 @@ export async function sendRegularMatch(
         }
 
         const participants = await ParticipantService.getAllParticipants(guild.id, image1Message.id);
-        const memberList = getMemberMentions(recruitData[0], participants);
+        const memberList = getMemberMentions(recruitData[0].recruitNum, participants);
         const hostMention = `<@${member.userId}>`;
 
         await regenerateCanvas(guild, recruitChannel.id, image1Message.id, RecruitOpCode.close);

--- a/src/app/feat-recruit/interactions/modals/regular_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/regular_recruit_modal.ts
@@ -87,6 +87,7 @@ export async function sendRegularMatch(
         // DBに募集情報を登録
         await RecruitService.registerRecruit(
             guild.id,
+            recruitChannel.id,
             image1Message.id,
             member.userId,
             recruitNum,

--- a/src/app/feat-recruit/interactions/modals/regular_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/regular_recruit_modal.ts
@@ -1,4 +1,4 @@
-import { AttachmentBuilder, BaseGuildTextChannel, ModalSubmitInteraction } from 'discord.js';
+import { AttachmentBuilder, ModalSubmitInteraction } from 'discord.js';
 
 import { Member } from '../../../../db/model/member';
 import { Participant } from '../../../../db/model/participant';
@@ -8,11 +8,11 @@ import { RecruitService } from '../../../../db/recruit_service';
 import { log4js_obj } from '../../../../log4js_settings';
 import { setButtonDisable } from '../../../common/button_components';
 import { searchMessageById } from '../../../common/manager/message_manager';
-import { assertExistCheck, exists, getCommandHelpEmbed, sleep } from '../../../common/others';
-import { createNewRecruitButton, recruitActionRow, recruitDeleteButton } from '../../buttons/create_recruit_buttons';
+import { assertExistCheck, exists, sleep } from '../../../common/others';
+import { recruitActionRow, recruitDeleteButton } from '../../buttons/create_recruit_buttons';
 import { RecruitOpCode, regenerateCanvas } from '../../canvases/regenerate_canvas';
 import { recruitRegularCanvas, ruleRegularCanvas } from '../../canvases/regular_canvas';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { sendCloseEmbedSticky, sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 import { getMemberMentions } from '../buttons/other_events';
 
 const logger = log4js_obj.getLogger('recruit');
@@ -124,9 +124,8 @@ export async function sendRegularMatch(
         });
 
         // 募集リスト更新
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const sticky = await availableRecruitString(guild, recruitChannel.id, RecruitType.RegularRecruit);
-            await sendStickyMessage(guild, recruitChannel.id, sticky);
+        if (recruitChannel.isTextBased()) {
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: recruitChannel.id } });
         }
 
         // 15秒後に削除ボタンを消す
@@ -160,15 +159,7 @@ export async function sendRegularMatch(
             components: setButtonDisable(buttonMessage),
         });
 
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const content = await availableRecruitString(guild, recruitChannel.id, recruitData[0].recruitType);
-            const helpEmbed = getCommandHelpEmbed(recruitChannel.name);
-            await sendStickyMessage(guild, recruitChannel.id, {
-                content: content,
-                embeds: [helpEmbed],
-                components: [createNewRecruitButton(recruitChannel.name)],
-            });
-        }
+        await sendCloseEmbedSticky(guild, recruitChannel);
     } catch (error) {
         logger.error(error);
     }

--- a/src/app/feat-recruit/interactions/modals/salmon_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/salmon_recruit_modal.ts
@@ -101,6 +101,7 @@ export async function sendSalmonRun(
         // DBに募集情報を登録
         await RecruitService.registerRecruit(
             guild.id,
+            recruitChannel.id,
             image1Message.id,
             member.userId,
             recruitNum,

--- a/src/app/feat-recruit/interactions/modals/salmon_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/salmon_recruit_modal.ts
@@ -14,6 +14,7 @@ import { recruitBigRunCanvas, ruleBigRunCanvas } from '../../canvases/big_run_ca
 import { RecruitOpCode } from '../../canvases/regenerate_canvas';
 import { recruitSalmonCanvas, ruleSalmonCanvas } from '../../canvases/salmon_canvas';
 import { sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
+import { getMemberMentions } from '../buttons/other_events';
 
 const logger = log4js_obj.getLogger('recruit');
 
@@ -121,7 +122,7 @@ export async function sendSalmonRun(
 
         const image2Message = await recruitChannel.send({ files: [rule] });
         const buttonMessage = await recruitChannel.send({
-            content: mention + ' ボタンを押して参加表明するでし！',
+            content: mention + ` ボタンを押して参加表明するでし！\n${getMemberMentions(recruitNum, [])}`,
         });
 
         buttonMessage.edit({ components: [recruitActionRow(image1Message)] });

--- a/src/app/feat-recruit/interactions/modals/salmon_recruit_modal.ts
+++ b/src/app/feat-recruit/interactions/modals/salmon_recruit_modal.ts
@@ -1,4 +1,4 @@
-import { AttachmentBuilder, BaseGuildTextChannel, ModalSubmitInteraction } from 'discord.js';
+import { AttachmentBuilder, ModalSubmitInteraction } from 'discord.js';
 
 import { Member } from '../../../../db/model/member';
 import { Participant } from '../../../../db/model/participant';
@@ -13,7 +13,7 @@ import { recruitActionRow, recruitDeleteButton } from '../../buttons/create_recr
 import { recruitBigRunCanvas, ruleBigRunCanvas } from '../../canvases/big_run_canvas';
 import { RecruitOpCode } from '../../canvases/regenerate_canvas';
 import { recruitSalmonCanvas, ruleSalmonCanvas } from '../../canvases/salmon_canvas';
-import { availableRecruitString, sendStickyMessage } from '../../sticky/recruit_sticky_messages';
+import { sendRecruitSticky } from '../../sticky/recruit_sticky_messages';
 
 const logger = log4js_obj.getLogger('recruit');
 
@@ -135,9 +135,8 @@ export async function sendSalmonRun(
         });
 
         // 募集リスト更新
-        if (recruitChannel instanceof BaseGuildTextChannel) {
-            const sticky = await availableRecruitString(guild, recruitChannel.id, RecruitType.SalmonRecruit);
-            await sendStickyMessage(guild, recruitChannel.id, sticky);
+        if (recruitChannel.isTextBased()) {
+            await sendRecruitSticky({ channelOpt: { guild: guild, channelId: recruitChannel.id } });
         }
 
         // 15秒後に削除ボタンを消す

--- a/src/app/feat-recruit/sticky/recruit_sticky_messages.ts
+++ b/src/app/feat-recruit/sticky/recruit_sticky_messages.ts
@@ -1,41 +1,61 @@
-import { Guild, Message, MessageCreateOptions, MessagePayload } from 'discord.js';
+import { Channel, Guild, Message } from 'discord.js';
 
-import { RecruitType } from '../../../db/model/recruit';
+import { Recruit, RecruitType } from '../../../db/model/recruit';
 import { ParticipantService } from '../../../db/participants_service';
 import { RecruitService } from '../../../db/recruit_service';
-import { StickyService } from '../../../db/sticky_service';
 import { log4js_obj } from '../../../log4js_settings';
-import { searchChannelById } from '../../common/manager/channel_manager';
 import { searchMessageById } from '../../common/manager/message_manager';
-import { assertExistCheck, exists } from '../../common/others';
+import { RequireOne, assertExistCheck, exists, getCommandHelpEmbed } from '../../common/others';
+import { sendStickyMessage } from '../../common/sticky_message';
+import { createNewRecruitButton } from '../buttons/create_recruit_buttons';
 
 const logger = log4js_obj.getLogger('message');
 
-export async function stickyChannelCheck(message: Message) {
-    try {
-        assertExistCheck(message.guild, 'guild');
+export type StickyOptions = RequireOne<{
+    message?: Message<true>;
+    channelOpt?: {
+        guild: Guild;
+        channelId: string;
+    };
+}>;
 
-        const guild = await message.guild.fetch();
-        const channelId = message.channelId;
+/**
+ * 募集用のSticky Messageを送信する
+ * @param {StickyOptions} stickyOptions StickyOptions
+ */
+export async function sendRecruitSticky(stickyOptions: StickyOptions) {
+    try {
+        let guild: Guild;
+        let channelId: string;
+        if (exists(stickyOptions.message)) {
+            guild = await stickyOptions.message.guild.fetch();
+            channelId = stickyOptions.message.channelId;
+        } else if (exists(stickyOptions.channelOpt)) {
+            guild = stickyOptions.channelOpt.guild;
+            channelId = stickyOptions.channelOpt.channelId;
+        } else {
+            throw new Error('Invalid sticky options');
+        }
+
         let content: string;
         if (channelId === process.env.CHANNEL_ID_RECRUIT_PRIVATE) {
-            content = await availableRecruitString(guild, channelId, RecruitType.PrivateRecruit);
+            content = await availableRecruitString(guild, channelId);
         } else if (channelId === process.env.CHANNEL_ID_RECRUIT_ANARCHY) {
-            content = await availableRecruitString(guild, channelId, RecruitType.AnarchyRecruit);
+            content = await availableRecruitString(guild, channelId);
         } else if (channelId === process.env.CHANNEL_ID_RECRUIT_REGULAR) {
-            content = await availableRecruitString(guild, channelId, RecruitType.RegularRecruit);
+            content = await availableRecruitString(guild, channelId);
         } else if (channelId === process.env.CHANNEL_ID_RECRUIT_EVENT) {
-            content = await availableRecruitString(guild, channelId, RecruitType.EventRecruit);
+            content = await availableRecruitString(guild, channelId);
         } else if (channelId === process.env.CHANNEL_ID_RECRUIT_SALMON) {
-            content = await availableRecruitString(guild, channelId, RecruitType.SalmonRecruit);
+            content = await availableRecruitString(guild, channelId);
         } else if (channelId === process.env.CHANNEL_ID_RECRUIT_OTHERGAMES) {
-            content = await availableRecruitString(guild, channelId, RecruitType.OtherGameRecruit);
+            content = await availableRecruitString(guild, channelId);
         } else if (channelId === process.env.CHANNEL_ID_RECRUIT_SHIVER) {
-            content = await availableRecruitString(guild, channelId, RecruitType.FestivalRecruit);
+            content = await availableRecruitString(guild, channelId);
         } else if (channelId === process.env.CHANNEL_ID_RECRUIT_FRYE) {
-            content = await availableRecruitString(guild, channelId, RecruitType.FestivalRecruit);
+            content = await availableRecruitString(guild, channelId);
         } else if (channelId === process.env.CHANNEL_ID_RECRUIT_BIGMAN) {
-            content = await availableRecruitString(guild, channelId, RecruitType.FestivalRecruit);
+            content = await availableRecruitString(guild, channelId);
         } else {
             return;
         }
@@ -46,34 +66,33 @@ export async function stickyChannelCheck(message: Message) {
     }
 }
 
-export async function availableRecruitString(guild: Guild, channelId: string, recruitType: number) {
-    let recruitData = await RecruitService.getRecruitsByRecruitType(guild.id, recruitType);
+export async function sendCloseEmbedSticky(guild: Guild, channel: Channel) {
+    if (channel.isTextBased() && !channel.isDMBased() && !channel.isThread() && !channel.isVoiceBased()) {
+        const content = await availableRecruitString(guild, channel.id);
+        const helpEmbed = getCommandHelpEmbed(channel.name);
+        await sendStickyMessage(guild, channel.id, {
+            content: content,
+            embeds: [helpEmbed],
+            components: [createNewRecruitButton(channel.name)],
+        });
+    }
+}
 
-    // プラベ募集のときもう一種類取り直して結合
-    if (recruitType === RecruitType.ButtonNotify) {
+export async function availableRecruitString(guild: Guild, channelId: string) {
+    let recruitData = await RecruitService.getRecruitsByChannelId(guild.id, channelId);
+
+    // チャンネルIDがプラベ募集チャンネルの場合は、フォーラムでのコマンド募集も含める
+    if (channelId === process.env.CHANNEL_ID_RECRUIT_PRIVATE) {
         const privateRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.PrivateRecruit);
-        recruitData = recruitData.concat(privateRecruitData);
-    } else if (recruitType === RecruitType.PrivateRecruit) {
         const buttonRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.ButtonNotify);
+        recruitData = privateRecruitData;
         recruitData = recruitData.concat(buttonRecruitData);
     }
 
-    // サーモン募集のとき複数種別を結合
-    if (recruitType === RecruitType.SalmonRecruit) {
-        const bigRunRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.BigRunRecruit);
-        const teamContestRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.TeamContestRecruit);
-        recruitData = recruitData.concat(bigRunRecruitData);
-        recruitData = recruitData.concat(teamContestRecruitData);
-    } else if (recruitType === RecruitType.BigRunRecruit) {
-        const salmonRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.SalmonRecruit);
-        const teamContestRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.TeamContestRecruit);
-        recruitData = recruitData.concat(salmonRecruitData);
-        recruitData = recruitData.concat(teamContestRecruitData);
-    } else if (recruitType === RecruitType.TeamContestRecruit) {
-        const salmonRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.SalmonRecruit);
-        const bigRunRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.BigRunRecruit);
-        recruitData = recruitData.concat(salmonRecruitData);
-        recruitData = recruitData.concat(bigRunRecruitData);
+    // チャンネルIDが別ゲー募集チャンネルの場合は、フォーラムでの別ゲー募集も含める
+    if (channelId === process.env.CHANNEL_ID_RECRUIT_OTHERGAMES) {
+        const otherGameRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.OtherGameRecruit);
+        recruitData = otherGameRecruitData;
     }
 
     recruitData.sort((x, y) => x.createdAt.getTime() - y.createdAt.getTime()); // 作成順でソート
@@ -88,7 +107,7 @@ export async function availableRecruitString(guild: Guild, channelId: string, re
                 applicantList.push(participant);
             }
         }
-        const message = await searchMessageById(guild, channelId, recruit.messageId);
+        const message = await searchMessageById(guild, recruit.channelId, recruit.messageId);
         const recruiter = participantsData[0];
         if (exists(message) && participantsData.length !== 0) {
             // 別チャンネルで同じタイプの募集をしているときmessage = nullになる
@@ -98,6 +117,9 @@ export async function availableRecruitString(guild: Guild, channelId: string, re
                 recruits = recruits + `\n\`${recruiter.displayName}\`: ${message.url} \`[${applicantList.length}\`]`;
             }
             count++;
+        } else {
+            await RecruitService.deleteRecruit(guild.id, recruit.messageId);
+            logger.warn(`recruit message is not found. record deleted. \n[guildId: ${guild.id}, messageId: ${recruit.messageId}]`);
         }
     }
 
@@ -111,21 +133,12 @@ export async function availableRecruitString(guild: Guild, channelId: string, re
     return result;
 }
 
-export async function sendStickyMessage(guild: Guild, channelId: string, content: string | MessagePayload | MessageCreateOptions) {
-    const lastStickyMsgId = await StickyService.getMessageId(guild.id, channelId);
-    if (lastStickyMsgId.length !== 0) {
-        const lastStickyMsg = await searchMessageById(guild, channelId, lastStickyMsgId[0]);
-        if (exists(lastStickyMsg)) {
-            try {
-                await lastStickyMsg.delete();
-            } catch (error) {
-                logger.warn(`last sticky message not found! [${lastStickyMsgId}]`);
-            }
-        }
-    }
-    const channel = await searchChannelById(guild, channelId);
-    if (exists(channel) && channel.isTextBased()) {
-        const stickyMessage = await channel.send(content);
-        await StickyService.registerMessageId(guild.id, channelId, stickyMessage.id);
+export function getStickyChannelId(recruit: Recruit) {
+    assertExistCheck(process.env.CHANNEL_ID_RECRUIT_PRIVATE, 'CHANNEL_ID_RECRUIT_PRIVATE');
+    assertExistCheck(process.env.CHANNEL_ID_RECRUIT_OTHERGAMES, 'CHANNEL_ID_RECRUIT_OTHERGAMES');
+    if (recruit.recruitType === RecruitType.PrivateRecruit) {
+        return process.env.CHANNEL_ID_RECRUIT_PRIVATE;
+    } else if (recruit.recruitType === RecruitType.OtherGameRecruit) {
+        return process.env.CHANNEL_ID_RECRUIT_OTHERGAMES;
     }
 }

--- a/src/app/feat-recruit/sticky/recruit_sticky_messages.ts
+++ b/src/app/feat-recruit/sticky/recruit_sticky_messages.ts
@@ -81,18 +81,12 @@ export async function sendCloseEmbedSticky(guild: Guild, channel: Channel) {
 export async function availableRecruitString(guild: Guild, channelId: string) {
     let recruitData = await RecruitService.getRecruitsByChannelId(guild.id, channelId);
 
-    // チャンネルIDがプラベ募集チャンネルの場合は、フォーラムでのコマンド募集も含める
     if (channelId === process.env.CHANNEL_ID_RECRUIT_PRIVATE) {
-        const privateRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.PrivateRecruit);
-        const buttonRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.ButtonNotify);
-        recruitData = privateRecruitData;
-        recruitData = recruitData.concat(buttonRecruitData);
-    }
-
-    // チャンネルIDが別ゲー募集チャンネルの場合は、フォーラムでの別ゲー募集も含める
-    if (channelId === process.env.CHANNEL_ID_RECRUIT_OTHERGAMES) {
-        const otherGameRecruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.OtherGameRecruit);
-        recruitData = otherGameRecruitData;
+        // チャンネルIDがプラベ募集チャンネルの場合は、フォーラムでのコマンド募集も含める
+        recruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.PrivateRecruit);
+    } else if (channelId === process.env.CHANNEL_ID_RECRUIT_OTHERGAMES) {
+        // チャンネルIDが別ゲー募集チャンネルの場合は、フォーラムでの別ゲー募集も含める
+        recruitData = await RecruitService.getRecruitsByRecruitType(guild.id, RecruitType.OtherGameRecruit);
     }
 
     recruitData.sort((x, y) => x.createdAt.getTime() - y.createdAt.getTime()); // 作成順でソート

--- a/src/app/handlers/command_handler.ts
+++ b/src/app/handlers/command_handler.ts
@@ -10,6 +10,7 @@ import { handleCreateRole, handleDeleteRole, handleAssignRole, handleUnassignRol
 import { variablesHandler } from '../feat-admin/environment_variables/variables_handler';
 import { createNewRecruitButton } from '../feat-recruit/buttons/create_recruit_buttons';
 import { anarchyRecruit } from '../feat-recruit/interactions/commands/anarchy_recruit';
+import { buttonRecruit } from '../feat-recruit/interactions/commands/button_recruit.js';
 import { eventRecruit } from '../feat-recruit/interactions/commands/event_recruit';
 import { fesRecruit } from '../feat-recruit/interactions/commands/fes_recruit';
 import { otherGameRecruit } from '../feat-recruit/interactions/commands/other_game_recruit';
@@ -60,6 +61,8 @@ export async function call(interaction: ChatInputCommandInteraction<CacheType>) 
         await regularRecruit(interaction);
     } else if (commandName === commandNames.other_game) {
         await otherGameRecruit(interaction);
+    } else if (commandName === commandNames.buttonRecruit) {
+        await buttonRecruit(interaction);
     } else if (commandName === commandNames.anarchy) {
         await anarchyRecruit(interaction);
     } else if (commandName === commandNames.private) {

--- a/src/app/handlers/message_handler.ts
+++ b/src/app/handlers/message_handler.ts
@@ -1,4 +1,4 @@
-import { PermissionsBitField, AttachmentBuilder } from 'discord.js';
+import { PermissionsBitField, AttachmentBuilder, Message } from 'discord.js';
 
 import { log4js_obj } from '../../log4js_settings';
 import { randomBool, isNotEmpty } from '../common/others';
@@ -7,12 +7,12 @@ import { dispand } from '../event/message_related/dispander';
 import { chatCountUp } from '../event/message_related/message_count';
 import { removeRookie } from '../event/rookie/remove_rookie';
 import { sendIntentionConfirmReply } from '../event/rookie/send_questionnaire';
-import { stickyChannelCheck } from '../feat-recruit/sticky/recruit_sticky_messages';
+import { sendRecruitSticky } from '../feat-recruit/sticky/recruit_sticky_messages';
 import { handleStageInfo } from '../feat-utils/splat3/stageinfo';
 import { play } from '../feat-utils/voice/tts/discordjs_voice';
 const logger = log4js_obj.getLogger('message');
 
-export async function call(message: $TSFixMe) {
+export async function call(message: Message<boolean>) {
     try {
         if (message.author.bot) {
             if (message.content.startsWith('/poll')) {
@@ -27,12 +27,11 @@ export async function call(message: $TSFixMe) {
             }
             return;
         } else {
+            if (!message.inGuild()) return;
             // ステージ情報デバッグ用
             if (message.content === 'stageinfo') {
                 const guild = await message.guild.fetch();
-                const member = await guild.members.fetch(message.author.id, {
-                    force: true, // intentsによってはGuildMemberUpdateが配信されないため
-                });
+                const member = await guild.members.fetch(message.author.id);
                 if (member.permissions.has(PermissionsBitField.Flags.ManageChannels)) {
                     handleStageInfo(message);
                 }
@@ -58,11 +57,11 @@ export async function call(message: $TSFixMe) {
         }
 
         await deleteToken(message);
-        dispand(message);
-        play(message);
+        await dispand(message);
+        await play(message);
         await chatCountUp(message);
-        await stickyChannelCheck(message);
-        removeRookie(message);
+        await sendRecruitSticky({ message: message });
+        await removeRookie(message);
     } catch (error) {
         logger.error(error);
     }

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -24,6 +24,7 @@ export const commandNames = {
     fesB: 'マンタロー陣営',
     fesC: 'ウツホ陣営',
     private: 'プラベ募集',
+    buttonRecruit: '募集ボタン',
     buttonEnabler: 'ボタンを有効化する',
     recuitEditor: '募集を編集',
     voiceChannelMention: 'ボイスメンション',

--- a/src/db/model/recruit.ts
+++ b/src/db/model/recruit.ts
@@ -1,5 +1,6 @@
 export class Recruit {
     guildId: string;
+    channelId: string;
     messageId: string;
     authorId: string;
     recruitNum: number;
@@ -10,6 +11,7 @@ export class Recruit {
     createdAt: Date;
     constructor(
         guildId: string,
+        channelId: string,
         messageId: string,
         authorId: string,
         recruitNum: number,
@@ -20,6 +22,7 @@ export class Recruit {
         createdAt: string | Date,
     ) {
         this.guildId = guildId;
+        this.channelId = channelId;
         this.messageId = messageId;
         this.authorId = authorId;
         this.recruitNum = recruitNum;

--- a/src/db/model/recruit.ts
+++ b/src/db/model/recruit.ts
@@ -39,7 +39,7 @@ export class Recruit {
 }
 
 export const RecruitType = {
-    ButtonNotify: 0,
+    None: 0,
     PrivateRecruit: 1,
     RegularRecruit: 2,
     AnarchyRecruit: 3,

--- a/src/db/recruit_service.ts
+++ b/src/db/recruit_service.ts
@@ -22,11 +22,12 @@ export class RecruitService {
             DBCommon.init();
             await DBCommon.run(`CREATE TABLE IF NOT EXISTS recruit (
                                 guild_id text,
+                                channel_id text,
                                 message_id text,
                                 author_id text,
                                 recruit_num number,
                                 condition text,
-                                channel_name text,
+                                vc_name text,
                                 recruit_type number,
                                 option text,
                                 created_at text NOT NULL DEFAULT (DATETIME('now', 'localtime')),
@@ -40,19 +41,20 @@ export class RecruitService {
 
     static async registerRecruit(
         guildId: string,
+        channelId: string,
         messageId: string,
         authorId: string,
         recruitNum: number,
         condition: string,
-        channelName: string | null,
+        vcName: string | null,
         recruitType: number,
         option?: string | null,
     ) {
         try {
             DBCommon.init();
             await DBCommon.run(
-                `INSERT INTO recruit (guild_id, message_id, author_id, recruit_num, condition, channel_name, recruit_type, option) values ($1, $2, $3, $4, $5, $6, $7, $8)`,
-                [guildId, messageId, authorId, recruitNum, condition, channelName, recruitType, option],
+                `INSERT INTO recruit (guild_id, channel_id, message_id, author_id, recruit_num, condition, vc_name, recruit_type, option) values ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+                [guildId, channelId, messageId, authorId, recruitNum, condition, vcName, recruitType, option],
             );
             DBCommon.close();
         } catch (err) {
@@ -100,11 +102,12 @@ export class RecruitService {
             recruits.push(
                 new Recruit(
                     results[i].guild_id,
+                    results[i].channel_id,
                     results[i].message_id,
                     results[i].author_id,
                     results[i].recruit_num,
                     results[i].condition,
-                    results[i].channel_name,
+                    results[i].vc_name,
                     results[i].recruit_type,
                     results[i].option,
                     results[i].created_at,
@@ -124,11 +127,12 @@ export class RecruitService {
             recruits.push(
                 new Recruit(
                     results[i].guild_id,
+                    results[i].channel_id,
                     results[i].message_id,
                     results[i].author_id,
                     results[i].recruit_num,
                     results[i].condition,
-                    results[i].channel_name,
+                    results[i].vc_name,
                     results[i].recruit_type,
                     results[i].option,
                     results[i].created_at,

--- a/src/db/recruit_service.ts
+++ b/src/db/recruit_service.ts
@@ -141,4 +141,29 @@ export class RecruitService {
         }
         return recruits;
     }
+
+    static async getRecruitsByChannelId(guildId: string, channelId: string) {
+        const db = DBCommon.open();
+        db.all = util.promisify(db.all);
+        const results = await db.all(`SELECT * FROM recruit WHERE guild_id = ${guildId} AND channel_id = ${channelId}`);
+        DBCommon.close();
+        const recruits: Recruit[] = [];
+        for (let i = 0; i < results.length; i++) {
+            recruits.push(
+                new Recruit(
+                    results[i].guild_id,
+                    results[i].channel_id,
+                    results[i].message_id,
+                    results[i].author_id,
+                    results[i].recruit_num,
+                    results[i].condition,
+                    results[i].vc_name,
+                    results[i].recruit_type,
+                    results[i].option,
+                    results[i].created_at,
+                ),
+            );
+        }
+        return recruits;
+    }
 }

--- a/src/register.ts
+++ b/src/register.ts
@@ -708,7 +708,7 @@ const privateMatch = new SlashCommandBuilder()
     .setDescription('プラベ募集コマンド')
     .addSubcommand((subcommand: SlashCommandSubcommandBuilder) =>
         subcommand
-            .setName('recruit')
+            .setName('private')
             .setDescription('開始時刻や人数などを細かく設定できます。通常はこちらを使ってください。')
             .addStringOption((option: SlashCommandStringOption) =>
                 option.setName('開始時刻').setDescription('何時から始める？例: 21:00').setRequired(true),
@@ -725,11 +725,6 @@ const privateMatch = new SlashCommandBuilder()
             .addStringOption((option: SlashCommandStringOption) =>
                 option.setName('ヘヤタテurl').setDescription('イカリング3のヘヤタテURLがある場合はこちらに入力してください'),
             ),
-    )
-    .addSubcommand((subcommand: SlashCommandSubcommandBuilder) =>
-        subcommand
-            .setName('button')
-            .setDescription('募集条件を通常のチャットで打ち込んだ後に通知と募集用のボタンを出せます。※@everyoneメンションを使用します。'),
     )
     .setDMPermission(false);
 
@@ -832,6 +827,19 @@ const otherGame = new SlashCommandBuilder()
     )
     .setDMPermission(false);
 
+const buttonRecruit = new SlashCommandBuilder()
+    .setName(commandNames.buttonRecruit)
+    .setDescription('募集ボタンを使って募集を建てます。')
+    .addSubcommand((subcommand: SlashCommandSubcommandBuilder) =>
+        subcommand
+            .setName('button')
+            .setDescription('募集条件を通常のチャットで打ち込んだ後に通知と募集用のボタンを出せます。')
+            .addIntegerOption((option: SlashCommandIntegerOption) =>
+                option.setName('募集人数').setDescription('募集人数を入力してください。').setRequired(false),
+            ),
+    )
+    .setDMPermission(false);
+
 const teamDivider = new SlashCommandBuilder()
     .setName(commandNames.team_divider)
     .setDescription('チーム分けを行います。')
@@ -919,6 +927,7 @@ const commands = [
     voice,
     closeRecruit,
     otherGame,
+    buttonRecruit,
     privateMatch,
     regularMatch,
     eventMatch,


### PR DESCRIPTION
- Sticky更新時に取得できないデータがあるとmessage missing出まくってたので修正
→ みつからなければ削除
Close #417
- `/プラベ募集 button`を個別コマンドとして切り出し
- 募集時に参加人数の状況表示
- スレッドで募集ボタンを使ったときにテキストの募集チャンネルのSticky更新

#### ※recruitテーブルカラム追加有り