### PR TITLE
fix: schedules.jsonの構造が変わったのに合わせて変更

### DIFF
--- a/src/app/common/apis/splatoon3.ink/splatoon3_ink.ts
+++ b/src/app/common/apis/splatoon3.ink/splatoon3_ink.ts
@@ -82,7 +82,7 @@ export async function updateSchedule() {
 export function checkFes(schedule: Sp3Schedule, num: number) {
     try {
         const festList = getFesList(schedule);
-        const festSetting = festList[num].festMatchSetting;
+        const festSetting = festList[num].festMatchSettings[1];
         return exists(festSetting);
     } catch (error) {
         void sendErrorLogs(logger, error);
@@ -632,7 +632,7 @@ export async function getFesData(schedule: Sp3Schedule, num: number) {
             return null;
         }
 
-        const festSetting = festList[num].festMatchSetting;
+        const festSetting = festList[num].festMatchSettings[1];
 
         const result: MatchInfo = {
             startTime: festList[num].startTime,

--- a/src/app/common/apis/splatoon3.ink/types/fest_properties.ts
+++ b/src/app/common/apis/splatoon3.ink/types/fest_properties.ts
@@ -1,31 +1,33 @@
 export type FestProperties = {
     startTime: string;
     endTime: string;
-    festMatchSetting: {
-        __isVsSetting: string;
-        __typename: string;
-        vsStages: [
-            {
-                vsStageId: number;
-                name: string;
-                image: {
-                    url: string;
-                };
-                id: string;
-            },
-            {
-                vsStageId: number;
-                name: string;
-                image: {
-                    url: string;
-                };
-                id: string;
-            },
-        ];
-        vsRule: {
-            name: string;
-            rule: string;
-            id: string;
-        };
-    } | null;
+    festMatchSettings: festMatchSetting[];
 };
+
+type festMatchSetting = {
+    __isVsSetting: string;
+    __typename: string;
+    vsStages: [
+        {
+            vsStageId: number;
+            name: string;
+            image: {
+                url: string;
+            };
+            id: string;
+        },
+        {
+            vsStageId: number;
+            name: string;
+            image: {
+                url: string;
+            };
+            id: string;
+        },
+    ];
+    vsRule: {
+        name: string;
+        rule: string;
+        id: string;
+    };
+} | null;


### PR DESCRIPTION
bankara_propertiesとfest_propertiesプロパティを見比べる限り、bankaraMatchSettingsと同じ構造になった？のでフェスだけの話だと思ってます。
とりあえず募集ができない障害が起きてるのでこれでいきます。