### PR TITLE
chore: Prismaクライアントのバージョンを本体と同じに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@discordjs/opus": "0.9.0",
     "@discordjs/voice": "0.16.0",
-    "@prisma/client": "^5.1.0",
+    "@prisma/client": "^5.3.1",
     "@types/sqlite3": "^3.1.8",
     "axios": "^1.4.0",
     "canvas": "^2.9.1",


### PR DESCRIPTION
- `5.3.1`で統一