### PR TITLE
feat: 参加の返信をある程度省略するボタンを作成

### DIFF
--- a/src/app/constant/button_id.ts
+++ b/src/app/constant/button_id.ts
@@ -42,6 +42,8 @@ export const RecruitParam = {
     CancelNotify: 'ncr',
     CloseNotify: 'nclose',
     NewModalRecruit: 'newr',
+    Approve: 'apr',
+    Reject: 'rej',
 } as const;
 export type RecruitParam = ObjectValueList<typeof RecruitParam>;
 export function isRecruitParam(value: string): value is RecruitParam {

--- a/src/app/feat-recruit/buttons/create_join_request_buttons.ts
+++ b/src/app/feat-recruit/buttons/create_join_request_buttons.ts
@@ -1,0 +1,36 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+
+import { RecruitParam } from '../../constant/button_id';
+
+export function joinRequestConfirmButtons(
+    recruitId: string,
+    memberListMessageId: string,
+    participantId: string,
+) {
+    const approvalParams = new URLSearchParams();
+    approvalParams.append('d', RecruitParam.Approve);
+    approvalParams.append('rid', recruitId);
+    approvalParams.append('mid', memberListMessageId);
+    approvalParams.append('pid', participantId);
+
+    const rejectParams = new URLSearchParams();
+    rejectParams.append('d', RecruitParam.Reject);
+    rejectParams.append('rid', recruitId);
+    rejectParams.append('mid', memberListMessageId);
+    rejectParams.append('pid', participantId);
+
+    const button = new ActionRowBuilder<ButtonBuilder>();
+    button.addComponents([
+        new ButtonBuilder()
+            .setCustomId(approvalParams.toString())
+            .setLabel('承認')
+            .setStyle(ButtonStyle.Success),
+    ]);
+    button.addComponents([
+        new ButtonBuilder()
+            .setCustomId(rejectParams.toString())
+            .setLabel('拒否')
+            .setStyle(ButtonStyle.Danger),
+    ]);
+    return button;
+}

--- a/src/app/feat-recruit/interactions/buttons/cancel_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/cancel_event.ts
@@ -1,6 +1,7 @@
 import { ButtonInteraction, EmbedBuilder } from 'discord.js';
 
-import { memberListMessage } from './other_events.js';
+import { memberListText } from './other_events.js';
+import { sendCancelNotifyToHost } from './send_notify_to_host.js';
 import { ParticipantService, ParticipantMember } from '../../../../db/participant_service.js';
 import { RecruitService } from '../../../../db/recruit_service.js';
 import { log4js_obj } from '../../../../log4js_settings.js';
@@ -12,12 +13,7 @@ import {
 import { searchChannelById } from '../../../common/manager/channel_manager.js';
 import { getGuildByInteraction } from '../../../common/manager/guild_manager.js';
 import { searchAPIMemberById, searchDBMemberById } from '../../../common/manager/member_manager.js';
-import {
-    assertExistCheck,
-    createMentionsFromIdList,
-    exists,
-    notExists,
-} from '../../../common/others.js';
+import { assertExistCheck, exists, notExists } from '../../../common/others.js';
 import { sendStickyMessage } from '../../../common/sticky_message.js';
 import { StickyKey } from '../../../constant/sticky_key.js';
 import { sendRecruitButtonLog } from '../../../logs/buttons/recruit_button_log.js';
@@ -148,13 +144,17 @@ export async function cancel(
                 await regenerateCanvas(guild, recruitChannel.id, image1MsgId, RecruitOpCode.open);
 
                 // ホストに通知
-                await interaction.message.reply({
-                    content:
-                        createMentionsFromIdList(confirmedMemberIDList).join(' ') +
-                        `\n<@${member.userId}>たんがキャンセルしたでし！`,
-                });
+                sendCancelNotifyToHost(
+                    interaction.message,
+                    guild,
+                    recruitChannel,
+                    member,
+                    recruiter,
+                    [recruiter.userId],
+                );
+
                 await interaction.editReply({
-                    content: await memberListMessage(interaction, image1MsgId),
+                    content: await memberListText(interaction, image1MsgId),
                     components: recoveryThinkingButton(interaction, 'キャンセル'),
                 });
 

--- a/src/app/feat-recruit/interactions/buttons/cancel_notify_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/cancel_notify_event.ts
@@ -1,6 +1,7 @@
 import { ButtonInteraction, EmbedBuilder } from 'discord.js';
 
-import { memberListMessage } from './other_events.js';
+import { memberListText } from './other_events.js';
+import { sendCancelNotifyToHost } from './send_notify_to_host.js';
 import { sendRecruitButtonLog } from '../.././../logs/buttons/recruit_button_log';
 import { ParticipantService, ParticipantMember } from '../../../../db/participant_service.js';
 import { RecruitService } from '../../../../db/recruit_service.js';
@@ -123,11 +124,17 @@ export async function cancelNotify(interaction: ButtonInteraction<'cached' | 'ra
                 await ParticipantService.deleteParticipant(guild.id, embedMessageId, member.userId);
 
                 // ホストに通知
-                await interaction.message.reply({
-                    content: `<@${recruiterId}> <@${member.userId}>たんがキャンセルしたでし！`,
-                });
+                sendCancelNotifyToHost(
+                    interaction.message,
+                    guild,
+                    recruitChannel,
+                    member,
+                    recruiter,
+                    [recruiter.userId],
+                );
+
                 await interaction.editReply({
-                    content: await memberListMessage(interaction, embedMessageId),
+                    content: await memberListText(interaction, embedMessageId),
                     components: recoveryThinkingButton(interaction, 'キャンセル'),
                 });
 

--- a/src/app/feat-recruit/interactions/buttons/confirm_join_request.ts
+++ b/src/app/feat-recruit/interactions/buttons/confirm_join_request.ts
@@ -1,0 +1,166 @@
+import { ButtonInteraction, EmbedBuilder } from 'discord.js';
+
+import { memberListText } from './other_events';
+import { ParticipantMember, ParticipantService } from '../../../../db/participant_service';
+import { RecruitService } from '../../../../db/recruit_service';
+import { log4js_obj } from '../../../../log4js_settings';
+import { recoveryThinkingButton, setButtonDisable } from '../../../common/button_components';
+import { searchChannelById } from '../../../common/manager/channel_manager';
+import { getGuildByInteraction } from '../../../common/manager/guild_manager';
+import { searchAPIMemberById, searchDBMemberById } from '../../../common/manager/member_manager';
+import { searchMessageById } from '../../../common/manager/message_manager';
+import { assertExistCheck, exists, notExists } from '../../../common/others';
+import { sendStickyMessage } from '../../../common/sticky_message';
+import { RecruitParam } from '../../../constant/button_id';
+import { StickyKey } from '../../../constant/sticky_key';
+import { sendErrorLogs } from '../../../logs/error/send_error_logs';
+import { RecruitOpCode, regenerateCanvas } from '../../canvases/regenerate_canvas';
+import { availableRecruitString } from '../../sticky/recruit_sticky_messages';
+
+const logger = log4js_obj.getLogger('recruitButton');
+
+export async function confirmJoinRequest(
+    interaction: ButtonInteraction<'cached' | 'raw'>,
+    params: URLSearchParams,
+) {
+    try {
+        await interaction.update({
+            components: setButtonDisable(interaction.message, interaction),
+        });
+        const guild = await getGuildByInteraction(interaction);
+        const recruitMessageId = params.get('rid') ?? '';
+
+        const recruitData = await RecruitService.getRecruit(guild.id, recruitMessageId);
+
+        // 既に募集が終了している場合
+        if (notExists(recruitData)) {
+            return await interaction.message.edit({ components: [] });
+        }
+
+        const recruitChannelId = recruitData.channelId;
+
+        const recruitMessage = await searchMessageById(guild, recruitChannelId, recruitMessageId);
+        if (notExists(recruitMessage)) {
+            await interaction.message.edit({ components: [] });
+            return await interaction.followUp('募集メッセージが存在しないでし!');
+        }
+        const recuritPram = params.get('d');
+
+        if (!(await hasPermission(guild.id, interaction.member.user.id, recruitMessageId))) {
+            await interaction.followUp({
+                content:
+                    '参加承認/拒否の操作は募集主か募集時に参加確定していた人しかできないでし！',
+                ephemeral: true,
+            });
+            if (recuritPram === RecruitParam.Approve) {
+                return await interaction.editReply({
+                    components: recoveryThinkingButton(interaction, '承認'),
+                });
+            } else if (recuritPram === RecruitParam.Reject) {
+                return await interaction.editReply({
+                    components: recoveryThinkingButton(interaction, '拒否'),
+                });
+            }
+        }
+
+        const embed = new EmbedBuilder();
+
+        const participantId = params.get('pid') ?? '';
+        const participant = await searchDBMemberById(guild, participantId);
+        assertExistCheck(participant, 'participant');
+        embed.setAuthor({
+            name: participant.displayName,
+            iconURL: participant.iconUrl,
+        });
+
+        let text = `<@${interaction.member.user.id}>たん`;
+
+        if (recuritPram === RecruitParam.Approve) {
+            embed.setTitle('参加承認');
+            embed.setColor('Green');
+            text += 'によって参加が承認されたでし！';
+            const recruit = await RecruitService.getRecruit(guild.id, recruitMessageId);
+            assertExistCheck(recruit, 'recruit');
+            const recruiter = await searchAPIMemberById(guild, recruit.authorId);
+            assertExistCheck(recruiter, 'recruiter');
+            if (exists(recruiter.voice.channel)) {
+                text += `<@${recruiter.id}>たんは<#${recruiter.voice.channel.id}>で通話中でし！\n別途開始時間やボイスチャンネルの指定がない場合はこのボイスチャンネルに参加するでし！`;
+            } else {
+                text += `開始時間や使用するボイスチャンネルについては募集主からの連絡を待つでし！`;
+            }
+            embed.setThumbnail(
+                'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/stamp/approval.png',
+            );
+        } else if (recuritPram === RecruitParam.Reject) {
+            embed.setTitle('参加拒否');
+            embed.setColor('Red');
+            text +=
+                'が参加を拒否したため、参加は自動的に取り下げられたでし！\n参加条件を見返してみるでし！';
+            embed.setThumbnail(
+                'https://raw.githubusercontent.com/shngmsw/ikabu/stg/images/stamp/reject.png',
+            );
+
+            // participantsテーブルから自分のデータのみ削除
+            await ParticipantService.deleteParticipant(guild.id, recruitMessageId, participantId);
+
+            await regenerateCanvas(guild, recruitChannelId, recruitMessageId, RecruitOpCode.open);
+
+            const memberListMessageId = params.get('mid') ?? '';
+            const memberListMessage = await searchMessageById(
+                guild,
+                recruitChannelId,
+                memberListMessageId,
+            );
+            assertExistCheck(memberListMessage, 'memberListMessage');
+            await memberListMessage.edit({
+                content: await memberListText(interaction, recruitMessageId),
+            });
+        }
+
+        embed.setDescription(text);
+
+        await recruitMessage.reply({ content: `<@${participantId}>`, embeds: [embed] });
+
+        const recruitChannel = await searchChannelById(guild, recruitChannelId);
+
+        if (exists(recruitChannel) && recruitChannel.isTextBased()) {
+            const content = await availableRecruitString(guild, recruitChannel.id);
+            await sendStickyMessage(guild, recruitChannelId, StickyKey.AvailableRecruit, content);
+        }
+
+        await interaction.message.edit({
+            components: [],
+        });
+    } catch (error) {
+        await sendErrorLogs(logger, error);
+        await interaction.message.edit({
+            components: [],
+        });
+        await interaction.channel?.send('なんかエラー出てるわ');
+        await interaction.channel?.send('手動で返信するでし！');
+    }
+}
+
+async function hasPermission(guildId: string, userId: string, messageId: string) {
+    const participantsData = await ParticipantService.getAllParticipants(guildId, messageId);
+
+    let recruiter = participantsData[0]; // 募集者
+    const recruiterId = recruiter.userId;
+    const attendeeList: ParticipantMember[] = []; // 募集時参加確定者リスト
+    for (const participant of participantsData) {
+        if (participant.userType === 0) {
+            recruiter = participant;
+        } else if (participant.userType === 1) {
+            attendeeList.push(participant);
+        }
+    }
+
+    // 募集者と募集時参加確定者のIDリスト
+    const confirmedMemberIDList = [];
+    confirmedMemberIDList.push(recruiterId);
+    for (const attendee of attendeeList) {
+        confirmedMemberIDList.push(attendee.userId);
+    }
+
+    return confirmedMemberIDList.includes(userId);
+}

--- a/src/app/feat-recruit/interactions/buttons/other_events.ts
+++ b/src/app/feat-recruit/interactions/buttons/other_events.ts
@@ -55,7 +55,7 @@ export function getMemberMentions(recruitNum: number, participants: ParticipantM
     return mentionString;
 }
 
-export async function memberListMessage(
+export async function memberListText(
     interaction: ButtonInteraction<'cached' | 'raw'>,
     messageId: string,
 ) {

--- a/src/app/feat-recruit/interactions/buttons/recruit_button_handler.ts
+++ b/src/app/feat-recruit/interactions/buttons/recruit_button_handler.ts
@@ -4,6 +4,7 @@ import { cancel } from './cancel_event';
 import { cancelNotify } from './cancel_notify_event';
 import { close } from './close_event';
 import { closeNotify } from './close_notify_event';
+import { confirmJoinRequest } from './confirm_join_request';
 import { del } from './delete_event';
 import { join } from './join_event';
 import { joinNotify } from './join_notify_event';
@@ -43,6 +44,10 @@ export async function recruitButtonHandler(
             break;
         case RecruitParam.NewModalRecruit:
             await handleCreateModal(interaction, params);
+            break;
+        case RecruitParam.Approve:
+        case RecruitParam.Reject:
+            await confirmJoinRequest(interaction, params);
             break;
         default:
             break;

--- a/src/app/feat-recruit/interactions/buttons/send_notify_to_host.ts
+++ b/src/app/feat-recruit/interactions/buttons/send_notify_to_host.ts
@@ -1,0 +1,133 @@
+import { Member } from '@prisma/client';
+import {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ChannelType,
+    ColorResolvable,
+    EmbedBuilder,
+    Guild,
+    GuildBasedChannel,
+    Message,
+    TextBasedChannel,
+} from 'discord.js';
+
+import { ParticipantMember } from '../../../../db/participant_service';
+import { log4js_obj } from '../../../../log4js_settings';
+import { searchChannelById } from '../../../common/manager/channel_manager';
+import { searchAPIMemberById } from '../../../common/manager/member_manager';
+import { searchMessageById } from '../../../common/manager/message_manager';
+import { createMentionsFromIdList, exists, sleep } from '../../../common/others';
+import { sendErrorLogs } from '../../../logs/error/send_error_logs';
+import { joinRequestConfirmButtons } from '../../buttons/create_join_request_buttons';
+import { messageLinkButtons } from '../../buttons/create_recruit_buttons';
+
+const logger = log4js_obj.getLogger('recruitButton');
+
+export function sendJoinNotifyToHost(
+    message: Message<true>,
+    recruitId: string,
+    guild: Guild,
+    recruitChannel: TextBasedChannel,
+    member: Member,
+    recruiter: ParticipantMember,
+    confirmedMemberIDList: string[],
+) {
+    const text = `${member.displayName}たんが参加表明したでし！`;
+    void sendNotifyToHost(
+        message,
+        text,
+        'Blurple',
+        guild,
+        recruitChannel,
+        member,
+        recruiter,
+        confirmedMemberIDList,
+        [joinRequestConfirmButtons(recruitId, message.id, member.userId)],
+    );
+}
+
+export function sendCancelNotifyToHost(
+    message: Message<true>,
+    guild: Guild,
+    recruitChannel: TextBasedChannel,
+    member: Member,
+    recruiter: ParticipantMember,
+    confirmedMemberIDList: string[],
+) {
+    const text = `${member.displayName}たんがキャンセルしたでし！`;
+    void sendNotifyToHost(
+        message,
+        text,
+        'Red',
+        guild,
+        recruitChannel,
+        member,
+        recruiter,
+        confirmedMemberIDList,
+        [],
+    );
+}
+
+async function sendNotifyToHost(
+    message: Message<true>,
+    text: string,
+    embedColor: ColorResolvable,
+    guild: Guild,
+    recruitChannel: TextBasedChannel,
+    member: Member,
+    recruiter: ParticipantMember,
+    confirmedMemberIDList: string[],
+    buttons: ActionRowBuilder<ButtonBuilder>[],
+) {
+    try {
+        const embed = new EmbedBuilder();
+        embed.setAuthor({
+            name: text,
+            iconURL: member.iconUrl,
+        });
+        embed.setColor(embedColor);
+
+        // ホストがVCにいるかチェックして、VCにいる場合はText in Voiceにメッセージ送信
+        const recruiterGuildMember = await searchAPIMemberById(guild, recruiter.userId);
+
+        let hostJoinedVC: GuildBasedChannel | null = null;
+
+        if (
+            exists(recruiterGuildMember) &&
+            exists(recruiterGuildMember.voice.channel) &&
+            recruiterGuildMember.voice.channel.type === ChannelType.GuildVoice
+        ) {
+            hostJoinedVC = await searchChannelById(guild, recruiterGuildMember.voice.channel.id);
+
+            if (exists(hostJoinedVC) && hostJoinedVC.isTextBased()) {
+                await hostJoinedVC.send({
+                    embeds: [embed],
+                    components: [messageLinkButtons(guild.id, recruitChannel.id, message.id)],
+                });
+            }
+        }
+
+        const notifyMessage = await message.reply({
+            content: createMentionsFromIdList(confirmedMemberIDList).join(' '),
+            embeds: [embed],
+            components: buttons,
+        });
+
+        await sleep(1800);
+        // 30分後に承認/拒否ボタンを削除
+        const checkNotifyMessage = await searchMessageById(
+            guild,
+            recruitChannel.id,
+            notifyMessage.id,
+        );
+        if (exists(checkNotifyMessage)) {
+            try {
+                await checkNotifyMessage.edit({ components: [] });
+            } catch (error) {
+                logger.warn('notify message was not found.');
+            }
+        }
+    } catch (error) {
+        await sendErrorLogs(logger, error);
+    }
+}

--- a/src/app/feat-recruit/interactions/buttons/send_notify_to_host.ts
+++ b/src/app/feat-recruit/interactions/buttons/send_notify_to_host.ts
@@ -113,7 +113,7 @@ async function sendNotifyToHost(
             components: buttons,
         });
 
-        await sleep(1800);
+        await sleep(30 * 60);
         // 30分後に承認/拒否ボタンを削除
         const checkNotifyMessage = await searchMessageById(
             guild,


### PR DESCRIPTION
募集参加時に参加OKかどうかを1ボタンで返信できる機能の追加
- 新たに募集用パラメータを2種追加

参加ボタン→参加通知メッセージ→承認・拒否に応じてメッセージ送信
拒否されたときは、自動的に参加取り下げ

30分後にボタンは消える(逆に〆ても消えない・〆た状態で押すと消える)

承認時はVCに募集主がいれば案内、いなけば待つように伝える