### PR TITLE
fix: 新入部員をDBに保存してなかったのを修正

### DIFF
--- a/src/app/common/manager/member_manager.ts
+++ b/src/app/common/manager/member_manager.ts
@@ -63,7 +63,9 @@ export async function searchDBMemberById(guild: Guild, userId: string): Promise<
         const guildMember = await searchAPIMemberById(guild, userId);
 
         if (notExists(guildMember)) {
-            logger.warn('member missing (ikabu DB) => member missing (Discord API)');
+            logger.warn(
+                `member missing (ikabu DB) => member missing (Discord API)\n [guildId: ${guild.id}, userId: ${userId}]`,
+            );
             return null;
         }
 
@@ -72,9 +74,14 @@ export async function searchDBMemberById(guild: Guild, userId: string): Promise<
         const newMember = await MemberService.saveMemberFromGuildMember(guildMember);
 
         if (exists(newMember)) {
-            logger.warn('member missing (ikabu DB) => member was registered successfully.');
+            logger.warn(
+                `member missing (ikabu DB) => member was registered successfully.\n [guildId: ${guild.id}, userId: ${userId}]`,
+            );
         } else {
-            await sendErrorLogs(logger, 'member missing (ikabu DB) => Failed to register.');
+            await sendErrorLogs(
+                logger,
+                `member missing (ikabu DB) => Failed to register.\n [guildId: ${guild.id}, userId: ${userId}]`,
+            );
             return null;
         }
 
@@ -84,16 +91,23 @@ export async function searchDBMemberById(guild: Guild, userId: string): Promise<
         const guildMember = await searchAPIMemberById(guild, userId);
 
         if (notExists(guildMember)) {
-            logger.warn('member Icon invalid => member missing (Discord API)');
+            logger.warn(
+                `member Icon invalid => member missing (Discord API)\n [guildId: ${guild.id}, userId: ${userId}]`,
+            );
             return null;
         }
 
         const newMember = await MemberService.saveMemberFromGuildMember(guildMember);
 
         if (exists(newMember)) {
-            logger.warn('member Icon invalid => Icon URL was updated successfully.');
+            logger.warn(
+                `member Icon invalid => Icon URL was updated successfully.\n [guildId: ${guild.id}, userId: ${userId}]`,
+            );
         } else {
-            await sendErrorLogs(logger, 'member Icon invalid => Failed to update Icon URL.');
+            await sendErrorLogs(
+                logger,
+                `member Icon invalid => Failed to update Icon URL.\n [guildId: ${guild.id}, userId: ${userId}]`,
+            );
             return null;
         }
 

--- a/src/app/common/manager/member_manager.ts
+++ b/src/app/common/manager/member_manager.ts
@@ -69,7 +69,7 @@ export async function searchDBMemberById(guild: Guild, userId: string): Promise<
 
         assertExistCheck(guildMember.joinedAt, 'joinedAt');
 
-        const newMember = await MemberService.setGuildMemberToDB(guildMember);
+        const newMember = await MemberService.saveMemberFromGuildMember(guildMember);
 
         if (exists(newMember)) {
             logger.warn('member missing (ikabu DB) => member was registered successfully.');
@@ -88,7 +88,7 @@ export async function searchDBMemberById(guild: Guild, userId: string): Promise<
             return null;
         }
 
-        const newMember = await MemberService.setGuildMemberToDB(guildMember);
+        const newMember = await MemberService.saveMemberFromGuildMember(guildMember);
 
         if (exists(newMember)) {
             logger.warn('member Icon invalid => Icon URL was updated successfully.');

--- a/src/app/common/manager/member_manager.ts
+++ b/src/app/common/manager/member_manager.ts
@@ -4,11 +4,9 @@ import { Guild, GuildMember, Interaction, Message } from 'discord.js';
 
 import { getGuildByInteraction } from './guild_manager';
 import { MemberService } from '../../../db/member_service';
-import { UniqueRoleService } from '../../../db/unique_role_service';
 import { log4js_obj } from '../../../log4js_settings';
-import { RoleKeySet } from '../../constant/role_key';
 import { sendErrorLogs } from '../../logs/error/send_error_logs';
-import { assertExistCheck, notExists } from '../others';
+import { assertExistCheck, exists, notExists } from '../others';
 
 const logger = log4js_obj.getLogger('MemberManager');
 
@@ -62,72 +60,46 @@ export async function searchDBMemberById(guild: Guild, userId: string): Promise<
 
     // membersテーブルにレコードがあるか確認
     if (notExists(member)) {
-        const memberRaw = await searchAPIMemberById(guild, userId);
+        const guildMember = await searchAPIMemberById(guild, userId);
 
-        if (notExists(memberRaw)) {
+        if (notExists(guildMember)) {
             logger.warn('member missing (ikabu DB) => member missing (Discord API)');
             return null;
         }
-        assertExistCheck(memberRaw.joinedAt, 'joinedAt');
 
-        const roleId = await UniqueRoleService.getRoleIdByKey(guild.id, RoleKeySet.Rookie.key);
-        let newMember: Member | null;
-        if (memberRaw.roles.cache.find((role) => role.id === roleId)) {
-            newMember = await MemberService.registerMember(
-                guild.id,
-                userId,
-                memberRaw.displayName,
-                memberRaw.displayAvatarURL().replace('.webp', '.png').replace('.webm', '.gif'),
-                memberRaw.joinedAt,
-                true,
-            );
+        assertExistCheck(guildMember.joinedAt, 'joinedAt');
+
+        const newMember = await MemberService.setGuildMemberToDB(guildMember);
+
+        if (exists(newMember)) {
+            logger.warn('member missing (ikabu DB) => member was registered successfully.');
         } else {
-            newMember = await MemberService.registerMember(
-                guild.id,
-                userId,
-                memberRaw.displayName,
-                memberRaw.displayAvatarURL().replace('.webp', '.png').replace('.webm', '.gif'),
-                memberRaw.joinedAt,
-                false,
-            );
+            await sendErrorLogs(logger, 'member missing (ikabu DB) => Failed to register.');
+            return null;
         }
 
-        if (notExists(newMember)) {
-            await sendErrorLogs(logger, 'Failed to register member.');
+        return newMember;
+    } else if (await isUrlValid(member.iconUrl)) {
+        // 画像URLが無効な場合
+        const guildMember = await searchAPIMemberById(guild, userId);
+
+        if (notExists(guildMember)) {
+            logger.warn('member Icon invalid => member missing (Discord API)');
+            return null;
+        }
+
+        const newMember = await MemberService.setGuildMemberToDB(guildMember);
+
+        if (exists(newMember)) {
+            logger.warn('member Icon invalid => Icon URL was updated successfully.');
+        } else {
+            await sendErrorLogs(logger, 'member Icon invalid => Failed to update Icon URL.');
             return null;
         }
 
         return newMember;
     } else {
-        if (await isUrlValid(member.iconUrl)) {
-            return member;
-        } else {
-            // 画像URLが無効な場合
-            const memberRaw = await searchAPIMemberById(guild, userId);
-
-            if (notExists(memberRaw)) {
-                logger.warn('member Icon invalid => member missing (Discord API)');
-                return null;
-            }
-
-            const newMember: Member = {
-                guildId: guild.id,
-                userId: userId,
-                displayName: memberRaw.displayName,
-                iconUrl: memberRaw
-                    .displayAvatarURL()
-                    .replace('.webp', '.png')
-                    .replace('.webm', '.gif'),
-                joinedAt: member.joinedAt,
-                isRookie: member.isRookie,
-            };
-
-            await MemberService.updateMember(newMember);
-
-            logger.warn('member Icon invalid => Icon URL was updated successfully.');
-
-            return newMember;
-        }
+        return member;
     }
 }
 

--- a/src/app/event/rookie/set_rookie.ts
+++ b/src/app/event/rookie/set_rookie.ts
@@ -84,7 +84,7 @@ export async function guildMemberAddEvent(newMember: GuildMember) {
 
             if (exists(storedMember)) {
                 // 退部していた部員のプロフィール更新()
-                await MemberService.setGuildMemberToDB(guildMember, storedMember.isRookie);
+                await MemberService.saveMemberFromGuildMember(guildMember, storedMember.isRookie);
 
                 if (storedMember.isRookie) {
                     await setRookieRole(guild.id, userId, beginnerRole);
@@ -96,7 +96,7 @@ export async function guildMemberAddEvent(newMember: GuildMember) {
                 }
             } else {
                 // 新入部員の情報を登録
-                await MemberService.setGuildMemberToDB(guildMember, true);
+                await MemberService.saveMemberFromGuildMember(guildMember, true);
 
                 await sleep(60 * 10);
                 await setRookieRole(guild.id, userId, beginnerRole);

--- a/src/app/event/rookie/set_rookie.ts
+++ b/src/app/event/rookie/set_rookie.ts
@@ -17,7 +17,7 @@ const logger = log4js_obj.getLogger('guildMemberAdd');
 export async function guildMemberAddEvent(newMember: GuildMember) {
     try {
         const guild = await newMember.guild.fetch();
-        const memberId = newMember.user.id;
+        const userId = newMember.user.id;
 
         const lobbyChannelId = await UniqueChannelService.getChannelIdByKey(
             guild.id,
@@ -44,7 +44,7 @@ export async function guildMemberAddEvent(newMember: GuildMember) {
             );
 
             welcomeMessage = await lobbyChannel.send(
-                `<@!${memberId}> たん、よろしくお願いします！\n` +
+                `<@!${userId}> たん、よろしくお願いします！\n` +
                     `最初の10分間は閲覧しかできません、その間に <#${ruleChannelId}> と <#${descriptionChannelId}> をよく読んでくださいね\n` +
                     `10分経ったら、書き込めるようになります。 <#${introductionChannelId}> で自己紹介も兼ねて自分のフレコを貼ってください\n\n` +
                     `${guild.name}のみんなが歓迎していますよ〜`,
@@ -75,17 +75,32 @@ export async function guildMemberAddEvent(newMember: GuildMember) {
         // 新入部員ロールが設定されているサーバーでは、新入部員ロールを付与する
         if (exists(beginnerRole)) {
             // membersテーブルにレコードがあるか確認
-            const storedMember = await MemberService.getMemberByUserId(guild.id, memberId);
+            const storedMember = await MemberService.getMemberByUserId(guild.id, userId);
+            const guildMember = await searchAPIMemberById(guild, userId);
+            if (notExists(guildMember)) {
+                await sendErrorLogs(logger, 'member missing (Discord API)');
+                return;
+            }
+
             if (exists(storedMember)) {
+                // 退部していた部員のプロフィール更新()
+                await MemberService.setGuildMemberToDB(guildMember, storedMember.isRookie);
+
                 if (storedMember.isRookie) {
-                    await setRookieRole(memberId, beginnerRole);
+                    await setRookieRole(guild.id, userId, beginnerRole);
                 }
+
                 // 出戻り勢の場合はリアクションを変える
                 if (exists(welcomeMessage)) {
                     await welcomeMessage.react('👌');
                 }
             } else {
-                await setRookieRole(memberId, beginnerRole);
+                // 新入部員の情報を登録
+                await MemberService.setGuildMemberToDB(guildMember, true);
+
+                await sleep(60 * 10);
+                await setRookieRole(guild.id, userId, beginnerRole);
+
                 if (exists(welcomeMessage)) {
                     await welcomeMessage.react('👍');
                 }
@@ -96,10 +111,10 @@ export async function guildMemberAddEvent(newMember: GuildMember) {
     }
 }
 
-async function setRookieRole(memberId: string, beginnerRole: Role) {
-    await sleep(600);
-    const member = await searchAPIMemberById(beginnerRole.guild, memberId);
+async function setRookieRole(guildId: string, userId: string, beginnerRole: Role) {
+    const member = await searchAPIMemberById(beginnerRole.guild, userId);
     if (exists(member)) {
         await assignRoleToMember(beginnerRole, member);
+        await MemberService.setRookieFlag(guildId, userId, true);
     }
 }

--- a/src/app/event/vctools_sticky/radio_request.ts
+++ b/src/app/event/vctools_sticky/radio_request.ts
@@ -20,7 +20,7 @@ export async function sendRadioRequest(interaction: ButtonInteraction<'cached' |
 
         if (notExists(channel) || !channel.isVoiceBased()) return;
 
-        assertExistCheck(sender, 'DBMember');
+        assertExistCheck(sender, 'storedMember');
 
         const members = channel.members;
 

--- a/src/app/handlers/message_handler.ts
+++ b/src/app/handlers/message_handler.ts
@@ -1,13 +1,10 @@
 import { AttachmentBuilder, Message, PermissionsBitField } from 'discord.js';
 
-import { MemberService } from '../../db/member_service';
 import { UniqueChannelService } from '../../db/unique_channel_service';
-import { UniqueRoleService } from '../../db/unique_role_service';
 import { log4js_obj } from '../../log4js_settings';
-import { searchAPIMemberById, searchDBMemberById } from '../common/manager/member_manager';
-import { randomBool, exists, notExists } from '../common/others';
+import { searchAPIMemberById } from '../common/manager/member_manager';
+import { randomBool, exists } from '../common/others';
 import { ChannelKeySet } from '../constant/channel_key';
-import { RoleKeySet } from '../constant/role_key';
 import { stageInfo } from '../event/cron/stageinfo';
 import { deleteToken } from '../event/message_related/delete_token';
 import { dispand } from '../event/message_related/dispander';
@@ -22,41 +19,6 @@ const logger = log4js_obj.getLogger('message');
 
 export async function call(message: Message<true>) {
     try {
-        if (message.content.startsWith('/rookie_set')) {
-            // 一時的に設定用コマンドを追加
-            // 次のメンテナンスで削除する
-            const guild = await message.guild.fetch();
-            const member = await searchAPIMemberById(guild, message.author.id);
-            if (
-                exists(member) &&
-                member.permissions.has(PermissionsBitField.Flags.ManageChannels)
-            ) {
-                const rookieRoleId = await UniqueRoleService.getRoleIdByKey(
-                    guild.id,
-                    RoleKeySet.Rookie.key,
-                );
-
-                if (notExists(rookieRoleId)) return;
-
-                const allMembers = await guild.members.fetch();
-                const membersNum = allMembers.size;
-                let count = 0;
-                const sentMessage = await message.channel.send(
-                    `新入部員を保存中でし！ \`${count}/${membersNum}\``,
-                );
-                allMembers.forEach(async (member) => {
-                    await searchDBMemberById(guild, member.id);
-                    if (member.roles.cache.find((role) => role.id === rookieRoleId)) {
-                        await MemberService.setRookieFlag(guild.id, member.id, true);
-                    } else {
-                        await MemberService.setRookieFlag(guild.id, member.id, false);
-                    }
-                    await sentMessage.edit(`新入部員を保存中でし！ \`${++count}/${membersNum}\``);
-                });
-                await sentMessage.edit('新入部員をDBに保存したでし！');
-            }
-        }
-
         if (message.author.bot) {
             if (message.content.startsWith('/poll')) {
                 if (message.author.username === 'ブキチ') {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -115,9 +115,12 @@ client.on('guildMemberRemove', async (member: GuildMember | PartialGuildMember) 
         let joinedAt = member.joinedAt;
         // joinedAtがnullだったらDBからとってくる
         if (notExists(joinedAt)) {
-            const dbMember = await MemberService.getMemberByUserId(member.guild.id, member.user.id);
-            if (exists(dbMember)) {
-                joinedAt = dbMember.joinedAt;
+            const storedMember = await MemberService.getMemberByUserId(
+                member.guild.id,
+                member.user.id,
+            );
+            if (exists(storedMember)) {
+                joinedAt = storedMember.joinedAt;
             }
         }
 

--- a/src/db/member_service.ts
+++ b/src/db/member_service.ts
@@ -11,41 +11,23 @@ import { log4js_obj } from '../log4js_settings';
 const logger = log4js_obj.getLogger('database');
 
 export class MemberService {
-    static async registerMemberObj(member: Member): Promise<Member | null> {
-        try {
-            return await prisma.member.upsert({
-                where: {
-                    guildId_userId: {
-                        guildId: member.guildId,
-                        userId: member.userId,
-                    },
-                },
-                update: {
-                    displayName: member.displayName,
-                    iconUrl: member.iconUrl,
-                },
-                create: {
-                    guildId: member.guildId,
-                    userId: member.userId,
-                    displayName: member.displayName,
-                    iconUrl: member.iconUrl,
-                    joinedAt: member.joinedAt,
-                    isRookie: true,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
-    }
-
-    static async registerMember(
+    /**
+     * GuildMemberオブジェクトをMemberテーブルに登録/更新 (項目: displayName, iconUrl, isRookie, (登録時: joinedAt))
+     * @param guildId Guild ID
+     * @param userId User ID
+     * @param displayName ユーザ名
+     * @param iconUrl アイコン画像URL
+     * @param joinedAt サーバ参加日時(登録時のみ)
+     * @param isRookie 新入部員フラグ
+     * @returns 登録/更新したMemberオブジェクト
+     */
+    static async saveMember(
         guildId: string,
         userId: string,
         displayName: string,
         iconUrl: string,
         joinedAt: Date,
-        isRookie?: boolean,
+        isRookie: boolean,
     ): Promise<Member | null> {
         try {
             return await prisma.member.upsert({
@@ -58,6 +40,7 @@ export class MemberService {
                 update: {
                     displayName: displayName,
                     iconUrl: iconUrl,
+                    isRookie: isRookie,
                 },
                 create: {
                     guildId: guildId,
@@ -65,7 +48,7 @@ export class MemberService {
                     displayName: displayName,
                     iconUrl: iconUrl,
                     joinedAt: joinedAt,
-                    isRookie: isRookie ?? true,
+                    isRookie: isRookie,
                 },
             });
         } catch (error) {
@@ -78,9 +61,9 @@ export class MemberService {
      * GuildMemberオブジェクトをMemberテーブルに登録/更新 (項目: displayName, iconUrl, isRookie, (登録時: joinedAt))
      * @param member GuildMember オブジェクト
      * @param isRookie isRookieをオーバーライドできます。省略すれば、新入部員ロールを持っているか確認します。
-     * @returns 登録後のMemberオブジェクト
+     * @returns 登録/更新したMemberオブジェクト
      */
-    static async setGuildMemberToDB(
+    static async saveMemberFromGuildMember(
         member: GuildMember,
         isRookie?: boolean,
     ): Promise<Member | null> {
@@ -135,27 +118,6 @@ export class MemberService {
         } catch (error) {
             await sendErrorLogs(logger, error);
             return null;
-        }
-    }
-
-    static async updateMember(member: Member) {
-        try {
-            return await prisma.member.update({
-                where: {
-                    guildId_userId: {
-                        guildId: member.guildId,
-                        userId: member.userId,
-                    },
-                },
-                data: {
-                    displayName: member.displayName,
-                    iconUrl: member.iconUrl,
-                    joinedAt: member.joinedAt,
-                    isRookie: member.isRookie,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
         }
     }
 


### PR DESCRIPTION
- もう使用しない一括DB登録コマンドの削除
- `searchDBMemberById`の新入部員ロールの有無確認部分をMemberService側で行うように変更
- `GuildMemberAdd`時にDBにMember保存してなかったのを修正
- `MemberUpdate`, `UserUpdate`の処理変更
- 変数名`dbMember`を`storedMember`に変更

`[[WARN] MemberManager] member Icon invalid => Icon URL was updated successfully.`
の警告が大量に出てたのでログの情報追加 (多分UserUpdateのときの処理がうまく動いてなかったっぽい？)
