### PR TITLE
fix: placehold.jpが503になるのでblankAvatar用の画像URLで代用

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -37,10 +37,12 @@ export const commandNames = {
 };
 export const modalRecruit = {
     placeHold:
-        'https://placehold.jp/22/4650bc/ffffff/150x150.png?text=%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E5%8B%9F%E9%9B%86%0A%E3%81%AA%E3%82%89%E8%A1%A8%E7%A4%BA%E5%8F%AF%E8%83%BD',
+        // 'https://placehold.jp/22/4650bc/ffffff/150x150.png?text=%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E5%8B%9F%E9%9B%86%0A%E3%81%AA%E3%82%89%E8%A1%A8%E7%A4%BA%E5%8F%AF%E8%83%BD',
+        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/blank_avatar.png',
 };
 
 export const placeHold = {
     error100x100:
-        'http://placehold.jp/15/4c4d57/ffffff/100x100.png?text=%E3%81%93%E3%81%93%E3%81%AB%E7%94%BB%E5%83%8F%E3%82%92%E8%B2%BC%E3%82%8A%E3%81%9F%E3%81%8B%E3%81%A3%E3%81%9F%E3%82%93%E3%81%A0%E3%81%8C%E3%80%81%E3%81%A9%E3%81%86%E3%82%84%E3%82%89%E3%82%A8%E3%83%A9%E3%83%BC%E3%81%BF%E3%81%9F%E3%81%84%E3%81%A0%E2%80%A6%E3%80%82',
+        // 'http://placehold.jp/15/4c4d57/ffffff/100x100.png?text=%E3%81%93%E3%81%93%E3%81%AB%E7%94%BB%E5%83%8F%E3%82%92%E8%B2%BC%E3%82%8A%E3%81%9F%E3%81%8B%E3%81%A3%E3%81%9F%E3%82%93%E3%81%A0%E3%81%8C%E3%80%81%E3%81%A9%E3%81%86%E3%82%84%E3%82%89%E3%82%A8%E3%83%A9%E3%83%BC%E3%81%BF%E3%81%9F%E3%81%84%E3%81%A0%E2%80%A6%E3%80%82',
+        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/blank_avatar.png',
 };


### PR DESCRIPTION
https://placehold.jp/ のAdvancedのうち、文字サイズやテキストをパラメータに含めると503エラーになる模様
とりあえずblankAvatarで使ってるURLに置き換えて応急処置します。