### PR TITLE
fix: 募集が〆っていても自動〆の処理が行われるのを修正

### DIFF
--- a/src/app/feat-recruit/common/auto_close.ts
+++ b/src/app/feat-recruit/common/auto_close.ts
@@ -8,6 +8,7 @@ import {
 import { ParticipantService } from '../../../db/participant_service';
 import { RecruitService } from '../../../db/recruit_service';
 import { setButtonDisable } from '../../common/button_components';
+import { notExists } from '../../common/others';
 import { regenerateCanvas, RecruitOpCode } from '../canvases/regenerate_canvas';
 import { getMemberMentions } from '../interactions/buttons/other_events';
 import { sendCloseEmbedSticky } from '../sticky/recruit_sticky_messages';
@@ -20,6 +21,8 @@ export async function recruitAutoClose(
     const guild = recruitData.guild;
     const recruitChannel = recruitData.recruitChannel;
     const recruiter = recruitData.interactionMember;
+
+    if (notExists(await RecruitService.getRecruit(guild.id, recruitId))) return;
 
     const participants = await ParticipantService.getAllParticipants(guild.id, recruitId);
     const memberList = getMemberMentions(recruitData.recruitNum, participants);

--- a/src/app/feat-recruit/common/condition_checks/schedule_check.ts
+++ b/src/app/feat-recruit/common/condition_checks/schedule_check.ts
@@ -19,13 +19,9 @@ export async function checkRecruitSchedule(
     type: number,
     recruitType: RecruitType,
 ): Promise<checkRecruitScheduleResponse> {
-    const isDuringFest = checkFes(schedule, type);
-    const isDuringBigRun = checkBigRun(schedule, type);
-    const isDuringTeamContest = checkTeamContest(schedule, type);
-
     switch (recruitType) {
         case RecruitType.FestivalRecruit:
-            if (!isDuringFest) {
+            if (!checkFes(schedule, type)) {
                 // フェス期間外にフェス募集を建てようとした場合
                 return {
                     canRecruit: false,
@@ -36,7 +32,7 @@ export async function checkRecruitSchedule(
 
         case RecruitType.RegularRecruit:
         case RecruitType.AnarchyRecruit:
-            if (isDuringFest) {
+            if (checkFes(schedule, type)) {
                 // フェス期間中にナワバリ募集またはバンカラ募集を建てようとした場合
                 return {
                     canRecruit: false,
@@ -47,6 +43,25 @@ export async function checkRecruitSchedule(
 
         case RecruitType.EventRecruit:
             break;
+        case RecruitType.SalmonRecruit:
+        case RecruitType.BigRunRecruit:
+        case RecruitType.TeamContestRecruit:
+            return await checkSalmonGroupCondtion(schedule, type, recruitType);
+        default:
+            break;
+    }
+    return { canRecruit: true, recruitDateErrorMessage: '' };
+}
+
+async function checkSalmonGroupCondtion(
+    schedule: Sp3Schedule,
+    type: number,
+    recruitType: RecruitType,
+) {
+    const isDuringBigRun = checkBigRun(schedule, type);
+    const isDuringTeamContest = checkTeamContest(schedule, type);
+
+    switch (recruitType) {
         case RecruitType.SalmonRecruit:
             if (isDuringBigRun) {
                 // ビッグラン期間中に通常のサーモン募集を建てようとした場合

--- a/src/app/feat-recruit/common/create_recruit/arrange_command_data.ts
+++ b/src/app/feat-recruit/common/create_recruit/arrange_command_data.ts
@@ -188,8 +188,8 @@ export async function arrangeRecruitData(
             });
         } else {
             await recruitChannel.send(ErrorTexts.UndefinedError);
+            await sendErrorLogs(logger, error);
         }
-        await sendErrorLogs(logger, error);
         throw new Error();
     }
 }


### PR DESCRIPTION
- サーモンラン関連イベントの条件チェックを関係する募集以外で行われないように変更
- 自動〆時に募集情報がDBにあるかチェックするように変更
- 条件チェックでエラーが出た場合にエラーログを出さないように修正