### PR TITLE
fix: モーダル募集時に条件エラーがでるとエラーログに通知される問題を修正

### DIFF
--- a/src/app/feat-recruit/common/auto_close.ts
+++ b/src/app/feat-recruit/common/auto_close.ts
@@ -1,6 +1,5 @@
 import { Message } from 'discord.js';
 
-import { RecruitData } from './create_recruit/arrange_command_data';
 import {
     isVoiceChannelLockNeeded,
     removeVoiceChannelReservation,
@@ -12,6 +11,7 @@ import { notExists } from '../../common/others';
 import { regenerateCanvas, RecruitOpCode } from '../canvases/regenerate_canvas';
 import { getMemberMentions } from '../interactions/buttons/other_events';
 import { sendCloseEmbedSticky } from '../sticky/recruit_sticky_messages';
+import { RecruitData } from '../types/recruit_data';
 
 export async function recruitAutoClose(
     recruitData: RecruitData,

--- a/src/app/feat-recruit/common/create_recruit/arrange_command_data.ts
+++ b/src/app/feat-recruit/common/create_recruit/arrange_command_data.ts
@@ -180,7 +180,6 @@ export async function arrangeRecruitData(
     } catch (error) {
         if (error instanceof RecruitConditionError) {
             // 募集条件のチェックを行う
-
             await interaction.deleteReply();
             await interaction.followUp({
                 content: `\`${interaction.toString()}\`\n${error.getErrorMessage()}`,

--- a/src/app/feat-recruit/common/create_recruit/arrange_command_data.ts
+++ b/src/app/feat-recruit/common/create_recruit/arrange_command_data.ts
@@ -1,17 +1,8 @@
-import { Member } from '@prisma/client';
-import {
-    ChannelType,
-    ChatInputCommandInteraction,
-    Guild,
-    GuildMember,
-    GuildTextBasedChannel,
-    VoiceBasedChannel,
-} from 'discord.js';
+import { ChannelType, ChatInputCommandInteraction } from 'discord.js';
 
 import { RecruitType } from '../../../../db/recruit_service';
 import { log4js_obj } from '../../../../log4js_settings';
 import { getSchedule } from '../../../common/apis/splatoon3.ink/splatoon3_ink';
-import { Sp3Schedule } from '../../../common/apis/splatoon3.ink/types/schedule';
 import { getGuildByInteraction } from '../../../common/manager/guild_manager';
 import { searchAPIMemberById, searchDBMemberById } from '../../../common/manager/member_manager';
 import { assertExistCheck, exists, getDeveloperMention, notExists } from '../../../common/others';
@@ -24,36 +15,10 @@ import {
 } from '../../common/condition_checks/recruit_num_check';
 import { checkRecruitSchedule } from '../../common/condition_checks/schedule_check';
 import { getVCReserveErrorMessage } from '../../common/condition_checks/vc_reserve_check';
+import { RecruitConditionError } from '../../types/recruit_condition_error';
+import { RecruitData } from '../../types/recruit_data';
+
 const logger = log4js_obj.getLogger('recruit');
-
-export type RecruitData = {
-    guild: Guild;
-    interactionMember: GuildMember;
-    recruitChannel: GuildTextBasedChannel;
-    scheduleNum: number;
-    txt: string;
-    recruitNum: number;
-    condition: string;
-    count: number;
-    recruiter: Member;
-    attendee1: Member | null;
-    attendee2: Member | null;
-    attendee3: Member | null;
-    schedule: Sp3Schedule;
-    voiceChannel: VoiceBasedChannel | null;
-};
-
-export class RecruitConditionError extends Error {
-    private errorMessage: string | undefined;
-    constructor(errorMessage?: string) {
-        super();
-        this.errorMessage = errorMessage;
-    }
-
-    public getErrorMessage() {
-        return this.errorMessage ?? ErrorTexts.UndefinedError;
-    }
-}
 
 export async function arrangeRecruitData(
     interaction: ChatInputCommandInteraction<'cached' | 'raw'>,

--- a/src/app/feat-recruit/common/create_recruit/arrange_command_data.ts
+++ b/src/app/feat-recruit/common/create_recruit/arrange_command_data.ts
@@ -154,6 +154,6 @@ export async function arrangeRecruitData(
             await recruitChannel.send(ErrorTexts.UndefinedError);
             await sendErrorLogs(logger, error);
         }
-        throw new Error();
+        throw error;
     }
 }

--- a/src/app/feat-recruit/common/create_recruit/arrange_modal_data.ts
+++ b/src/app/feat-recruit/common/create_recruit/arrange_modal_data.ts
@@ -1,16 +1,8 @@
-import { Member } from '@prisma/client';
-import {
-    Guild,
-    GuildMember,
-    GuildTextBasedChannel,
-    ModalSubmitInteraction,
-    VoiceBasedChannel,
-} from 'discord.js';
+import { ModalSubmitInteraction } from 'discord.js';
 
 import { RecruitType } from '../../../../db/recruit_service';
 import { log4js_obj } from '../../../../log4js_settings';
 import { getSchedule } from '../../../common/apis/splatoon3.ink/splatoon3_ink';
-import { Sp3Schedule } from '../../../common/apis/splatoon3.ink/types/schedule';
 import { getGuildByInteraction } from '../../../common/manager/guild_manager';
 import { searchAPIMemberById, searchDBMemberById } from '../../../common/manager/member_manager';
 import {
@@ -28,36 +20,10 @@ import {
     checkRegularRecruitNum,
 } from '../../common/condition_checks/recruit_num_check';
 import { checkRecruitSchedule } from '../../common/condition_checks/schedule_check';
+import { RecruitConditionError } from '../../types/recruit_condition_error';
+import { RecruitData } from '../../types/recruit_data';
+
 const logger = log4js_obj.getLogger('recruit');
-
-export type RecruitData = {
-    guild: Guild;
-    interactionMember: GuildMember;
-    recruitChannel: GuildTextBasedChannel;
-    scheduleNum: number;
-    txt: string;
-    recruitNum: number;
-    condition: string;
-    count: number;
-    recruiter: Member;
-    attendee1: Member | null;
-    attendee2: Member | null;
-    attendee3: Member | null;
-    schedule: Sp3Schedule;
-    voiceChannel: VoiceBasedChannel | null;
-};
-
-export class RecruitConditionError extends Error {
-    private errorMessage: string | undefined;
-    constructor(errorMessage?: string) {
-        super();
-        this.errorMessage = errorMessage;
-    }
-
-    public getErrorMessage() {
-        return this.errorMessage ?? ErrorTexts.UndefinedError;
-    }
-}
 
 export async function arrangeModalRecruitData(
     interaction: ModalSubmitInteraction<'cached' | 'raw'>,

--- a/src/app/feat-recruit/common/create_recruit/arrange_modal_data.ts
+++ b/src/app/feat-recruit/common/create_recruit/arrange_modal_data.ts
@@ -139,7 +139,6 @@ export async function arrangeModalRecruitData(
     } catch (error) {
         if (error instanceof RecruitConditionError) {
             // 募集条件のチェックを行う
-
             await interaction.deleteReply();
             await interaction.followUp({
                 content: `\`${interaction.toString()}\`\n${error.getErrorMessage()}`,
@@ -147,8 +146,8 @@ export async function arrangeModalRecruitData(
             });
         } else {
             await recruitChannel.send(ErrorTexts.UndefinedError);
+            await sendErrorLogs(logger, error);
         }
-        await sendErrorLogs(logger, error);
         throw new Error();
     }
 }

--- a/src/app/feat-recruit/common/create_recruit/arrange_modal_data.ts
+++ b/src/app/feat-recruit/common/create_recruit/arrange_modal_data.ts
@@ -114,6 +114,6 @@ export async function arrangeModalRecruitData(
             await recruitChannel.send(ErrorTexts.UndefinedError);
             await sendErrorLogs(logger, error);
         }
-        throw new Error();
+        throw error;
     }
 }

--- a/src/app/feat-recruit/common/create_recruit/remove_delete_button.ts
+++ b/src/app/feat-recruit/common/create_recruit/remove_delete_button.ts
@@ -1,7 +1,7 @@
-import { RecruitData } from './arrange_command_data';
 import { log4js_obj } from '../../../../log4js_settings';
 import { searchMessageById } from '../../../common/manager/message_manager';
 import { exists } from '../../../common/others';
+import { RecruitData } from '../../types/recruit_data';
 import {
     isVoiceChannelLockNeeded,
     removeVoiceChannelReservation,

--- a/src/app/feat-recruit/common/create_recruit/send_recruit_message.ts
+++ b/src/app/feat-recruit/common/create_recruit/send_recruit_message.ts
@@ -5,13 +5,13 @@ import {
     ModalSubmitInteraction,
 } from 'discord.js';
 
-import { RecruitData } from './arrange_command_data';
 import {
     recruitActionRow,
     recruitDeleteButton,
     unlockChannelButton,
 } from '../../buttons/create_recruit_buttons';
 import { getMemberMentions } from '../../interactions/buttons/other_events';
+import { RecruitData } from '../../types/recruit_data';
 import { isVoiceChannelLockNeeded, reserveVoiceChannel } from '../voice_channel_reservation';
 
 type RecruitMessageList = {

--- a/src/app/feat-recruit/interactions/anarchy_recruit.ts
+++ b/src/app/feat-recruit/interactions/anarchy_recruit.ts
@@ -18,7 +18,7 @@ import { sendErrorLogs } from '../../logs/error/send_error_logs';
 import { recruitAnarchyCanvas, ruleAnarchyCanvas } from '../canvases/anarchy_canvas';
 import { RecruitOpCode } from '../canvases/regenerate_canvas';
 import { recruitAutoClose } from '../common/auto_close';
-import { RecruitData, arrangeRecruitData } from '../common/create_recruit/arrange_command_data';
+import { arrangeRecruitData } from '../common/create_recruit/arrange_command_data';
 import { arrangeModalRecruitData } from '../common/create_recruit/arrange_modal_data';
 import { removeDeleteButton } from '../common/create_recruit/remove_delete_button';
 import {
@@ -26,6 +26,7 @@ import {
     RecruitImageBuffers,
 } from '../common/create_recruit/send_recruit_message';
 import { sendRecruitSticky } from '../sticky/recruit_sticky_messages';
+import { RecruitData } from '../types/recruit_data';
 
 const logger = log4js_obj.getLogger('recruit');
 

--- a/src/app/feat-recruit/interactions/event_recruit.ts
+++ b/src/app/feat-recruit/interactions/event_recruit.ts
@@ -9,7 +9,7 @@ import { RoleKeySet } from '../../constant/role_key';
 import { recruitEventCanvas, ruleEventCanvas } from '../canvases/event_canvas';
 import { RecruitOpCode } from '../canvases/regenerate_canvas';
 import { recruitAutoClose } from '../common/auto_close';
-import { RecruitData, arrangeRecruitData } from '../common/create_recruit/arrange_command_data';
+import { arrangeRecruitData } from '../common/create_recruit/arrange_command_data';
 import { arrangeModalRecruitData } from '../common/create_recruit/arrange_modal_data';
 import { removeDeleteButton } from '../common/create_recruit/remove_delete_button';
 import {
@@ -17,6 +17,7 @@ import {
     RecruitImageBuffers,
 } from '../common/create_recruit/send_recruit_message';
 import { sendRecruitSticky } from '../sticky/recruit_sticky_messages';
+import { RecruitData } from '../types/recruit_data';
 
 export async function eventRecruit(
     interaction:

--- a/src/app/feat-recruit/interactions/fest_recruit.ts
+++ b/src/app/feat-recruit/interactions/fest_recruit.ts
@@ -9,7 +9,7 @@ import { assertExistCheck, sleep, notExists, getDeveloperMention } from '../../c
 import { recruitFestCanvas, ruleFestCanvas } from '../canvases/fest_canvas';
 import { RecruitOpCode } from '../canvases/regenerate_canvas';
 import { recruitAutoClose } from '../common/auto_close';
-import { RecruitData, arrangeRecruitData } from '../common/create_recruit/arrange_command_data';
+import { arrangeRecruitData } from '../common/create_recruit/arrange_command_data';
 import { arrangeModalRecruitData } from '../common/create_recruit/arrange_modal_data';
 import { removeDeleteButton } from '../common/create_recruit/remove_delete_button';
 import {
@@ -17,6 +17,7 @@ import {
     RecruitImageBuffers,
 } from '../common/create_recruit/send_recruit_message';
 import { sendRecruitSticky } from '../sticky/recruit_sticky_messages';
+import { RecruitData } from '../types/recruit_data';
 
 export async function festRecruit(
     interaction:

--- a/src/app/feat-recruit/interactions/registerRecruitData.ts
+++ b/src/app/feat-recruit/interactions/registerRecruitData.ts
@@ -1,7 +1,7 @@
 import { ParticipantService } from '../../../db/participant_service';
 import { RecruitType, RecruitService } from '../../../db/recruit_service';
 import { exists } from '../../common/others';
-import { RecruitData } from '../common/create_recruit/arrange_command_data';
+import { RecruitData } from '../types/recruit_data';
 
 export async function registerRecruitData(
     recruitId: string,

--- a/src/app/feat-recruit/interactions/regular_recruit.ts
+++ b/src/app/feat-recruit/interactions/regular_recruit.ts
@@ -9,7 +9,7 @@ import { RoleKeySet } from '../../constant/role_key';
 import { RecruitOpCode } from '../canvases/regenerate_canvas';
 import { recruitRegularCanvas, ruleRegularCanvas } from '../canvases/regular_canvas';
 import { recruitAutoClose } from '../common/auto_close';
-import { RecruitData, arrangeRecruitData } from '../common/create_recruit/arrange_command_data';
+import { arrangeRecruitData } from '../common/create_recruit/arrange_command_data';
 import { arrangeModalRecruitData } from '../common/create_recruit/arrange_modal_data';
 import { removeDeleteButton } from '../common/create_recruit/remove_delete_button';
 import {
@@ -17,6 +17,7 @@ import {
     RecruitImageBuffers,
 } from '../common/create_recruit/send_recruit_message';
 import { sendRecruitSticky } from '../sticky/recruit_sticky_messages';
+import { RecruitData } from '../types/recruit_data';
 
 export async function regularRecruit(
     interaction:

--- a/src/app/feat-recruit/interactions/salmon_recruit.ts
+++ b/src/app/feat-recruit/interactions/salmon_recruit.ts
@@ -15,7 +15,7 @@ import { RoleKeySet } from '../../constant/role_key';
 import { recruitBigRunCanvas, ruleBigRunCanvas } from '../canvases/big_run_canvas';
 import { RecruitOpCode } from '../canvases/regenerate_canvas';
 import { recruitSalmonCanvas, ruleSalmonCanvas } from '../canvases/salmon_canvas';
-import { RecruitData, arrangeRecruitData } from '../common/create_recruit/arrange_command_data';
+import { arrangeRecruitData } from '../common/create_recruit/arrange_command_data';
 import { arrangeModalRecruitData } from '../common/create_recruit/arrange_modal_data';
 import { removeDeleteButton } from '../common/create_recruit/remove_delete_button';
 import {
@@ -27,6 +27,7 @@ import {
     removeVoiceChannelReservation,
 } from '../common/voice_channel_reservation';
 import { sendRecruitSticky } from '../sticky/recruit_sticky_messages';
+import { RecruitData } from '../types/recruit_data';
 
 export async function salmonRecruit(
     interaction:

--- a/src/app/feat-recruit/types/recruit_condition_error.ts
+++ b/src/app/feat-recruit/types/recruit_condition_error.ts
@@ -1,0 +1,13 @@
+import { ErrorTexts } from '../../constant/error_texts';
+
+export class RecruitConditionError extends Error {
+    private errorMessage: string | undefined;
+    constructor(errorMessage?: string) {
+        super();
+        this.errorMessage = errorMessage;
+    }
+
+    public getErrorMessage() {
+        return this.errorMessage ?? ErrorTexts.UndefinedError;
+    }
+}

--- a/src/app/feat-recruit/types/recruit_data.ts
+++ b/src/app/feat-recruit/types/recruit_data.ts
@@ -1,0 +1,21 @@
+import { Member } from '@prisma/client';
+import { Guild, GuildMember, GuildTextBasedChannel, VoiceBasedChannel } from 'discord.js';
+
+import { Sp3Schedule } from '../../common/apis/splatoon3.ink/types/schedule';
+
+export type RecruitData = {
+    guild: Guild;
+    interactionMember: GuildMember;
+    recruitChannel: GuildTextBasedChannel;
+    scheduleNum: number;
+    txt: string;
+    recruitNum: number;
+    condition: string;
+    count: number;
+    recruiter: Member;
+    attendee1: Member | null;
+    attendee2: Member | null;
+    attendee3: Member | null;
+    schedule: Sp3Schedule;
+    voiceChannel: VoiceBasedChannel | null;
+};


### PR DESCRIPTION
- エラーログ通知を行う関数の呼び出し位置の修正
- コマンド募集とモーダル募集で全く同じ型・クラスを定義していたので共通化
- 募集データ成形時にエラーが出た場合にそのエラーをそのまま投げるように修正