### PR TITLE
perf: コマンドログ送信処理を待たずにコマンド処理を行うように変更

### DIFF
--- a/src/app/handlers/command_handler.ts
+++ b/src/app/handlers/command_handler.ts
@@ -51,17 +51,20 @@ import { sendErrorLogs } from '../logs/error/send_error_logs.js';
 const logger = log4js_obj.getLogger('interaction');
 
 export async function call(interaction: ChatInputCommandInteraction<CacheType>) {
-    await sendCommandLog(interaction);
+    try {
+        sendCommandLog(interaction);
+    } catch (error) {
+        await sendErrorLogs(logger, error);
+    }
 
     await CommandsHandler(interaction); // DMとGuild両方で動くコマンド
 
-    if (interaction.inGuild()) {
+    if (interaction.inCachedGuild()) {
         // Guildのみで動くコマンド
         await guildOnlyCommandsHandler(interaction);
-    } else {
+    } else if (exists(interaction.channel) && interaction.channel.isDMBased()) {
         // DMのみで動くコマンド
     }
-
     return;
 }
 

--- a/src/app/handlers/context_handler.ts
+++ b/src/app/handlers/context_handler.ts
@@ -1,12 +1,20 @@
 import { CacheType, MessageContextMenuCommandInteraction } from 'discord.js';
 
 import { commandNames } from '../../constant';
+import { log4js_obj } from '../../log4js_settings';
 import { buttonEnable } from '../feat-admin/button_enabler/enable_button';
 import { createRecruitEditor } from '../feat-recruit/interactions/context_menus/recruit_editor';
 import { sendCommandLog } from '../logs/commands/command_log';
+import { sendErrorLogs } from '../logs/error/send_error_logs';
+const logger = log4js_obj.getLogger('interaction');
 
 export async function call(interaction: MessageContextMenuCommandInteraction<CacheType>) {
-    await sendCommandLog(interaction);
+    try {
+        sendCommandLog(interaction);
+    } catch (error) {
+        await sendErrorLogs(logger, error);
+    }
+
     if (interaction.inGuild()) {
         if (interaction.commandName === commandNames.buttonEnabler) {
             await buttonEnable(interaction);

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -27,7 +27,7 @@ import {
 import { updateLocale, updateSchedule } from './common/apis/splatoon3.ink/splatoon3_ink';
 import { searchChannelById } from './common/manager/channel_manager';
 import { searchAPIMemberById } from './common/manager/member_manager';
-import { assertExistCheck, exists, notExists } from './common/others';
+import { assertExistCheck, exists, getDeveloperMention, notExists } from './common/others';
 import { ChannelKeySet } from './constant/channel_key';
 import {
     deleteChannel,
@@ -303,8 +303,20 @@ client.on(
 
 client.on('interactionCreate', async (interaction: Interaction<CacheType>) => {
     try {
+        // RawGuildのInteractionが送られてくる頻度を確認するためのログ
+        if (interaction.inRawGuild()) {
+            const guildId = interaction.guildId;
+            const guild = await client.guilds.fetch(guildId);
+            logger.warn(`raw guild interaction: ${guild.name}, guild fetched!`);
+            if (exists(interaction.channel)) {
+                await interaction.channel.send(
+                    (await getDeveloperMention(interaction.guildId)) +
+                        'サーバー情報が取得できなかったでし！',
+                );
+            }
+        }
+
         if (interaction.isRepliable()) {
-            // 各handlerの内どれかしか呼ばれないためawaitしない
             if (interaction.isButton()) {
                 void buttonHandler.call(interaction);
             } else if (interaction.isModalSubmit()) {

--- a/src/app/logs/commands/command_log.ts
+++ b/src/app/logs/commands/command_log.ts
@@ -5,81 +5,68 @@ import {
     MessageContextMenuCommandInteraction,
 } from 'discord.js';
 
-import { log4js_obj } from '../../../log4js_settings';
-import { getGuildByInteraction } from '../../common/manager/guild_manager';
-import { searchDBMemberById } from '../../common/manager/member_manager';
 import { assertExistCheck, exists } from '../../common/others';
 import { sendEmbedsWebhook } from '../../common/webhook';
-import { sendErrorLogs } from '../error/send_error_logs';
 
-const logger = log4js_obj.getLogger('interaction');
-
-export async function sendCommandLog(
+export function sendCommandLog(
     interaction:
         | MessageContextMenuCommandInteraction<CacheType>
         | ChatInputCommandInteraction<CacheType>,
 ) {
-    try {
-        let authorName = '不明なユーザー';
-        let authorId = '????????????????????';
-        let iconUrl = 'https://cdn.discordapp.com/embed/avatars/0.png';
-        let channelName = '不明なチャンネル';
-        if (interaction.inGuild()) {
-            const guild = await getGuildByInteraction(interaction);
-            const member = await searchDBMemberById(guild, interaction.member.user.id);
-            if (exists(member)) {
-                authorName = member.displayName;
-                authorId = member.userId;
-                iconUrl = member.iconUrl;
-                if (exists(interaction.channel)) {
-                    channelName = interaction.channel.name;
-                }
-            }
-        } else {
-            const user = interaction.user;
-            authorName = user.displayName;
-            authorId = user.id;
-            iconUrl = user.avatarURL() ?? 'https://cdn.discordapp.com/embed/avatars/0.png';
-            channelName = 'DM';
+    let authorName = '不明なユーザー';
+    let authorId = '????????????????????';
+    let iconUrl = 'https://cdn.discordapp.com/embed/avatars/0.png';
+    let channelName = '不明なチャンネル';
+    if (interaction.inCachedGuild()) {
+        const member = interaction.member;
+        authorName = member.displayName;
+        authorId = member.id;
+        iconUrl = member.displayAvatarURL();
+        if (exists(interaction.channel)) {
+            channelName = interaction.channel.name;
         }
-
-        let commandName = interaction.commandName;
-        let title = 'コマンドログ';
-        if (interaction.isChatInputCommand()) {
-            title = 'スラッシュコマンドログ';
-            if (interaction.inGuild()) {
-                commandName = interaction.toString(); // 鯖内の場合はコマンド名と引数を表示
-            } else {
-                commandName = interaction.commandName; // DMの場合はコマンド名のみ
-            }
-        } else if (interaction.isMessageContextMenuCommand()) {
-            title = 'コンテキストメニューログ';
-            commandName = interaction.commandName;
-        }
-
-        const embed = new EmbedBuilder();
-        embed.setTitle(title);
-        embed.setAuthor({
-            name: `${authorName} [${authorId}]`,
-            iconURL: iconUrl,
-        });
-        embed.addFields([
-            {
-                name: '使用コマンド',
-                value: commandName,
-                inline: true,
-            },
-            {
-                name: '使用チャンネル',
-                value: channelName,
-                inline: false,
-            },
-        ]);
-        embed.setColor('#CFCFCF');
-        embed.setTimestamp(interaction.createdAt);
-        assertExistCheck(process.env.COMMAND_LOG_WEBHOOK_URL, 'COMMAND_LOG_WEBHOOK_URL');
-        void sendEmbedsWebhook(process.env.COMMAND_LOG_WEBHOOK_URL, [embed]);
-    } catch (error) {
-        await sendErrorLogs(logger, error);
+    } else {
+        const user = interaction.user;
+        authorName = user.displayName;
+        authorId = user.id;
+        iconUrl = user.avatarURL() ?? 'https://cdn.discordapp.com/embed/avatars/0.png';
+        channelName = 'DM or RawGuild';
     }
+
+    let commandName = interaction.commandName;
+    let title = 'コマンドログ';
+    if (interaction.isChatInputCommand()) {
+        title = 'スラッシュコマンドログ';
+        if (interaction.inGuild()) {
+            commandName = interaction.toString(); // 鯖内の場合はコマンド名と引数を表示
+        } else {
+            commandName = interaction.commandName; // DMの場合はコマンド名のみ
+        }
+    } else if (interaction.isMessageContextMenuCommand()) {
+        title = 'コンテキストメニューログ';
+        commandName = interaction.commandName;
+    }
+
+    const embed = new EmbedBuilder();
+    embed.setTitle(title);
+    embed.setAuthor({
+        name: `${authorName} [${authorId}]`,
+        iconURL: iconUrl,
+    });
+    embed.addFields([
+        {
+            name: '使用コマンド',
+            value: commandName,
+            inline: true,
+        },
+        {
+            name: '使用チャンネル',
+            value: channelName,
+            inline: false,
+        },
+    ]);
+    embed.setColor('#CFCFCF');
+    embed.setTimestamp(interaction.createdAt);
+    assertExistCheck(process.env.COMMAND_LOG_WEBHOOK_URL, 'COMMAND_LOG_WEBHOOK_URL');
+    void sendEmbedsWebhook(process.env.COMMAND_LOG_WEBHOOK_URL, [embed]);
 }


### PR DESCRIPTION
- コマンドログでGuildのフェッチとDBからメンバー情報検索を削って、interaction.memberが取れない(Raw)データが送られてきた場合はユーザー情報で表示するように変更
- キャッシュされてないGuildからInteractionが来たときにエラーログが出るように変更
  - 頻度が低そうならキャッシュされてない場合はフェッチし直すように変更したい
  (interaction.guild, interaction.memberのチェックせずに済むため)
  - エラーログにしてるのはコンソールログだと気付けなさそうだからです。