### PR TITLE
feat: イベントジョブが見つからないときに処理を抜けるように変更

### DIFF
--- a/src/app/feat-recruit/common/vc_reservation/recruit_event.ts
+++ b/src/app/feat-recruit/common/vc_reservation/recruit_event.ts
@@ -104,6 +104,8 @@ export async function cancelRecruitEvent(guild: Guild, eventId: string) {
     if (exists(eventJob)) {
         eventJob.stop();
         activeJobs.delete(eventId);
+    } else {
+        return;
     }
 
     const event = await guild.scheduledEvents.fetch(eventId);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- 存在しないイベントをキャンセルしようとした際のエラーを防ぐため、`cancelRecruitEvent` 関数に新しい条件分岐を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->