### PR TITLE
fix: splatoon3.inkから情報が取れないとき募集ができない問題を修正

### DIFF
--- a/src/app/common/apis/splatoon3.ink/types/bankara_properties.ts
+++ b/src/app/common/apis/splatoon3.ink/types/bankara_properties.ts
@@ -1,3 +1,5 @@
+import { placeHold } from '../../../../../constant';
+
 export type BankaraProperties = {
     startTime: string;
     endTime: string;
@@ -65,3 +67,53 @@ export type bankaraMatchSettings = [
         mode: string;
     },
 ];
+
+export function getBankaraDummyProperties(startTime: Date, endTime: Date): BankaraProperties {
+    return {
+        startTime: startTime.toString(),
+        endTime: endTime.toString(),
+        bankaraMatchSettings: [
+            {
+                __isVsSetting: 'BankaraMatchSetting',
+                __typename: 'BankaraMatchSetting',
+                vsRule: { id: 'dummy_rule_id', name: 'dummy_rule', rule: 'dummy_rule' },
+                vsStages: [
+                    {
+                        id: 'dummy_stage_a_id',
+                        name: 'dummy_stage_a',
+                        image: { url: placeHold.error100x100 },
+                        vsStageId: 0,
+                    },
+                    {
+                        id: 'dummy_stage_b_id',
+                        name: 'dummy_stage_b',
+                        image: { url: placeHold.error100x100 },
+                        vsStageId: 1,
+                    },
+                ],
+                mode: 'dummy_mode',
+            },
+            {
+                __isVsSetting: 'BankaraMatchSetting',
+                __typename: 'BankaraMatchSetting',
+                vsRule: { id: 'dummy_rule_id', name: 'dummy_rule', rule: 'dummy_rule' },
+                vsStages: [
+                    {
+                        id: 'dummy_stage_a_id',
+                        name: 'dummy_stage_a',
+                        image: { url: placeHold.error100x100 },
+                        vsStageId: 0,
+                    },
+                    {
+                        id: 'dummy_stage_b_id',
+                        name: 'dummy_stage_b',
+                        image: { url: placeHold.error100x100 },
+                        vsStageId: 1,
+                    },
+                ],
+                mode: 'dummy_mode',
+            },
+        ],
+        festMatchSetting: null,
+    };
+}

--- a/src/app/common/apis/splatoon3.ink/types/event_properties.ts
+++ b/src/app/common/apis/splatoon3.ink/types/event_properties.ts
@@ -1,3 +1,5 @@
+import { placeHold } from '../../../../../constant';
+
 export type EventProperties = {
     leagueMatchSetting: {
         leagueMatchEvent: {
@@ -49,3 +51,40 @@ export type EventProperties = {
         },
     ];
 };
+
+export function getEventDummyProperties(startTime: Date, endTime: Date): EventProperties {
+    return {
+        leagueMatchSetting: {
+            leagueMatchEvent: {
+                id: 'dummy_event_id',
+                name: 'dummy_event',
+                desc: 'dummy_event',
+                regulationUrl: null,
+                regulation: 'dummy_regulation',
+                leagueMatchEventId: 'dummy_event_id',
+            },
+            vsRule: { id: 'dummy_rule_id', name: 'dummy_rule', rule: 'dummy_rule' },
+            vsStages: [
+                {
+                    id: 'dummy_stage_a_id',
+                    name: 'dummy_stage_a',
+                    image: { url: placeHold.error100x100 },
+                    vsStageId: 0,
+                },
+                {
+                    id: 'dummy_stage_b_id',
+                    name: 'dummy_stage_b',
+                    image: { url: placeHold.error100x100 },
+                    vsStageId: 1,
+                },
+            ],
+            __isVsSetting: 'LeagueMatchSetting',
+            __typename: 'LeagueMatchSetting',
+        },
+        timePeriods: [
+            { startTime: startTime.toString(), endTime: endTime.toString() },
+            { startTime: startTime.toString(), endTime: endTime.toString() },
+            { startTime: startTime.toString(), endTime: endTime.toString() },
+        ],
+    };
+}

--- a/src/app/common/apis/splatoon3.ink/types/fest_properties.ts
+++ b/src/app/common/apis/splatoon3.ink/types/fest_properties.ts
@@ -1,3 +1,5 @@
+import { placeHold } from '../../../../../constant';
+
 export type FestProperties = {
     startTime: string;
     endTime: string;
@@ -60,3 +62,50 @@ type festMatchSettings = [
         };
     },
 ];
+
+export function getFestDummyProperties(startTime: Date, endTime: Date): FestProperties {
+    return {
+        startTime: startTime.toString(),
+        endTime: endTime.toString(),
+        festMatchSettings: [
+            {
+                __isVsSetting: 'FestMatchSetting',
+                __typename: 'FestMatchSetting',
+                vsRule: { id: 'dummy_rule_id', name: 'dummy_rule', rule: 'dummy_rule' },
+                vsStages: [
+                    {
+                        id: 'dummy_stage_a_id',
+                        name: 'dummy_stage_a',
+                        image: { url: placeHold.error100x100 },
+                        vsStageId: 0,
+                    },
+                    {
+                        id: 'dummy_stage_b_id',
+                        name: 'dummy_stage_b',
+                        image: { url: placeHold.error100x100 },
+                        vsStageId: 1,
+                    },
+                ],
+            },
+            {
+                __isVsSetting: 'FestMatchSetting',
+                __typename: 'FestMatchSetting',
+                vsRule: { id: 'dummy_rule_id', name: 'dummy_rule', rule: 'dummy_rule' },
+                vsStages: [
+                    {
+                        id: 'dummy_stage_a_id',
+                        name: 'dummy_stage_a',
+                        image: { url: placeHold.error100x100 },
+                        vsStageId: 0,
+                    },
+                    {
+                        id: 'dummy_stage_b_id',
+                        name: 'dummy_stage_b',
+                        image: { url: placeHold.error100x100 },
+                        vsStageId: 1,
+                    },
+                ],
+            },
+        ],
+    };
+}

--- a/src/app/common/apis/splatoon3.ink/types/regular_properties.ts
+++ b/src/app/common/apis/splatoon3.ink/types/regular_properties.ts
@@ -1,3 +1,5 @@
+import { placeHold } from '../../../../../constant';
+
 export type RegularProperties = {
     startTime: string;
     endTime: string;
@@ -32,3 +34,30 @@ export type RegularProperties = {
         __typename: string;
     } | null;
 };
+
+export function getRegularDummyProperties(startTime: Date, endTime: Date): RegularProperties {
+    return {
+        startTime: startTime.toString(),
+        endTime: endTime.toString(),
+        regularMatchSetting: {
+            __isVsSetting: 'RegularMatchSetting',
+            __typename: 'RegularMatchSetting',
+            vsRule: { id: 'dummy_rule_id', name: 'dummy_rule', rule: 'dummy_rule' },
+            vsStages: [
+                {
+                    id: 'dummy_stage_a_id',
+                    name: 'dummy_stage_a',
+                    image: { url: placeHold.error100x100 },
+                    vsStageId: 0,
+                },
+                {
+                    id: 'dummy_stage_b_id',
+                    name: 'dummy_stage_b',
+                    image: { url: placeHold.error100x100 },
+                    vsStageId: 1,
+                },
+            ],
+        },
+        festMatchSetting: null,
+    };
+}

--- a/src/app/common/apis/splatoon3.ink/types/salmon_properties.ts
+++ b/src/app/common/apis/splatoon3.ink/types/salmon_properties.ts
@@ -1,3 +1,5 @@
+import { placeHold } from '../../../../../constant';
+
 export type SalmonRegularProperties = {
     startTime: string;
     endTime: string;
@@ -148,3 +150,46 @@ export type TeamContestProperties = {
         ];
     };
 };
+
+export function getSalmonRegularDummyProperties(
+    startTime: Date,
+    endTime: Date,
+): SalmonRegularProperties {
+    return {
+        startTime: startTime.toString(),
+        endTime: endTime.toString(),
+        setting: {
+            __typename: 'SalmonRegularSetting',
+            coopStage: {
+                id: 'dummy_stage_id',
+                name: 'dummy_stage',
+                thumbnailImage: { url: placeHold.error100x100 },
+                image: { url: placeHold.error100x100 },
+            },
+            __isCoopSetting: 'SalmonRegularSetting',
+            weapons: [
+                {
+                    __splatoon3ink_id: 'dummy_weapon_id',
+                    name: 'dummy_weapon',
+                    image: { url: placeHold.error100x100 },
+                },
+                {
+                    __splatoon3ink_id: 'dummy_weapon_id',
+                    name: 'dummy_weapon',
+                    image: { url: placeHold.error100x100 },
+                },
+                {
+                    __splatoon3ink_id: 'dummy_weapon_id',
+                    name: 'dummy_weapon',
+                    image: { url: placeHold.error100x100 },
+                },
+                {
+                    __splatoon3ink_id: 'dummy_weapon_id',
+                    name: 'dummy_weapon',
+                    image: { url: placeHold.error100x100 },
+                },
+            ],
+        },
+        __splatoon3ink_king_salmonid_guess: 'dummy_salmon_id',
+    };
+}

--- a/src/app/common/apis/splatoon3.ink/types/x_properties.ts
+++ b/src/app/common/apis/splatoon3.ink/types/x_properties.ts
@@ -1,3 +1,5 @@
+import { placeHold } from '../../../../../constant';
+
 export type XProperties = {
     startTime: string;
     endTime: string;
@@ -32,3 +34,30 @@ export type XProperties = {
         __typename: string;
     } | null;
 };
+
+export function getXDummyProperties(startTime: Date, endTime: Date): XProperties {
+    return {
+        startTime: startTime.toString(),
+        endTime: endTime.toString(),
+        xMatchSetting: {
+            __isVsSetting: 'XMatchSetting',
+            __typename: 'XMatchSetting',
+            vsRule: { id: 'dummy_rule_id', name: 'dummy_rule', rule: 'dummy_rule' },
+            vsStages: [
+                {
+                    id: 'dummy_stage_a_id',
+                    name: 'dummy_stage_a',
+                    image: { url: placeHold.error100x100 },
+                    vsStageId: 0,
+                },
+                {
+                    id: 'dummy_stage_b_id',
+                    name: 'dummy_stage_b',
+                    image: { url: placeHold.error100x100 },
+                    vsStageId: 1,
+                },
+            ],
+        },
+        festMatchSetting: null,
+    };
+}

--- a/src/app/event/cron/stageinfo.ts
+++ b/src/app/event/cron/stageinfo.ts
@@ -10,6 +10,7 @@ import {
     getXMatchData,
     checkFes,
     getSchedule,
+    inFallbackMode,
 } from '../../common/apis/splatoon3.ink/splatoon3_ink';
 import { Sp3Schedule } from '../../common/apis/splatoon3.ink/types/schedule';
 import { formatDatetime, dateformat } from '../../common/convert_datetime.js';
@@ -82,7 +83,10 @@ async function getAOEmbed(schedule: Sp3Schedule) {
         assertExistCheck(anarchyData, 'anarchyData');
         let stage;
         let rule;
-        if (checkFes(schedule, i)) {
+        if (inFallbackMode) {
+            rule = '不明';
+            stage = 'バンカラマッチのデータが取得できなかったでし';
+        } else if (checkFes(schedule, i)) {
             rule = 'フェス期間中';
             stage = 'フェス期間中はお休みでし';
         } else {
@@ -107,7 +111,10 @@ async function getACEmbed(schedule: Sp3Schedule) {
         assertExistCheck(anarchyData, 'anarchyData');
         let stage;
         let rule;
-        if (checkFes(schedule, i)) {
+        if (inFallbackMode) {
+            rule = '不明';
+            stage = 'バンカラマッチのデータが取得できなかったでし';
+        } else if (checkFes(schedule, i)) {
             rule = 'フェス期間中';
             stage = 'フェス期間中はお休みでし';
         } else {
@@ -132,7 +139,10 @@ async function getXMatchEmbed(schedule: Sp3Schedule) {
         assertExistCheck(xData, 'xData');
         let stage;
         let rule;
-        if (checkFes(schedule, i)) {
+        if (inFallbackMode) {
+            rule = '不明';
+            stage = 'Xマッチのデータが取得できなかったでし';
+        } else if (checkFes(schedule, i)) {
             rule = 'フェス期間中';
             stage = 'フェス期間中はお休みでし';
         } else {

--- a/src/app/feat-recruit/common/condition_checks/schedule_check.ts
+++ b/src/app/feat-recruit/common/condition_checks/schedule_check.ts
@@ -4,6 +4,7 @@ import {
     checkBigRun,
     checkTeamContest,
     getEventData,
+    inFallbackMode,
 } from '../../../common/apis/splatoon3.ink/splatoon3_ink';
 import { Sp3Schedule } from '../../../common/apis/splatoon3.ink/types/schedule';
 import { notExists } from '../../../common/others';
@@ -23,7 +24,7 @@ export async function checkRecruitSchedule(
 ): Promise<checkRecruitScheduleResponse> {
     switch (recruitType) {
         case RecruitType.FestivalRecruit:
-            if (!checkFes(schedule, type)) {
+            if (!checkFes(schedule, type) && !inFallbackMode) {
                 // フェス期間外にフェス募集を建てようとした場合
                 return {
                     canRecruit: false,
@@ -34,7 +35,7 @@ export async function checkRecruitSchedule(
 
         case RecruitType.RegularRecruit:
         case RecruitType.AnarchyRecruit:
-            if (checkFes(schedule, type)) {
+            if (checkFes(schedule, type) && !inFallbackMode) {
                 // フェス期間中にナワバリ募集またはバンカラ募集を建てようとした場合
                 return {
                     canRecruit: false,
@@ -44,7 +45,7 @@ export async function checkRecruitSchedule(
             break;
 
         case RecruitType.EventRecruit:
-            if (notExists(await getEventData(schedule))) {
+            if (notExists(await getEventData(schedule)) && !inFallbackMode) {
                 return {
                     canRecruit: false,
                     recruitDateErrorMessage: RecruitAlertTexts.NotDuringEvent,

--- a/src/app/feat-utils/splat3/show.ts
+++ b/src/app/feat-utils/splat3/show.ts
@@ -17,6 +17,7 @@ import {
     getAnarchyChallengeData,
     getAnarchyOpenData,
     getXMatchData,
+    inFallbackMode,
 } from '../../common/apis/splatoon3.ink/splatoon3_ink';
 import { Sp3Schedule } from '../../common/apis/splatoon3.ink/types/schedule';
 import { createRoundRect, fillTextWithStroke } from '../../common/canvas_components';
@@ -34,7 +35,11 @@ export async function handleShow(interaction: ChatInputCommandInteraction<CacheT
         const { options } = interaction;
         const subCommand = options.getSubcommand();
         const schedule = await getSchedule();
-        assertExistCheck(schedule, 'schedule');
+
+        if (inFallbackMode) {
+            return interaction.editReply('現在スケジュール情報が取得できないでし！');
+        }
+
         if (subCommand === `now`) {
             if (checkFes(schedule, 0)) {
                 await sendFesInfo(interaction, schedule, 0);

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -24,7 +24,11 @@ import {
     VoiceState,
 } from 'discord.js';
 
-import { updateLocale, updateSchedule } from './common/apis/splatoon3.ink/splatoon3_ink';
+import {
+    inFallbackMode,
+    updateLocale,
+    updateSchedule,
+} from './common/apis/splatoon3.ink/splatoon3_ink';
 import { searchChannelById } from './common/manager/channel_manager';
 import { searchAPIMemberById } from './common/manager/member_manager';
 import { assertExistCheck, exists, getDeveloperMention, notExists } from './common/others';
@@ -413,9 +417,10 @@ const job = new cron.CronJob(
         try {
             const guild = await client.guilds.fetch(process.env.SERVER_ID || '');
 
-            // イベント作成
-            // イベントマッチの作成
-            await subscribeSplatEventMatch(guild);
+            if (!inFallbackMode) {
+                // イベントマッチのイベント作成
+                await subscribeSplatEventMatch(guild);
+            }
             // ステージ情報の送信
             await stageInfo(guild);
         } catch (error) {


### PR DESCRIPTION
splatoon3.inkから情報が取れないときはダミーデータをキャッシュに保存するように変更し、Fallback Modeをオンにする。
レギュラーマッチのスケジュールデータが直近2つ以上取得できたときはFallback Modeを抜ける

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- スプラトゥーン3のスケジュール取得における、フォールバックモードの追加
	- データ取得に失敗した場合のダミーデータ生成機能

- **バグ修正**
	- スケジュール情報の取得エラーに対する堅牢な対応
	- 異なるマッチタイプ（バンカラ、リーグ、フェス等）のダミーデータサポート

- **改善**
	- スケジュール情報の取得プロセスの信頼性向上
	- エラー発生時のアプリケーション動作の安定化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->