### PR TITLE
chore: mise 環境向けに CLAUDE.md と VS Code 設定を修正

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,12 +9,12 @@
       "request": "launch",
       "name": "Botを起動 - TypeScript",
       "preLaunchTask": "Compile TypeScript",
-      "args": [
-        "-r",
-        "dotenv/config",
-        "${workspaceFolder}/build/server.js",
-        "dotenv_config_path=./.env"
-      ],
+      "runtimeArgs": ["-r", "dotenv/config"],
+      "program": "${workspaceFolder}/build/server.js",
+      "args": ["dotenv_config_path=./.env"],
+      "env": {
+        "PATH": "${env:HOME}/.local/share/mise/shims:${env:PATH}"
+      },
       "outputCapture": "std"
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,13 +3,13 @@
   "tasks": [
     {
       "label": "Compile TypeScript",
-      "type": "typescript",
-      "tsconfig": "tsconfig.json",
+      "type": "shell",
+      "command": "mise exec -- pnpm run compile",
       "problemMatcher": ["$tsc"],
       "presentation": {
         "reveal": "silent",
         "clear": true
-      },
+      }
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,15 @@ ikabu は Discord Bot アプリケーション。Node.js + TypeScript + discord.
 
 ## コマンド
 
+Node.js と pnpm は mise で管理されているため、シェルで mise が有効化されていない環境（CI・エディタのターミナルなど）では `mise exec --` を前置して実行する。
+
 ```bash
-pnpm run compile    # prisma generate && tsc && prisma migrate deploy
-pnpm start          # compile してからサーバー起動
-pnpm test           # Vitest でテスト実行
-pnpm run lint       # ESLint
-pnpm run fix        # ESLint 自動修正
-pnpm run create-migrate  # Prisma マイグレーションファイル作成
+mise exec -- pnpm run compile    # prisma generate && tsc && prisma migrate deploy
+mise exec -- pnpm start          # compile してからサーバー起動
+mise exec -- pnpm test           # Vitest でテスト実行
+mise exec -- pnpm run lint       # ESLint
+mise exec -- pnpm run fix        # ESLint 自動修正
+mise exec -- pnpm run create-migrate  # Prisma マイグレーションファイル作成
 ```
 
 ## ディレクトリ構成


### PR DESCRIPTION
## 概要

### 背景

Node.js と pnpm が mise で管理されているため、mise が有効化されていない環境（VS Code のタスクランナーなど）では `node` や `pnpm` が PATH に見つからず起動に失敗していた。

### 作業内容

- `CLAUDE.md`: コマンド実行時に `mise exec --` を前置する必要がある旨を追記
- `.vscode/tasks.json`: `type: typescript` から `mise exec -- pnpm run compile` を使うシェルタスクに変更
- `.vscode/launch.json`: node フラグを `runtimeArgs` に分離・`program` を明示・mise shims を `PATH` に追加