### PR TITLE
refactor: discord.js の非推奨 API を修正

### DIFF
--- a/src/app/feat-recruit/interactions/anarchy_recruit.ts
+++ b/src/app/feat-recruit/interactions/anarchy_recruit.ts
@@ -44,7 +44,7 @@ export async function anarchyRecruit(
     let recruitRoleId: string | null;
     let rank: string;
 
-    if (interaction.isCommand()) {
+    if (interaction.isChatInputCommand()) {
         const recruitRankRole = await getAnarchyRecruitRole(interaction);
         recruitRoleId = recruitRankRole.recruitRoleId;
         rank = recruitRankRole.rank;

--- a/src/app/feat-recruit/interactions/event_recruit.ts
+++ b/src/app/feat-recruit/interactions/event_recruit.ts
@@ -35,7 +35,7 @@ export async function eventRecruit(
     );
 
     let recruitData: RecruitData;
-    if (interaction.isCommand()) {
+    if (interaction.isChatInputCommand()) {
         try {
             recruitData = await arrangeRecruitData(interaction, recruitName, recruitType);
         } catch (error) {

--- a/src/app/feat-recruit/interactions/fest_recruit.ts
+++ b/src/app/feat-recruit/interactions/fest_recruit.ts
@@ -39,7 +39,7 @@ export async function festRecruit(
     const teamName = recruitRole.name; // フェスのチーム名
 
     let recruitData: RecruitData;
-    if (interaction.isCommand()) {
+    if (interaction.isChatInputCommand()) {
         try {
             recruitData = await arrangeRecruitData(interaction, recruitName, recruitType);
         } catch (error) {

--- a/src/app/feat-recruit/interactions/regular_recruit.ts
+++ b/src/app/feat-recruit/interactions/regular_recruit.ts
@@ -35,7 +35,7 @@ export async function regularRecruit(
     );
 
     let recruitData: RecruitData;
-    if (interaction.isCommand()) {
+    if (interaction.isChatInputCommand()) {
         try {
             recruitData = await arrangeRecruitData(interaction, recruitName, recruitType);
         } catch (error) {

--- a/src/app/feat-recruit/interactions/salmon_recruit.ts
+++ b/src/app/feat-recruit/interactions/salmon_recruit.ts
@@ -41,7 +41,7 @@ export async function salmonRecruit(
     );
 
     let recruitData: RecruitData;
-    if (interaction.isCommand()) {
+    if (interaction.isChatInputCommand()) {
         recruitType = getRecruitType(interaction);
         try {
             recruitData = await arrangeRecruitData(interaction, recruitName, recruitType);

--- a/src/app/feat-utils/other/friendcode.ts
+++ b/src/app/feat-utils/other/friendcode.ts
@@ -24,7 +24,7 @@ import { sendErrorLogs } from '../../logs/error/send_error_logs.js';
 const logger = log4js_obj.getLogger();
 
 export async function handleFriendCode(interaction: ChatInputCommandInteraction<CacheType>) {
-    if (!interaction.isCommand()) return;
+    if (!interaction.isChatInputCommand()) return;
     // 'インタラクションに失敗'が出ないようにするため
 
     const options = interaction.options;

--- a/src/app/feat-utils/other/help.ts
+++ b/src/app/feat-utils/other/help.ts
@@ -1,7 +1,7 @@
 import { CacheType, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
 
 export async function handleHelp(interaction: ChatInputCommandInteraction<CacheType>) {
-    if (!interaction.isCommand()) return;
+    if (!interaction.isChatInputCommand()) return;
     // 'インタラクションに失敗'が出ないようにするため
     await interaction.deferReply();
     const { options } = interaction;

--- a/src/app/feat-utils/voice/voice_locker.ts
+++ b/src/app/feat-utils/voice/voice_locker.ts
@@ -74,7 +74,6 @@ export async function voiceLocker(interaction: ChatInputCommandInteraction<'cach
             .reply({
                 embeds: [embed],
                 components: [button],
-                fetchReply: true,
             })
             .catch(async (error) => {
                 await sendErrorLogs(logger, error);
@@ -169,7 +168,6 @@ export async function voiceLockCommandUpdate(
                 .reply({
                     content: '今はロックされてないでし！',
                     ephemeral: true,
-                    fetchReply: true,
                 })
                 .catch(async (error) => {
                     await sendErrorLogs(logger, error);
@@ -182,7 +180,6 @@ export async function voiceLockCommandUpdate(
         .update({
             embeds: [createVCLEmbed(channelState)],
             components: [createVCLButton(channelState)],
-            fetchReply: true,
         })
         .catch(async (error) => {
             await sendErrorLogs(logger, error);

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -221,7 +221,7 @@ client.on('userUpdate', async (oldUser: User | PartialUser, newUser: User) => {
     }
 });
 
-client.on('ready', async (client: Client<true>) => {
+client.on('clientReady', async (client: Client<true>) => {
     try {
         assertExistCheck(client.user);
         logger.info(`Logged in as ${client.user.tag}!`);


### PR DESCRIPTION
## 概要

### 背景

discord.js v14 で非推奨となった API がランタイムの deprecation 警告として出力されていた。

### 作業内容

- `interaction.isCommand()` → `isChatInputCommand()` に置き換え（7ファイル）
  - `isCommand()` はスラッシュコマンドとコンテキストメニューコマンドを区別しないため、スラッシュコマンド専用の `isChatInputCommand()` が正確
- `fetchReply: true` オプションを削除（`voice_locker.ts` の3箇所）
  - v14 で `@deprecated` となり、戻り値を使用していないため単純削除で対応
- `ready` イベント → `clientReady` に置き換え（`index.ts`）
  - v15 では `ready` イベントは削除予定