### PR TITLE
refactor: ephemeral オプションを MessageFlags に移行

### DIFF
--- a/src/app/event/rookie/send_questionnaire.ts
+++ b/src/app/event/rookie/send_questionnaire.ts
@@ -5,6 +5,7 @@ import {
     ButtonStyle,
     DiscordAPIError,
     Message,
+    MessageFlags,
 } from 'discord.js';
 import log4js from 'log4js';
 
@@ -124,7 +125,7 @@ export async function sendQuestionnaireFollowUp(
         if (interaction.member.user.id !== params.get('uid')) {
             await interaction.followUp({
                 content: '他人のアンケートに答えることはできないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, '答える'),
@@ -150,7 +151,7 @@ export async function sendQuestionnaireFollowUp(
                 'このメッセージはDiscordの再起動や画面遷移等によって消える場合があるでし！\n' +
                 'すぐに答えない場合は先に回答画面に飛んでおくことをおすすめするでし！',
             components: [urlButton],
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
 
         await interaction.message.edit({
@@ -175,7 +176,7 @@ export async function disableQuestionnaireButtons(
         if (interaction.member.user.id !== params.get('uid')) {
             await interaction.followUp({
                 content: 'あなたにこのボタンを押す権限はないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, '答えない'),

--- a/src/app/event/support_auto_tag/resolved_support.ts
+++ b/src/app/event/support_auto_tag/resolved_support.ts
@@ -1,4 +1,4 @@
-import { ButtonInteraction, PermissionsBitField } from 'discord.js';
+import { ButtonInteraction, MessageFlags, PermissionsBitField } from 'discord.js';
 
 import { tagIdsEmbed } from './tag_ids_embed';
 import { log4js_obj } from '../../../log4js_settings';
@@ -22,7 +22,7 @@ export async function setResolvedTag(interaction: ButtonInteraction<'cached' | '
         if (!member.permissions.has(PermissionsBitField.Flags.ManageThreads)) {
             return await interaction.reply({
                 content: '権限がないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         }
 
@@ -36,7 +36,7 @@ export async function setResolvedTag(interaction: ButtonInteraction<'cached' | '
             } else {
                 return await interaction.reply({
                     content: '想定されていないチャンネルでし！',
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
             }
         }

--- a/src/app/event/vctools_sticky/radio_request.ts
+++ b/src/app/event/vctools_sticky/radio_request.ts
@@ -1,5 +1,5 @@
 import { Member } from '@prisma/client';
-import { ButtonInteraction, EmbedBuilder } from 'discord.js';
+import { ButtonInteraction, EmbedBuilder, MessageFlags } from 'discord.js';
 
 import { log4js_obj } from '../../../log4js_settings';
 import { getGuildByInteraction } from '../../common/manager/guild_manager';
@@ -11,7 +11,7 @@ const logger = log4js_obj.getLogger('interaction');
 
 export async function sendRadioRequest(interaction: ButtonInteraction<'cached' | 'raw'>) {
     try {
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         const guild = await getGuildByInteraction(interaction);
         const sender = await searchDBMemberById(guild, interaction.member.user.id);

--- a/src/app/event/vctools_sticky/voice_lock.ts
+++ b/src/app/event/vctools_sticky/voice_lock.ts
@@ -5,6 +5,7 @@ import {
     ButtonStyle,
     ChannelType,
     DiscordAPIError,
+    MessageFlags,
     TextBasedChannel,
     VoiceBasedChannel,
     VoiceState,
@@ -34,7 +35,7 @@ export async function voiceLockUpdate(
         if (notExists(channel) || !channel.isVoiceBased()) {
             return await interaction.reply({
                 content: 'ボイスチャンネルでないと操作できないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         }
 
@@ -44,7 +45,7 @@ export async function voiceLockUpdate(
         if (notExists(member.voice.channel) || member.voice.channel.id != channel.id) {
             return await interaction.reply({
                 content: '対象のボイスチャンネルに接続する必要があるでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         }
         let limit = channel.userLimit;
@@ -92,7 +93,7 @@ export async function voiceLockUpdate(
             ) {
                 return await interaction.reply({
                     content: '今はロックされてないでし！',
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
             }
         }

--- a/src/app/feat-admin/ban/ban.ts
+++ b/src/app/feat-admin/ban/ban.ts
@@ -9,7 +9,7 @@ const logger = log4js_obj.getLogger('ban');
 
 export async function handleBan(interaction: ChatInputCommandInteraction<'cached'>) {
     // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({ ephemeral: false });
+    await interaction.deferReply({});
 
     const guild = interaction.guild;
     const member = interaction.member;

--- a/src/app/feat-admin/button_enabler/enable_button.ts
+++ b/src/app/feat-admin/button_enabler/enable_button.ts
@@ -1,4 +1,4 @@
-import { MessageContextMenuCommandInteraction, PermissionsBitField } from 'discord.js';
+import { MessageContextMenuCommandInteraction, MessageFlags, PermissionsBitField } from 'discord.js';
 
 import { log4js_obj } from '../../../log4js_settings';
 import { setButtonEnable } from '../../common/button_components';
@@ -19,7 +19,7 @@ export async function buttonEnable(
     if (!member.permissions.has(PermissionsBitField.Flags.ManageChannels)) {
         return await interaction.reply({
             content: '操作を実行する権限がないでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
     }
 

--- a/src/app/feat-admin/button_enabler/enable_button.ts
+++ b/src/app/feat-admin/button_enabler/enable_button.ts
@@ -24,7 +24,7 @@ export async function buttonEnable(
     }
 
     try {
-        await interaction.deferReply({ ephemeral: false });
+        await interaction.deferReply({});
 
         const message = interaction.targetMessage;
 

--- a/src/app/feat-admin/button_enabler/enable_button.ts
+++ b/src/app/feat-admin/button_enabler/enable_button.ts
@@ -1,4 +1,8 @@
-import { MessageContextMenuCommandInteraction, MessageFlags, PermissionsBitField } from 'discord.js';
+import {
+    MessageContextMenuCommandInteraction,
+    MessageFlags,
+    PermissionsBitField,
+} from 'discord.js';
 
 import { log4js_obj } from '../../../log4js_settings';
 import { setButtonEnable } from '../../common/button_components';

--- a/src/app/feat-admin/channel_settings/channel_settings_hanlder.ts
+++ b/src/app/feat-admin/channel_settings/channel_settings_hanlder.ts
@@ -17,7 +17,7 @@ const logger = log4js_obj.getLogger('interaction');
 
 export async function channelSettingsHandler(interaction: ChatInputCommandInteraction<'cached'>) {
     try {
-        await interaction.deferReply({ ephemeral: false });
+        await interaction.deferReply({});
 
         const guild = interaction.guild;
         const member = interaction.member;

--- a/src/app/feat-admin/environment_variables/variables_handler.ts
+++ b/src/app/feat-admin/environment_variables/variables_handler.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, PermissionsBitField } from 'discord.js';
+import { ChatInputCommandInteraction, MessageFlags, PermissionsBitField } from 'discord.js';
 
 import { deleteVariables } from './delete_variables';
 import { setVariables } from './set_variables';
@@ -7,7 +7,7 @@ import { ChannelService } from '../../../db/channel_service';
 import { notExists } from '../../common/others';
 
 export async function variablesHandler(interaction: ChatInputCommandInteraction<'cached'>) {
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
     const guild = interaction.guild;
     const member = interaction.member;
 

--- a/src/app/feat-admin/fest_setting/fest_settings.ts
+++ b/src/app/feat-admin/fest_setting/fest_settings.ts
@@ -8,7 +8,7 @@ import { notExists } from '../../common/others';
 import { ChannelKeySet } from '../../constant/channel_key';
 
 export async function festSettingHandler(interaction: ChatInputCommandInteraction<'cached'>) {
-    await interaction.deferReply({ ephemeral: false });
+    await interaction.deferReply({});
 
     const guild = interaction.guild;
     const member = interaction.member;

--- a/src/app/feat-admin/joined_date_fixer/fix_joined_date.ts
+++ b/src/app/feat-admin/joined_date_fixer/fix_joined_date.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction } from 'discord.js';
+import { ChatInputCommandInteraction, MessageFlags } from 'discord.js';
 
 import { MemberService } from '../../../db/member_service';
 import { UniqueRoleService } from '../../../db/unique_role_service';
@@ -26,7 +26,7 @@ export async function joinedAtFixer(interaction: ChatInputCommandInteraction<'ca
             return await interaction.reply('開発者のみが実行できるコマンドでし！');
         }
 
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         const targetUser = interaction.options.getUser('ユーザー', true);
         const year = interaction.options.getInteger('年', true);

--- a/src/app/feat-admin/shutdown/shutdown_process.ts
+++ b/src/app/feat-admin/shutdown/shutdown_process.ts
@@ -1,11 +1,11 @@
-import { ChatInputCommandInteraction, PermissionsBitField } from 'discord.js';
+import { ChatInputCommandInteraction, MessageFlags, PermissionsBitField } from 'discord.js';
 
 export async function shutdown(interaction: ChatInputCommandInteraction<'cached'>) {
     const member = interaction.member;
     if (!member.permissions.has(PermissionsBitField.Flags.ManageGuild)) {
         return await interaction.reply({
             content: '操作を実行する権限がないでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
     }
 

--- a/src/app/feat-admin/unique_channel_settings/unique_channel_settings_hanlder.ts
+++ b/src/app/feat-admin/unique_channel_settings/unique_channel_settings_hanlder.ts
@@ -12,7 +12,7 @@ export async function uniqueChannelSettingsHandler(
     interaction: ChatInputCommandInteraction<'cached'>,
 ) {
     try {
-        await interaction.deferReply({ ephemeral: false });
+        await interaction.deferReply({});
 
         const member = interaction.member;
 

--- a/src/app/feat-admin/unique_role_settings/unique_role_settings_hanlder.ts
+++ b/src/app/feat-admin/unique_role_settings/unique_role_settings_hanlder.ts
@@ -12,7 +12,7 @@ export async function uniqueRoleSettingsHandler(
     interaction: ChatInputCommandInteraction<'cached'>,
 ) {
     try {
-        await interaction.deferReply({ ephemeral: false });
+        await interaction.deferReply({});
 
         const member = interaction.member;
 

--- a/src/app/feat-recruit/common/create_recruit/arrange_command_data.ts
+++ b/src/app/feat-recruit/common/create_recruit/arrange_command_data.ts
@@ -1,4 +1,4 @@
-import { ChannelType, ChatInputCommandInteraction } from 'discord.js';
+import { ChannelType, ChatInputCommandInteraction, MessageFlags } from 'discord.js';
 
 import { RecruitType } from '../../../../db/recruit_service';
 import { log4js_obj } from '../../../../log4js_settings';
@@ -147,7 +147,7 @@ export async function arrangeRecruitData(
             await interaction.deleteReply();
             await interaction.followUp({
                 content: `\`${interaction.toString()}\`\n${error.getErrorMessage()}`,
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         } else {
             await recruitChannel.send(ErrorTexts.UndefinedError);

--- a/src/app/feat-recruit/common/create_recruit/arrange_modal_data.ts
+++ b/src/app/feat-recruit/common/create_recruit/arrange_modal_data.ts
@@ -1,4 +1,4 @@
-import { ModalSubmitInteraction } from 'discord.js';
+import { MessageFlags, ModalSubmitInteraction } from 'discord.js';
 
 import { RecruitType } from '../../../../db/recruit_service';
 import { log4js_obj } from '../../../../log4js_settings';
@@ -116,7 +116,7 @@ export async function arrangeModalRecruitData(
             await interaction.deleteReply();
             await interaction.followUp({
                 content: `${error.getErrorMessage()}`,
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         } else {
             await recruitChannel.send(ErrorTexts.UndefinedError);

--- a/src/app/feat-recruit/common/create_recruit/send_recruit_message.ts
+++ b/src/app/feat-recruit/common/create_recruit/send_recruit_message.ts
@@ -1,7 +1,8 @@
 import {
-    Message,
-    ChatInputCommandInteraction,
     AttachmentBuilder,
+    ChatInputCommandInteraction,
+    Message,
+    MessageFlags,
     ModalSubmitInteraction,
 } from 'discord.js';
 
@@ -64,7 +65,7 @@ export async function sendRecruitCanvas(
 
     await interaction.followUp({
         content: '募集完了でし！参加者が来るまで待つでし！\n15秒間は募集を取り消せるでし！',
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
     });
 
     return {

--- a/src/app/feat-recruit/common/vc_reservation/recruit_event.ts
+++ b/src/app/feat-recruit/common/vc_reservation/recruit_event.ts
@@ -14,9 +14,10 @@ import {
     GuildScheduledEventPrivacyLevel,
     GuildScheduledEventStatus,
     Message,
-    time,
+    MessageFlags,
     TimestampStyles,
     VoiceBasedChannel,
+    time,
 } from 'discord.js';
 
 import { log4js_obj } from '../../../../log4js_settings';
@@ -198,7 +199,7 @@ export async function endRecruitEventButton(
         if (userId !== recruiterId) {
             await interaction.followUp({
                 content: '募集者以外はイベントを終了できないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             return await interaction.editReply({
                 components: recoveryThinkingButton(interaction, 'イベント終了'),
@@ -208,7 +209,7 @@ export async function endRecruitEventButton(
         if (notExists(eventId)) {
             await interaction.followUp({
                 content: 'イベントが見つからないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
 
             return await interaction.message.delete();
@@ -220,7 +221,7 @@ export async function endRecruitEventButton(
             if (error instanceof RecruitEventError) {
                 await interaction.followUp({
                     content: error.getErrorMessage(),
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
             } else {
                 throw error;

--- a/src/app/feat-recruit/interactions/anarchy_recruit.ts
+++ b/src/app/feat-recruit/interactions/anarchy_recruit.ts
@@ -36,7 +36,7 @@ export async function anarchyRecruit(
 ) {
     assertExistCheck(interaction.channel, 'channel');
     // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({ ephemeral: false });
+    await interaction.deferReply({});
 
     const recruitName = 'バンカラ募集';
     const recruitType = RecruitType.AnarchyRecruit;

--- a/src/app/feat-recruit/interactions/buttons/cancel_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/cancel_event.ts
@@ -52,7 +52,6 @@ export async function cancel(
             });
             await interaction.followUp({
                 content: '募集データが存在しないでし！',
-                ephemeral: false,
             });
             return;
         }
@@ -109,7 +108,7 @@ export async function cancel(
                 content: `<@${recruiterId}>たんの募集はキャンセルされたでし！`,
                 components: disableThinkingButton(interaction, 'キャンセル'),
             });
-            await interaction.followUp({ embeds: [embed], ephemeral: false });
+            await interaction.followUp({ embeds: [embed] });
 
             if (recruitChannel.isThread()) {
                 // フォーラムやスレッドの場合は、テキストの募集チャンネルにSticky Messageを送信する

--- a/src/app/feat-recruit/interactions/buttons/cancel_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/cancel_event.ts
@@ -154,7 +154,7 @@ export async function cancel(
             } else {
                 await interaction.followUp({
                     content: '他人の募集は勝手にキャンセルできないでし！！',
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
                 await interaction.editReply({
                     components: recoveryThinkingButton(interaction, 'キャンセル'),

--- a/src/app/feat-recruit/interactions/buttons/cancel_notify_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/cancel_notify_event.ts
@@ -140,7 +140,7 @@ export async function cancelNotify(interaction: ButtonInteraction<'cached' | 'ra
             } else {
                 await interaction.followUp({
                     content: '他人の募集は勝手にキャンセルできないでし！！',
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
                 await interaction.editReply({
                     components: recoveryThinkingButton(interaction, 'キャンセル'),

--- a/src/app/feat-recruit/interactions/buttons/cancel_notify_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/cancel_notify_event.ts
@@ -43,7 +43,6 @@ export async function cancelNotify(interaction: ButtonInteraction<'cached' | 'ra
             });
             await interaction.followUp({
                 content: '募集データが存在しないでし！',
-                ephemeral: false,
             });
             return;
         }
@@ -97,7 +96,7 @@ export async function cancelNotify(interaction: ButtonInteraction<'cached' | 'ra
                 content: `<@${recruiterId}>たんの募集はキャンセルされたでし！`,
                 components: disableThinkingButton(interaction, 'キャンセル'),
             });
-            await interaction.followUp({ embeds: [embed], ephemeral: false });
+            await interaction.followUp({ embeds: [embed] });
 
             if (recruitChannel.isThread()) {
                 // フォーラムやスレッドの場合は、テキストの募集チャンネルにSticky Messageを送信する

--- a/src/app/feat-recruit/interactions/buttons/close_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/close_event.ts
@@ -47,7 +47,6 @@ export async function close(
             await interaction.editReply({ components: disableThinkingButton(interaction, '〆') });
             await interaction.followUp({
                 content: '募集データが存在しないでし！',
-                ephemeral: false,
             });
             return;
         }
@@ -110,7 +109,7 @@ export async function close(
                 content: `<@${recruiterId}>たんの募集は〆！\n${memberList}`,
                 components: disableThinkingButton(interaction, '〆'),
             });
-            await interaction.followUp({ embeds: [embed], ephemeral: false });
+            await interaction.followUp({ embeds: [embed] });
 
             if (recruitChannel.isThread()) {
                 // フォーラムやスレッドの場合は、テキストの募集チャンネルにSticky Messageを送信する
@@ -147,7 +146,7 @@ export async function close(
             const embed = new EmbedBuilder().setDescription(
                 `<@${recruiterId}>たんの募集〆 \n <@${member.userId}>たんが代理〆`,
             );
-            await interaction.followUp({ embeds: [embed], ephemeral: false });
+            await interaction.followUp({ embeds: [embed] });
 
             if (recruitChannel.isThread()) {
                 // フォーラムやスレッドの場合は、テキストの募集チャンネルにSticky Messageを送信する

--- a/src/app/feat-recruit/interactions/buttons/close_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/close_event.ts
@@ -1,4 +1,4 @@
-import { ButtonInteraction, EmbedBuilder } from 'discord.js';
+import { ButtonInteraction, EmbedBuilder, MessageFlags } from 'discord.js';
 
 import { getMemberMentions } from './other_events.js';
 import { increaseJoinCount, increaseRecruitCount } from './recruit_count.js';
@@ -163,7 +163,7 @@ export async function close(
         } else {
             await interaction.followUp({
                 content: '募集主以外は募集を〆られないでし。',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.editReply({
                 components: recoveryThinkingButton(interaction, '〆'),

--- a/src/app/feat-recruit/interactions/buttons/close_notify_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/close_notify_event.ts
@@ -38,7 +38,6 @@ export async function closeNotify(interaction: ButtonInteraction<'cached' | 'raw
             await interaction.editReply({ components: disableThinkingButton(interaction, '〆') });
             await interaction.followUp({
                 content: '募集データが存在しないでし！',
-                ephemeral: false,
             });
             return;
         }
@@ -101,7 +100,7 @@ export async function closeNotify(interaction: ButtonInteraction<'cached' | 'raw
                 components: disableThinkingButton(interaction, '〆'),
             });
 
-            await interaction.followUp({ embeds: [embed], ephemeral: false });
+            await interaction.followUp({ embeds: [embed] });
 
             if (recruitChannel.isThread()) {
                 // フォーラムやスレッドの場合は、テキストの募集チャンネルにSticky Messageを送信する
@@ -137,7 +136,7 @@ export async function closeNotify(interaction: ButtonInteraction<'cached' | 'raw
             const embed = new EmbedBuilder().setDescription(
                 `<@${recruiterId}>たんの募集〆 \n <@${member.userId}>たんが代理〆`,
             );
-            await interaction.followUp({ embeds: [embed], ephemeral: false });
+            await interaction.followUp({ embeds: [embed] });
 
             if (recruitChannel.isThread()) {
                 // フォーラムやスレッドの場合は、テキストの募集チャンネルにSticky Messageを送信する

--- a/src/app/feat-recruit/interactions/buttons/close_notify_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/close_notify_event.ts
@@ -1,4 +1,4 @@
-import { ButtonInteraction, EmbedBuilder } from 'discord.js';
+import { ButtonInteraction, EmbedBuilder, MessageFlags } from 'discord.js';
 
 import { getMemberMentions } from './other_events.js';
 import { increaseRecruitCount, increaseJoinCount } from './recruit_count.js';
@@ -153,7 +153,7 @@ export async function closeNotify(interaction: ButtonInteraction<'cached' | 'raw
         } else {
             await interaction.followUp({
                 content: '募集主以外は募集を〆られないでし。',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.editReply({
                 components: recoveryThinkingButton(interaction, '〆'),

--- a/src/app/feat-recruit/interactions/buttons/confirm_join_request.ts
+++ b/src/app/feat-recruit/interactions/buttons/confirm_join_request.ts
@@ -48,7 +48,7 @@ export async function confirmJoinRequest(
             await interaction.followUp({
                 content:
                     '参加承認/拒否の操作は募集主か募集時に参加確定していた人しかできないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             if (recuritPram === RecruitParam.Approve) {
                 return await interaction.editReply({

--- a/src/app/feat-recruit/interactions/buttons/delete_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/delete_event.ts
@@ -1,4 +1,4 @@
-import { ButtonInteraction } from 'discord.js';
+import { ButtonInteraction, MessageFlags } from 'discord.js';
 
 import { sendRecruitButtonLog } from '../.././../logs/buttons/recruit_button_log';
 import { ParticipantService, ParticipantMember } from '../../../../db/participant_service.js';
@@ -51,7 +51,7 @@ export async function del(
             });
             await interaction.followUp({
                 content: 'この募集はもう削除できないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             return;
         }
@@ -114,7 +114,7 @@ export async function del(
             if (notExists(recruitData)) {
                 return await interaction.followUp({
                     content: '募集データが存在しないでし！',
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
             }
 
@@ -130,7 +130,7 @@ export async function del(
 
             await interaction.followUp({
                 content: '募集を削除したでし！\n次回は内容をしっかり確認してから送信するでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
 
             // テキストの募集チャンネルにSticky Messageを送信
@@ -143,7 +143,7 @@ export async function del(
             });
             await interaction.followUp({
                 content: '他人の募集は消せる訳無いでし！！！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         }
     } catch (error) {

--- a/src/app/feat-recruit/interactions/buttons/join_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/join_event.ts
@@ -1,4 +1,4 @@
-import { ButtonInteraction } from 'discord.js';
+import { ButtonInteraction, MessageFlags } from 'discord.js';
 
 import { memberListText } from './other_events.js';
 import { sendJoinNotifyToHost } from './send_notify_to_host.js';
@@ -83,7 +83,7 @@ export async function join(
         if (confirmedMemberIDList.includes(member.userId)) {
             await interaction.followUp({
                 content: '募集メンバーは参加表明できないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
 
             await interaction.editReply({
@@ -96,7 +96,7 @@ export async function join(
             if (applicantIdList.includes(member.userId)) {
                 await interaction.followUp({
                     content: '既に参加ボタンを押してるでし！',
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
 
                 await interaction.editReply({
@@ -137,13 +137,13 @@ export async function join(
                 await interaction.followUp({
                     content: `<@${recruiterId}>からの返答を待つでし！\n条件を満たさない場合は参加を断られる場合があるでし！`,
                     // components: [channelLinkButtons(interaction.guildId, thread_message.url)], TODO: スレッド内へのリンクボタンを作る
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
             } else {
                 await interaction.followUp({
                     content: `<@${recruiterId}>からの返答を待つでし！\n条件を満たさない場合は参加を断られる場合があるでし！`,
                     components: [channelLinkButtons(guild.id, channelId)],
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
             }
 
@@ -154,7 +154,7 @@ export async function join(
                 await interaction.followUp({
                     content: `ボタンを押すとヘヤタテ機能を使ってプライベートマッチの部屋に参加できるでし！`,
                     components: [nsoRoomLinkButton(recruitData.option)],
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
             }
 

--- a/src/app/feat-recruit/interactions/buttons/join_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/join_event.ts
@@ -44,7 +44,6 @@ export async function join(
             await interaction.editReply({ components: disableThinkingButton(interaction, '参加') });
             await interaction.followUp({
                 content: '募集データが存在しないでし！',
-                ephemeral: false,
             });
             return;
         }

--- a/src/app/feat-recruit/interactions/buttons/join_notify_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/join_notify_event.ts
@@ -1,4 +1,4 @@
-import { ButtonInteraction } from 'discord.js';
+import { ButtonInteraction, MessageFlags } from 'discord.js';
 
 import { memberListText } from './other_events.js';
 import { sendJoinNotifyToHost } from './send_notify_to_host.js';
@@ -69,7 +69,7 @@ export async function joinNotify(interaction: ButtonInteraction<'cached' | 'raw'
         if (member.userId === recruiterId) {
             await interaction.followUp({
                 content: '募集主は参加表明できないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
 
             await interaction.editReply({
@@ -83,7 +83,7 @@ export async function joinNotify(interaction: ButtonInteraction<'cached' | 'raw'
             if (applicantIdList.includes(member.userId)) {
                 await interaction.followUp({
                     content: 'すでに参加ボタンを押してるでし！',
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
 
                 await interaction.editReply({
@@ -121,7 +121,7 @@ export async function joinNotify(interaction: ButtonInteraction<'cached' | 'raw'
 
             await interaction.followUp({
                 content: `<@${recruiterId}>からの返答を待つでし！\n条件を満たさない場合は参加を断られる場合があるでし！`,
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
 
             await interaction.editReply({

--- a/src/app/feat-recruit/interactions/buttons/join_notify_event.ts
+++ b/src/app/feat-recruit/interactions/buttons/join_notify_event.ts
@@ -34,7 +34,6 @@ export async function joinNotify(interaction: ButtonInteraction<'cached' | 'raw'
             await interaction.editReply({ components: disableThinkingButton(interaction, '参加') });
             await interaction.followUp({
                 content: '募集データが存在しないでし！',
-                ephemeral: false,
             });
             return;
         }

--- a/src/app/feat-recruit/interactions/commands/button_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/button_recruit.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction } from 'discord.js';
+import { ChatInputCommandInteraction, MessageFlags } from 'discord.js';
 
 import { ParticipantService } from '../../../../db/participant_service';
 import { RecruitService, RecruitType } from '../../../../db/recruit_service';
@@ -16,7 +16,7 @@ import { getMemberMentions } from '../buttons/other_events';
 export async function buttonRecruit(interaction: ChatInputCommandInteraction<'cached'>) {
     assertExistCheck(interaction.channel, 'channel');
 
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     const guild = interaction.guild;
 

--- a/src/app/feat-recruit/interactions/commands/other_game_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/other_game_recruit.ts
@@ -31,7 +31,7 @@ const logger = log4js_obj.getLogger('recruit');
 export async function otherGameRecruit(interaction: ChatInputCommandInteraction<'cached'>) {
     assertExistCheck(interaction.channel, 'channel');
 
-    await interaction.deferReply({ ephemeral: false });
+    await interaction.deferReply({});
 
     const guild = interaction.guild;
     const options = interaction.options;

--- a/src/app/feat-recruit/interactions/commands/other_game_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/other_game_recruit.ts
@@ -1,14 +1,15 @@
 import {
-    ChatInputCommandInteraction,
     CacheType,
-    Guild,
-    GuildMember,
+    ChannelType,
+    ChatInputCommandInteraction,
     Collection,
-    Role,
     ColorResolvable,
     EmbedBuilder,
-    ChannelType,
+    Guild,
+    GuildMember,
     GuildTextBasedChannel,
+    MessageFlags,
+    Role,
 } from 'discord.js';
 
 import { ParticipantService } from '../../../../db/participant_service';
@@ -365,7 +366,7 @@ async function sendOtherGames(
 
         await interaction.followUp({
             content: '募集完了でし！参加者が来るまで待つでし！\n15秒間は募集を取り消せるでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
 
         // 募集リスト更新

--- a/src/app/feat-recruit/interactions/commands/private_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/private_recruit.ts
@@ -16,7 +16,7 @@ import { getMemberMentions } from '../buttons/other_events';
 const logger = log4js_obj.getLogger('recruit');
 
 export async function privateRecruit(interaction: ChatInputCommandInteraction<'cached'>) {
-    await interaction.deferReply({ ephemeral: false });
+    await interaction.deferReply({});
 
     const options = interaction.options;
     const startTime = options.getString('開始時刻', true);

--- a/src/app/feat-recruit/interactions/commands/private_recruit.ts
+++ b/src/app/feat-recruit/interactions/commands/private_recruit.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import { ChatInputCommandInteraction, EmbedBuilder, MessageFlags } from 'discord.js';
 
 import { ParticipantService } from '../../../../db/participant_service';
 import { RecruitService, RecruitType } from '../../../../db/recruit_service';
@@ -31,7 +31,7 @@ export async function privateRecruit(interaction: ChatInputCommandInteraction<'c
         await interaction.deleteReply();
         return await interaction.followUp({
             content: `\`${roomUrl}\`はヘヤタテURLではないでし！`,
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
     }
 
@@ -131,7 +131,7 @@ export async function privateRecruit(interaction: ChatInputCommandInteraction<'c
         await interaction.followUp({
             content:
                 '募集完了でし！参加者が来るまで気長に待つでし！\n15秒間は募集を取り消せるでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
 
         // 募集リスト更新

--- a/src/app/feat-recruit/interactions/context_menus/recruit_editor.ts
+++ b/src/app/feat-recruit/interactions/context_menus/recruit_editor.ts
@@ -1,6 +1,7 @@
 import {
     ActionRowBuilder,
     MessageContextMenuCommandInteraction,
+    MessageFlags,
     ModalBuilder,
     TextInputBuilder,
     TextInputStyle,
@@ -29,13 +30,13 @@ export async function createRecruitEditor(
             await interaction.reply({
                 content:
                     '該当の募集が見つからなかったでし！\n参加条件が表示されている画像のメッセージに対して使用するでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             return;
         }
 
         if (recruitData.authorId !== userId) {
-            await interaction.reply({ content: '他人の募集は編集できないでし！', ephemeral: true });
+            await interaction.reply({ content: '他人の募集は編集できないでし！', flags: MessageFlags.Ephemeral });
             return;
         }
 

--- a/src/app/feat-recruit/interactions/context_menus/recruit_editor.ts
+++ b/src/app/feat-recruit/interactions/context_menus/recruit_editor.ts
@@ -36,7 +36,10 @@ export async function createRecruitEditor(
         }
 
         if (recruitData.authorId !== userId) {
-            await interaction.reply({ content: '他人の募集は編集できないでし！', flags: MessageFlags.Ephemeral });
+            await interaction.reply({
+                content: '他人の募集は編集できないでし！',
+                flags: MessageFlags.Ephemeral,
+            });
             return;
         }
 

--- a/src/app/feat-recruit/interactions/event_recruit.ts
+++ b/src/app/feat-recruit/interactions/event_recruit.ts
@@ -25,7 +25,7 @@ export async function eventRecruit(
 ) {
     assertExistCheck(interaction.channel, 'channel');
     // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({ ephemeral: false });
+    await interaction.deferReply({});
 
     const recruitName = 'イベマ募集';
     const recruitType = RecruitType.EventRecruit;

--- a/src/app/feat-recruit/interactions/fest_recruit.ts
+++ b/src/app/feat-recruit/interactions/fest_recruit.ts
@@ -31,7 +31,7 @@ export async function festRecruit(
 ) {
     assertExistCheck(interaction.channel, 'channel');
     // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({ ephemeral: false });
+    await interaction.deferReply({});
 
     const recruitName = 'フェス募集';
     const recruitType = RecruitType.FestivalRecruit;

--- a/src/app/feat-recruit/interactions/modals/recruit_edit.ts
+++ b/src/app/feat-recruit/interactions/modals/recruit_edit.ts
@@ -24,7 +24,7 @@ export async function recruitEdit(
         const messageId = params.get('mid');
         assertExistCheck(messageId, "params.get('mid')");
 
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         const guild = await getGuildByInteraction(interaction);
 

--- a/src/app/feat-recruit/interactions/regular_recruit.ts
+++ b/src/app/feat-recruit/interactions/regular_recruit.ts
@@ -25,7 +25,7 @@ export async function regularRecruit(
 ) {
     assertExistCheck(interaction.channel, 'channel');
     // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({ ephemeral: false });
+    await interaction.deferReply({});
 
     const recruitName = 'ナワバリ募集';
     const recruitType = RecruitType.RegularRecruit;

--- a/src/app/feat-recruit/interactions/salmon_recruit.ts
+++ b/src/app/feat-recruit/interactions/salmon_recruit.ts
@@ -31,7 +31,7 @@ export async function salmonRecruit(
 ) {
     assertExistCheck(interaction.channel, 'channel');
     // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({ ephemeral: false });
+    await interaction.deferReply({});
 
     const recruitName = 'バイト募集';
     let recruitType;

--- a/src/app/feat-utils/other/friendcode.ts
+++ b/src/app/feat-utils/other/friendcode.ts
@@ -8,6 +8,7 @@ import {
     ChatInputCommandInteraction,
     EmbedBuilder,
     Message,
+    MessageFlags,
     User,
 } from 'discord.js';
 
@@ -163,7 +164,7 @@ function composeEmbed(user: User | Member, fc: string, isDatabase: boolean) {
 }
 
 async function insertFriendCode(interaction: ChatInputCommandInteraction<CacheType>) {
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     let userId;
     if (interaction.inGuild()) {

--- a/src/app/feat-utils/other/friendcode.ts
+++ b/src/app/feat-utils/other/friendcode.ts
@@ -38,7 +38,7 @@ export async function handleFriendCode(interaction: ChatInputCommandInteraction<
 }
 
 export async function selectFriendCode(interaction: ChatInputCommandInteraction<CacheType>) {
-    await interaction.deferReply({ ephemeral: false });
+    await interaction.deferReply({});
 
     let targetUser: Member | User | null;
     let userId: string;

--- a/src/app/feat-utils/other/kansen.ts
+++ b/src/app/feat-utils/other/kansen.ts
@@ -1,4 +1,9 @@
-import { CacheType, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import {
+    CacheType,
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    MessageFlags,
+} from 'discord.js';
 import { Combination } from 'js-combinatorics';
 
 export async function handleKansen(interaction: ChatInputCommandInteraction<CacheType>) {
@@ -11,14 +16,14 @@ export async function handleKansen(interaction: ChatInputCommandInteraction<Cach
     if (numOfTimes > 20) {
         await interaction.reply({
             content: '20回以下じゃないとダメでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
         return;
     }
     if (numOfTimes <= 0) {
         await interaction.reply({
             content: '1以上じゃないとダメでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
         return;
     }

--- a/src/app/feat-utils/other/kansen.ts
+++ b/src/app/feat-utils/other/kansen.ts
@@ -1,9 +1,4 @@
-import {
-    CacheType,
-    ChatInputCommandInteraction,
-    EmbedBuilder,
-    MessageFlags,
-} from 'discord.js';
+import { CacheType, ChatInputCommandInteraction, EmbedBuilder, MessageFlags } from 'discord.js';
 import { Combination } from 'js-combinatorics';
 
 export async function handleKansen(interaction: ChatInputCommandInteraction<CacheType>) {

--- a/src/app/feat-utils/other/timer.ts
+++ b/src/app/feat-utils/other/timer.ts
@@ -1,4 +1,4 @@
-import { CacheType, ChatInputCommandInteraction } from 'discord.js';
+import { CacheType, ChatInputCommandInteraction, MessageFlags } from 'discord.js';
 
 import { notExists } from '../../common/others';
 import { ErrorTexts } from '../../constant/error_texts';
@@ -14,7 +14,7 @@ export async function handleTimer(interaction: ChatInputCommandInteraction<Cache
     if (count > 10 || count <= 0) {
         return await interaction.reply({
             content: '10分以内しか入力できないでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
     }
 

--- a/src/app/feat-utils/other/wiki.ts
+++ b/src/app/feat-utils/other/wiki.ts
@@ -24,7 +24,7 @@ export async function handleWiki(interaction: ChatInputCommandInteraction<CacheT
         }
 
         // 'インタラクションに失敗'が出ないようにするため
-        await interaction.deferReply({ ephemeral: false });
+        await interaction.deferReply({});
         const wikipedia = wiki({ apiUrl: 'http://ja.wikipedia.org/w/api.php' });
         const data = await wikipedia.search(word);
         const page = await wikipedia.page(data.results[0]);

--- a/src/app/feat-utils/other/wiki.ts
+++ b/src/app/feat-utils/other/wiki.ts
@@ -1,4 +1,9 @@
-import { CacheType, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import {
+    CacheType,
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    MessageFlags,
+} from 'discord.js';
 import wiki from 'wikijs';
 
 import { log4js_obj } from '../../../log4js_settings';
@@ -14,7 +19,7 @@ export async function handleWiki(interaction: ChatInputCommandInteraction<CacheT
         if (notExists(word)) {
             return await interaction.reply({
                 content: 'キーワードが読み取れなかったでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         }
 

--- a/src/app/feat-utils/other/wiki.ts
+++ b/src/app/feat-utils/other/wiki.ts
@@ -1,9 +1,4 @@
-import {
-    CacheType,
-    ChatInputCommandInteraction,
-    EmbedBuilder,
-    MessageFlags,
-} from 'discord.js';
+import { CacheType, ChatInputCommandInteraction, EmbedBuilder, MessageFlags } from 'discord.js';
 import wiki from 'wikijs';
 
 import { log4js_obj } from '../../../log4js_settings';

--- a/src/app/feat-utils/splat3/buki.ts
+++ b/src/app/feat-utils/splat3/buki.ts
@@ -1,5 +1,11 @@
 import { Member } from '@prisma/client';
-import { CacheType, ChatInputCommandInteraction, EmbedBuilder, User } from 'discord.js';
+import {
+    CacheType,
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    MessageFlags,
+    User,
+} from 'discord.js';
 import fetch from 'node-fetch';
 
 import { log4js_obj } from '../../../log4js_settings';
@@ -54,13 +60,13 @@ export async function handleBuki(interaction: ChatInputCommandInteraction<CacheT
     if (amount > 10) {
         return await interaction.reply({
             content: '一度に指定できるのは10個まででし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
     }
     if (amount <= 0) {
         return await interaction.reply({
             content: '1以上の数を指定するでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
     }
 

--- a/src/app/feat-utils/team_divider/divider.ts
+++ b/src/app/feat-utils/team_divider/divider.ts
@@ -1,13 +1,14 @@
 import { TeamDivider } from '@prisma/client';
 import {
-    EmbedBuilder,
-    ButtonBuilder,
-    ActionRowBuilder,
-    ButtonStyle,
     APIEmbedField,
+    ActionRowBuilder,
+    ButtonBuilder,
     ButtonInteraction,
+    ButtonStyle,
     ChatInputCommandInteraction,
+    EmbedBuilder,
     GuildMember,
+    MessageFlags,
 } from 'discord.js';
 
 import { TeamDividerService, TeamMember } from '../../../db/team_divider_service';
@@ -47,7 +48,7 @@ export async function dividerInitialMessage(interaction: ChatInputCommandInterac
             await interaction.reply({
                 content:
                     '各チームのメンバー数は2～8人まででし！\n観戦を含む参加者上限は20人まででし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             return;
         }
@@ -55,7 +56,7 @@ export async function dividerInitialMessage(interaction: ChatInputCommandInterac
         if (notExists(member.voice.channelId)) {
             await interaction.reply({
                 content: 'このコマンドはVC参加中しか使えないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             return;
         }
@@ -124,7 +125,7 @@ export async function joinButton(
         if (member.voice.channelId != hostMember.voice.channelId) {
             await interaction.followUp({
                 content: 'ホストと同じVC参加者のみ参加できるでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, '参加'),
@@ -135,7 +136,7 @@ export async function joinButton(
         if (exists(await TeamDividerService.selectMemberFromDB(messageId, 0, member.id))) {
             await interaction.followUp({
                 content: '参加登録済みでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, '参加'),
@@ -185,7 +186,7 @@ export async function joinButton(
             embeds: [embed],
             components: recoveryThinkingButton(interaction, '参加'),
         });
-        await interaction.followUp({ content: '登録したでし！', ephemeral: true });
+        await interaction.followUp({ content: '登録したでし！', flags: MessageFlags.Ephemeral });
     } catch (error) {
         await sendErrorLogs(logger, error);
         if (exists(interaction.channel)) {
@@ -250,19 +251,19 @@ export async function cancelButton(
             });
             await interaction.followUp({
                 content: '参加をキャンセルしたでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         } else if (hostId == interaction.member.user.id) {
             await TeamDividerService.deleteAllMemberFromDB(messageId);
             await interaction.message.delete();
             await interaction.followUp({
                 content: 'チーム分けをキャンセルしたでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         } else {
             await interaction.followUp({
                 content: 'チーム分けをキャンセルできるのはホストだけでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, 'キャンセル'),
@@ -304,7 +305,7 @@ export async function registerButton(
         if (hostId != member.id) {
             await interaction.followUp({
                 content: '登録完了ボタンはコマンドを使用したユーザーしか使えないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, '登録完了'),
@@ -317,7 +318,7 @@ export async function registerButton(
         if (memberList.length < teamNum * 2) {
             await interaction.followUp({
                 content: '参加メンバーが少なすぎるでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, '登録完了'),
@@ -363,7 +364,7 @@ export async function registerButton(
             } else {
                 await interaction.followUp({
                     content: 'チーム分けエラー',
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
                 await interaction.message.edit({
                     components: recoveryThinkingButton(interaction, '登録完了'),
@@ -392,7 +393,7 @@ export async function registerButton(
         });
         await interaction.followUp({
             content: 'チームを更新したでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
     } catch (error) {
         await sendErrorLogs(logger, error);
@@ -469,7 +470,7 @@ async function matching(
         if (member.id != hostId) {
             await interaction.followUp({
                 content: 'このボタンはコマンドを使用したユーザーしか使えないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, winTeamName),
@@ -640,7 +641,7 @@ export async function spectateButton(
         if (!fullIdList.includes(member.id)) {
             await interaction.followUp({
                 content: 'このチーム分けに参加してないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, '観戦希望'),
@@ -669,13 +670,13 @@ export async function spectateButton(
 
             await interaction.followUp({
                 content: '観戦希望を取り下げたでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         } else {
             if (wantSpectateIdList.length > fullMembers.length - teamNum * 2 - 1) {
                 await interaction.followUp({
                     content: '観戦席はもう空いてないでし！',
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
                 await interaction.message.edit({
                     components: recoveryThinkingButton(interaction, '観戦希望'),
@@ -700,7 +701,7 @@ export async function spectateButton(
 
             await interaction.followUp({
                 content: '観戦希望を申し込んだでし！\nもう一度押すと希望を取り下げられるでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         }
     } catch (error) {
@@ -736,7 +737,7 @@ export async function endButton(
         if (member.id != hostId) {
             await interaction.followUp({
                 content: 'このボタンはコマンドを使用したユーザーしか使えないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, '終了'),
@@ -789,7 +790,7 @@ export async function correctButton(
         if (member.id != hostId) {
             await interaction.followUp({
                 content: 'このボタンはコマンドを使用したユーザーしか使えないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, '直前訂正'),
@@ -808,7 +809,7 @@ export async function correctButton(
         await interaction.followUp({
             content:
                 '最新のチーム分けを削除したでし！\nもう一度同じ操作をしても違うチーム分けになる場合があるでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
     } catch (error) {
         await sendErrorLogs(logger, error);
@@ -849,7 +850,7 @@ export async function hideButton(
         if (member.id != hostId) {
             await interaction.followUp({
                 content: 'このボタンはコマンドを使用したユーザーしか使えないでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             await interaction.message.edit({
                 components: recoveryThinkingButton(interaction, '戦績表示切替'),
@@ -867,13 +868,13 @@ export async function hideButton(
             await TeamDividerService.setHideWin(messageId, false);
             await interaction.followUp({
                 content: '`【戦績表示】: 表示`',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         } else {
             await TeamDividerService.setHideWin(messageId, true);
             await interaction.followUp({
                 content: '`【戦績表示】: 非表示`',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
         }
         const embed = await loadTeamEmbed(messageId, count, hostMember);

--- a/src/app/feat-utils/team_divider/divider.ts
+++ b/src/app/feat-utils/team_divider/divider.ts
@@ -380,7 +380,6 @@ export async function registerButton(
         if (notExists(embed) || notExists(buttons) || notExists(correctButton)) {
             return await interaction.followUp({
                 content: ErrorTexts.UndefinedError,
-                ephemeral: false,
             });
         }
 
@@ -597,7 +596,6 @@ async function matching(
         } else {
             return await interaction.followUp({
                 content: ErrorTexts.UndefinedError,
-                ephemeral: false,
             });
         }
     } catch (error) {
@@ -659,7 +657,6 @@ export async function spectateButton(
             if (notExists(embed)) {
                 return await interaction.followUp({
                     content: ErrorTexts.UndefinedError,
-                    ephemeral: false,
                 });
             }
 
@@ -690,7 +687,6 @@ export async function spectateButton(
             if (notExists(embed)) {
                 return await interaction.followUp({
                     content: ErrorTexts.UndefinedError,
-                    ephemeral: false,
                 });
             }
 
@@ -881,7 +877,6 @@ export async function hideButton(
         if (notExists(embed)) {
             return await interaction.followUp({
                 content: ErrorTexts.UndefinedError,
-                ephemeral: false,
             });
         }
         await interaction.message.edit({

--- a/src/app/feat-utils/voice/tts/discordjs_voice.ts
+++ b/src/app/feat-utils/voice/tts/discordjs_voice.ts
@@ -10,7 +10,13 @@ import {
     AudioPlayer,
     VoiceConnection,
 } from '@discordjs/voice';
-import { ButtonInteraction, ChatInputCommandInteraction, Message, VoiceState } from 'discord.js';
+import {
+    ButtonInteraction,
+    ChatInputCommandInteraction,
+    Message,
+    MessageFlags,
+    VoiceState,
+} from 'discord.js';
 
 import { modeApi, bufferToStream, setting } from './voice_bot_node';
 import { log4js_obj } from '../../../../log4js_settings';
@@ -152,7 +158,7 @@ export async function autokill(oldState: VoiceState) {
 export async function handleTTSCommand(interaction: ChatInputCommandInteraction<'cached'>) {
     try {
         // 'インタラクションに失敗'が出ないようにするため
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         const subCommand = interaction.options.getSubcommand();
 

--- a/src/app/feat-utils/voice/voice_locker.ts
+++ b/src/app/feat-utils/voice/voice_locker.ts
@@ -1,14 +1,15 @@
 import { setTimeout } from 'timers/promises';
 
 import {
-    EmbedBuilder,
     ActionRowBuilder,
     ButtonBuilder,
-    ButtonStyle,
     ButtonInteraction,
+    ButtonStyle,
     ChatInputCommandInteraction,
-    VoiceBasedChannel,
+    EmbedBuilder,
+    MessageFlags,
     TextBasedChannel,
+    VoiceBasedChannel,
 } from 'discord.js';
 
 import { log4js_obj } from '../../../log4js_settings';
@@ -33,7 +34,7 @@ export async function voiceLocker(interaction: ChatInputCommandInteraction<'cach
     if (notExists(member.voice.channel) || member.voice.channel.id != channel.id) {
         await interaction.reply({
             content: '接続中のボイスチャンネルでコマンドを打つでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
         return;
     }
@@ -45,7 +46,7 @@ export async function voiceLocker(interaction: ChatInputCommandInteraction<'cach
         if (limitNum < 0 || limitNum > 99) {
             await interaction.reply({
                 content: '制限人数は0～99の間で指定するでし！',
-                ephemeral: true,
+                flags: MessageFlags.Ephemeral,
             });
             return;
         }
@@ -106,7 +107,7 @@ export async function voiceLockCommandUpdate(
     if (!channel.isVoiceBased()) {
         return await interaction.reply({
             content: 'ボイスチャンネルでないと操作できないでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
     }
 
@@ -117,7 +118,7 @@ export async function voiceLockCommandUpdate(
     if (notExists(member.voice.channel) || member.voice.channel.id != channel.id) {
         await interaction.reply({
             content: '対象のボイスチャンネルに接続する必要があるでし！',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
         });
         return;
     }
@@ -167,7 +168,7 @@ export async function voiceLockCommandUpdate(
             await interaction
                 .reply({
                     content: '今はロックされてないでし！',
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 })
                 .catch(async (error) => {
                     await sendErrorLogs(logger, error);

--- a/src/app/feat-utils/voice/voice_mention.ts
+++ b/src/app/feat-utils/voice/voice_mention.ts
@@ -11,7 +11,7 @@ const logger = log4js_obj.getLogger('interaction');
 
 export async function voiceMention(interaction: ChatInputCommandInteraction<'cached'>) {
     try {
-        await interaction.deferReply({ ephemeral: false });
+        await interaction.deferReply({});
 
         const guild = interaction.guild;
 

--- a/src/app/handlers/button_handler.ts
+++ b/src/app/handlers/button_handler.ts
@@ -1,6 +1,6 @@
 import { URLSearchParams } from 'url';
 
-import { ButtonInteraction, CacheType } from 'discord.js';
+import { ButtonInteraction, CacheType, MessageFlags } from 'discord.js';
 
 import { exists } from '../common/others';
 import {
@@ -42,10 +42,10 @@ export async function call(interaction: ButtonInteraction<CacheType>) {
         } else if (isVCLockButton(customId)) {
             await voiceLockUpdate(interaction, customId);
         } else if (customId === VCToolsButton.VoiceJoin) {
-            await interaction.deferReply({ ephemeral: true });
+            await interaction.deferReply({ flags: MessageFlags.Ephemeral });
             await joinTTS(interaction);
         } else if (customId === VCToolsButton.VoiceKill) {
-            await interaction.deferReply({ ephemeral: true });
+            await interaction.deferReply({ flags: MessageFlags.Ephemeral });
             await killTTS(interaction);
         } else if (customId === VCToolsButton.RequestRadio) {
             await sendRadioRequest(interaction);

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -24,6 +24,7 @@ import {
     VoiceState,
 } from 'discord.js';
 
+import { MemberService } from '../db/member_service';
 import {
     inFallbackMode,
     updateLocale,
@@ -33,6 +34,10 @@ import { searchChannelById } from './common/manager/channel_manager';
 import { searchAPIMemberById } from './common/manager/member_manager';
 import { assertExistCheck, exists, getDeveloperMention, notExists } from './common/others';
 import { ChannelKeySet } from './constant/channel_key';
+import { ParticipantService } from '../db/participant_service';
+import { UniqueChannelService } from '../db/unique_channel_service';
+import { log4js_obj } from '../log4js_settings';
+import { registerSlashCommands } from '../register';
 import {
     deleteChannel,
     saveChannel,
@@ -58,11 +63,6 @@ import * as messageHandler from './handlers/message_handler';
 import * as modalHandler from './handlers/modal_handler';
 import * as vcStateUpdateHandler from './handlers/vcState_update_handler';
 import { sendErrorLogs } from './logs/error/send_error_logs';
-import { MemberService } from '../db/member_service';
-import { ParticipantService } from '../db/participant_service';
-import { UniqueChannelService } from '../db/unique_channel_service';
-import { log4js_obj } from '../log4js_settings';
-import { registerSlashCommands } from '../register';
 
 export const client = new Client({
     intents: [


### PR DESCRIPTION
## 概要

### 背景

discord.js v14 で `ephemeral` オプションが非推奨となり、ランタイムに deprecation 警告が出力されていた。

### 作業内容

- `ephemeral: true` → `flags: MessageFlags.Ephemeral` に置き換え（34ファイル・80箇所以上）
  - 未 import のファイルには `MessageFlags` を discord.js の import に追加
- `ephemeral: false` を削除（23ファイル）
  - デフォルト値のため指定不要