### PR TITLE
docs: README と CLAUDE.md を更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,16 @@ images/            # Bot が生成する画像の素材
 - `DATABASE_URL` — SQLite ファイルパス（例: `file:./db.sqlite3`）
 - `SLASH_COMMAND_REGISTER_MODE` — `guild` または `global`
 
+## README の更新
+
+以下のような構成・設定の変更を行った場合は、`README.md` も合わせて更新する：
+
+- セットアップ手順に影響する変更（依存ツール・パッケージマネージャーの変更など）
+- スクリプト（`package.json` の `scripts`）の追加・変更・削除
+- 主要パッケージのバージョン変更（discord.js・Prisma・Node.js など）
+- 環境変数の追加・変更
+- git フック・CI など開発フローに関わるツールの追加・変更
+
 ## コミット規約
 
 `.cz-config.js` に基づき、以下のプレフィックスを使用する：

--- a/README.md
+++ b/README.md
@@ -2,81 +2,102 @@
 
 ## 概要
 
-このリポジトリは、discord.jsを用いたDiscord Botのソースコードです。
+このリポジトリは、discord.js を用いた Discord Bot のソースコードです。
 
-## 利用方法
+## セットアップ
 
-以下の手順にしたがって、Botを利用してください。
+### 前提条件
 
-1. このリポジトリをcloneしてください。
-2. `npm install` を実行して、必要なパッケージをインストールしてください。
-3. `.env.sample`ファイルを`.env`にリネームし、必要な情報を設定してください。
-4. `npm run start`を実行して、Botを起動してください。
+- [mise](https://mise.jdx.dev/) がインストールされていること
+
+### 手順
+
+1. このリポジトリを clone してください。
+2. `mise install` を実行して、Node.js と pnpm をインストールしてください。
+3. `mise exec -- pnpm install` を実行して、必要なパッケージをインストールしてください（lefthook の git フックも自動でセットアップされます）。
+4. `.env.sample` ファイルを `.env` にリネームし、必要な情報を設定してください。
+5. `mise exec -- pnpm start` を実行して、Bot を起動してください。
 
 ## 環境
 
-- Node.js: `>=24.0.0`
+- Node.js: `>=24.0.0`（mise で管理）
+- pnpm: `>=10.0.0`（mise で管理）
 - Discord.js: `14.25.1`
 - Prisma: `7.1.0`
 
 ## データベース
 
-このプロジェクトはSQLiteデータベースを使用しています。Prisma 7.xでは`@prisma/adapter-better-sqlite3`ドライバーアダプターを使用しています。
+このプロジェクトは SQLite データベースを使用しています。Prisma 7.x では `@prisma/adapter-better-sqlite3` ドライバーアダプターを使用しています。
 
 - データベースファイル: `ikabu.sqlite3`（プロジェクトルート）
-- Prisma設定: `prisma.config.ts`
+- Prisma 設定: `prisma.config.ts`
 
-### データベースURL設定
+### データベース URL 設定
 
-`DATABASE_URL`環境変数を使用してデータベースの場所を指定できます。指定がない場合は、プロジェクトルートの`ikabu.sqlite3`が使用されます。
+`DATABASE_URL` 環境変数を使用してデータベースの場所を指定できます。指定がない場合は、プロジェクトルートの `ikabu.sqlite3` が使用されます。
 
-**DATABASE_URLの形式:**
+**DATABASE_URL の形式:**
+
 - 相対パス: `file:./path/to/db.sqlite3`
 - 絶対パス: `file:/absolute/path/to/db.sqlite3`
 
-例: `.env`ファイルに以下のように設定します:
+例: `.env` ファイルに以下のように設定します:
+
 ```
 DATABASE_URL=file:./ikabu.sqlite3
 ```
 
 ## デプロイ
 
-- 本番環境へのデプロイは、`main`ブランチへのマージ後、GitHub Actionsによって自動的にデプロイされます。
-- ステージング環境へのデプロイは、`stg`ブランチへのマージ後、GitHub Actionsによって自動的にデプロイされます。
+- 本番環境へのデプロイは、`main` ブランチへのマージ後、GitHub Actions によって自動的にデプロイされます。
+- ステージング環境へのデプロイは、`stg` ブランチへのマージ後、GitHub Actions によって自動的にデプロイされます。
 
 ## 利用可能なスクリプト
 
-プロジェクトには、以下のスクリプトが含まれています。
+コマンドは `mise exec -- pnpm run <script>` の形式で実行してください。mise が有効化されているシェルでは `pnpm run <script>` のみでも動作します。
 
-### `npm start`
+### `pnpm start`
 
-`.env`ファイルを読み込み、TypeScriptをコンパイルして、サーバーを開始します。
+`.env` ファイルを読み込み、TypeScript をコンパイルして、サーバーを開始します。
 
-### `npm run create-migrate`
+### `pnpm run compile`
 
-`Prisma migrate dev --create-only`を実行し、マイグレーションを作成します。
-Databaseのスキーマ変更内容を元にmigrationsにDDLを生成します。
+`prisma generate && tsc && prisma migrate deploy` を実行します。
 
-### `npm run migrate-deploy`
+### `pnpm run create-migrate`
 
-`Prisma migrate deploy`を実行し、マイグレーションを実行します。
+`prisma migrate dev --create-only` を実行し、マイグレーションファイルを作成します。
 
-### `npm run prisma-generate`
+### `pnpm run migrate-deploy`
 
-`Prisma generate`を実行し、PrismaClientを自動生成します。
+`prisma migrate deploy` を実行し、マイグレーションを実行します。
 
-### `npm run lint`
+### `pnpm run prisma-generate`
 
-`eslint`を実行して、コードを検証します。
+`prisma generate` を実行し、PrismaClient を自動生成します。
 
-### `npm run fix`
+### `pnpm run lint`
 
-`eslint`を実行して、コードを自動で修正します。
+`eslint` を実行して、コードを検証します。
 
-### `npm run test`
+### `pnpm run fix`
 
-`vitest`を実行して、テストを実行します。
+`eslint --fix` を実行して、コードを自動修正します。
+
+### `pnpm test`
+
+`vitest` を実行して、テストを実行します。
+
+## git フック（lefthook）
+
+push 時に自動で ESLint/Prettier が実行されます。自動修正が発生した場合は push が中断されるので、修正内容をコミットしてから再度 push してください。
+
+セットアップする場合は以下を実行してください
+
+```bash
+lefthook install
+```
 
 ## ライセンス
 
-このプロジェクトはMITライセンスのもとで公開されます。詳細については、LICENSEファイルを参照してください。
+このプロジェクトは MIT ライセンスのもとで公開されます。詳細については、LICENSE ファイルを参照してください。


### PR DESCRIPTION
## 概要

### 背景

README の内容が npm/volta 時代のままで、mise/pnpm への移行や lefthook の導入が反映されていなかった。

### 作業内容

- `README.md`: 現状に合わせて全体を更新
  - `npm` → `pnpm`、mise によるセットアップ手順に変更
  - スクリプト一覧を現状に合わせて更新
  - lefthook の説明を追加
- `CLAUDE.md`: 構成・設定変更時に README を更新する旨を追記
  - 対象: セットアップ手順・スクリプト・主要パッケージバージョン・環境変数・開発ツール