### PR TITLE
chore: CI に concurrency とデプロイスキップ条件を追加

### DIFF
--- a/.github/workflows/auto-deploy-main.yml
+++ b/.github/workflows/auto-deploy-main.yml
@@ -5,9 +5,24 @@ on:
     branches:
       - main
     types: [closed]
+    paths:
+      - 'src/**'
+      - 'prisma/**'
+      - 'config/**'
+      - 'images/**'
+      - 'fonts/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.mise.toml'
+      - '.gcloudignore'
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/auto-deploy-stg.yml
+++ b/.github/workflows/auto-deploy-stg.yml
@@ -5,9 +5,24 @@ on:
     branches:
       - stg
     types: [closed]
+    paths:
+      - 'src/**'
+      - 'prisma/**'
+      - 'config/**'
+      - 'images/**'
+      - 'fonts/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.mise.toml'
+      - '.gcloudignore'
+
+concurrency:
+  group: deploy-stg
+  cancel-in-progress: false
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## 概要

### 背景

- PR が連続してマージされた場合に複数のデプロイが同時実行される可能性があった
- ドキュメントのみの変更でも毎回デプロイが走っていた

### 作業内容

- `concurrency` を追加し、同一環境へのデプロイが重複しないよう制御（進行中のデプロイはキャンセルせず待機）
- `paths` フィルターを追加し、デプロイに影響しないファイルのみの変更時はワークフローをスキップ
  - 対象: `src/`・`prisma/`・`config/`・`images/`・`fonts/`・`package.json`・`pnpm-lock.yaml`・`.mise.toml`・`.gcloudignore`
- `if: github.event.pull_request.merged == true` を追加し、マージ時のみデプロイを実行