### PR TITLE
feat: モーダル募集でスラッシュコマンド同等の募集ができるように改善

### DIFF
--- a/src/app/feat-recruit/buttons/create_recruit_buttons.ts
+++ b/src/app/feat-recruit/buttons/create_recruit_buttons.ts
@@ -119,7 +119,7 @@ export function createNewRecruitButton(channelName: string) {
         button.addComponents([
             new ButtonBuilder()
                 .setCustomId(buttonParams.toString())
-                .setLabel('簡易' + channelName + 'をする')
+                .setLabel(channelName + 'をする')
                 .setStyle(ButtonStyle.Success),
         ]);
     }

--- a/src/app/feat-recruit/canvases/anarchy_canvas.ts
+++ b/src/app/feat-recruit/canvases/anarchy_canvas.ts
@@ -198,8 +198,6 @@ export async function recruitAnarchyCanvas(
     let channelString;
     if (notExists(channelName)) {
         channelString = '🔉 VC指定なし';
-    } else if (channelName === '[簡易版募集]') {
-        channelString = channelName;
     } else {
         channelString = '🔉 ' + channelName;
     }

--- a/src/app/feat-recruit/canvases/big_run_canvas.ts
+++ b/src/app/feat-recruit/canvases/big_run_canvas.ts
@@ -173,8 +173,6 @@ export async function recruitBigRunCanvas(
     let channelString;
     if (notExists(channelName)) {
         channelString = '🔉 VC指定なし';
-    } else if (channelName === '[簡易版募集]') {
-        channelString = channelName;
     } else {
         channelString = '🔉 ' + channelName;
     }

--- a/src/app/feat-recruit/canvases/event_canvas.ts
+++ b/src/app/feat-recruit/canvases/event_canvas.ts
@@ -197,8 +197,6 @@ export async function recruitEventCanvas(
     let channelString;
     if (notExists(channelName)) {
         channelString = '🔉 VC指定なし';
-    } else if (channelName === '[簡易版募集]') {
-        channelString = channelName;
     } else {
         channelString = '🔉 ' + channelName;
     }

--- a/src/app/feat-recruit/canvases/fest_canvas.ts
+++ b/src/app/feat-recruit/canvases/fest_canvas.ts
@@ -195,8 +195,6 @@ export async function recruitFestCanvas(
     let channelString;
     if (notExists(channelName)) {
         channelString = '🔉 VC指定なし';
-    } else if (channelName === '[簡易版募集]') {
-        channelString = channelName;
     } else {
         channelString = '🔉 ' + channelName;
     }

--- a/src/app/feat-recruit/canvases/regular_canvas.ts
+++ b/src/app/feat-recruit/canvases/regular_canvas.ts
@@ -143,8 +143,6 @@ export async function recruitRegularCanvas(
     let channelString;
     if (notExists(channelName)) {
         channelString = '🔉 VC指定なし';
-    } else if (channelName === '[簡易版募集]') {
-        channelString = channelName;
     } else {
         channelString = '🔉 ' + channelName;
     }

--- a/src/app/feat-recruit/canvases/salmon_canvas.ts
+++ b/src/app/feat-recruit/canvases/salmon_canvas.ts
@@ -203,8 +203,6 @@ export async function recruitSalmonCanvas(
     let channelString;
     if (notExists(channelName)) {
         channelString = '🔉 VC指定なし';
-    } else if (channelName === '[簡易版募集]') {
-        channelString = channelName;
     } else {
         channelString = '🔉 ' + channelName;
     }

--- a/src/app/feat-recruit/common/create_recruit/arrange_modal_data.ts
+++ b/src/app/feat-recruit/common/create_recruit/arrange_modal_data.ts
@@ -1,4 +1,4 @@
-import { MessageFlags, ModalSubmitInteraction } from 'discord.js';
+import { ChannelType, MessageFlags, ModalSubmitInteraction, VoiceBasedChannel } from 'discord.js';
 
 import { RecruitType } from '../../../../db/recruit_service';
 import { log4js_obj } from '../../../../log4js_settings';
@@ -21,6 +21,7 @@ import {
     checkRegularRecruitNum,
 } from '../../common/condition_checks/recruit_num_check';
 import { checkRecruitSchedule } from '../../common/condition_checks/schedule_check';
+import { getVCReserveErrorMessage } from '../../common/condition_checks/vc_reserve_check';
 import { RecruitConditionError } from '../../types/recruit_condition_error';
 import { RecruitData } from '../../types/recruit_data';
 
@@ -36,7 +37,6 @@ export async function arrangeModalRecruitData(
     const recruitChannel = interaction.channel;
     assertExistCheck(interactionMember, 'GuildMember');
     assertExistCheck(recruitChannel, 'interaction.channel');
-    const scheduleNum = 0;
 
     try {
         await sendRecruitModalLog(interaction);
@@ -48,17 +48,33 @@ export async function arrangeModalRecruitData(
             );
         }
 
+        // スケジュール番号（StringSelect がある場合は読み取る）
+        const scheduleNum = interaction.fields.fields.has('scheduleNum')
+            ? interaction.fields.getStringSelectValues('scheduleNum')[0] === 'next'
+                ? 1
+                : 0
+            : 0;
+
         const checkScheduleResponse = await checkRecruitSchedule(
             guild.id,
             schedule,
             scheduleNum,
             recruitType,
-        ); // 対象の日時に募集を建てられるかチェック
+        );
         if (!checkScheduleResponse.canRecruit) {
             throw new RecruitConditionError(checkScheduleResponse.recruitDateErrorMessage);
         }
 
-        const voiceChannel = null;
+        // ボイスチャンネル（ChannelSelect がある場合は読み取る）
+        const voiceChannelCollection = interaction.fields.fields.has('voiceChannel')
+            ? interaction.fields.getSelectedChannels('voiceChannel', false, [
+                  ChannelType.GuildVoice,
+              ])
+            : null;
+        const voiceChannel = voiceChannelCollection
+            ? ([...voiceChannelCollection.values()][0] as VoiceBasedChannel) ?? null
+            : null;
+
         const recruitNum = Number(interaction.fields.getTextInputValue('rNum'));
 
         if (Number.isNaN(recruitNum)) {
@@ -71,9 +87,20 @@ export async function arrangeModalRecruitData(
         const recruiter = await searchDBMemberById(guild, interactionMember.id);
         assertExistCheck(recruiter, 'Member');
 
-        const attendee1 = null;
-        const attendee2 = null;
-        const attendee3 = null;
+        // 参加者（UserSelect がある場合は読み取る）
+        const attendeeUsersCollection = interaction.fields.fields.has('attendees')
+            ? interaction.fields.getSelectedUsers('attendees')
+            : null;
+        const attendeeUsers = attendeeUsersCollection ? [...attendeeUsersCollection.values()] : [];
+        const attendee1 = attendeeUsers[0]
+            ? await searchDBMemberById(guild, attendeeUsers[0].id)
+            : null;
+        const attendee2 = attendeeUsers[1]
+            ? await searchDBMemberById(guild, attendeeUsers[1].id)
+            : null;
+        const attendee3 = attendeeUsers[2]
+            ? await searchDBMemberById(guild, attendeeUsers[2].id)
+            : null;
 
         let recruitNumCheckResponse;
         if (recruitType === RecruitType.RegularRecruit) {
@@ -91,7 +118,41 @@ export async function arrangeModalRecruitData(
             throw new RecruitConditionError(recruitNumCheckResponse.recruitNumErrorMessage);
         }
 
+        if (exists(voiceChannel)) {
+            const voiceChannelReserveErrorMessage = await getVCReserveErrorMessage(
+                guild.id,
+                voiceChannel,
+                recruiter.userId,
+            );
+            if (exists(voiceChannelReserveErrorMessage)) {
+                throw new RecruitConditionError(voiceChannelReserveErrorMessage);
+            }
+        }
+
         let txt = `### ${recruiter.mention}たんの${recruitName}\n`;
+        const members: string[] = [];
+
+        if (exists(attendee1)) {
+            members.push(attendee1.mention + 'たん');
+        }
+        if (exists(attendee2)) {
+            members.push(attendee2.mention + 'たん');
+        }
+        if (exists(attendee3)) {
+            members.push(attendee3.mention + 'たん');
+        }
+
+        if (members.length !== 0) {
+            for (const i in members) {
+                if (parseInt(i) === 0) {
+                    txt = txt + members[i];
+                } else {
+                    txt = txt + 'と' + members[i];
+                }
+            }
+            txt += 'の参加が既に決定しているでし！\n';
+        }
+
         txt += 'よければ合流しませんか？';
 
         return {

--- a/src/app/feat-recruit/interactions/anarchy_recruit.ts
+++ b/src/app/feat-recruit/interactions/anarchy_recruit.ts
@@ -55,11 +55,9 @@ export async function anarchyRecruit(
             return;
         }
     } else if (interaction.isModalSubmit()) {
-        recruitRoleId = await UniqueRoleService.getRoleIdByKey(
-            interaction.guildId,
-            RoleKeySet.AnarchyRecruit.key,
-        );
-        rank = '指定なし';
+        const recruitRankRole = await getAnarchyRecruitRoleFromModal(interaction);
+        recruitRoleId = recruitRankRole.recruitRoleId;
+        rank = recruitRankRole.rank;
 
         try {
             recruitData = await arrangeModalRecruitData(interaction, recruitName, recruitType);
@@ -156,6 +154,25 @@ type AnarchyRecruitRankRole = {
     recruitRoleId: string | null;
     rank: string;
 };
+async function getAnarchyRecruitRoleFromModal(
+    interaction: ModalSubmitInteraction<'cached' | 'raw'>,
+): Promise<AnarchyRecruitRankRole> {
+    assertExistCheck(interaction.channel, 'channel');
+    const anarchyRecruitRoleId = await UniqueRoleService.getRoleIdByKey(
+        interaction.guildId,
+        RoleKeySet.AnarchyRecruit.key,
+    );
+    if (notExists(anarchyRecruitRoleId)) {
+        await interaction.channel.send(
+            (await getDeveloperMention(interaction.guildId)) +
+                `\nバンカラ募集ロールが設定されていないでし！`,
+        );
+        return { recruitRoleId: null, rank: 'えらー' };
+    }
+
+    return { recruitRoleId: anarchyRecruitRoleId, rank: '指定なし' };
+}
+
 async function getAnarchyRecruitRole(
     interaction: ChatInputCommandInteraction<'cached' | 'raw'>,
 ): Promise<AnarchyRecruitRankRole> {

--- a/src/app/feat-recruit/modals/create_anarchy_modal.ts
+++ b/src/app/feat-recruit/modals/create_anarchy_modal.ts
@@ -55,7 +55,7 @@ export async function createAnarchyModal(interaction: ButtonInteraction<'cached'
         );
 
     const attendeesLabel = new LabelBuilder()
-        .setLabel('既にに決まっている参加者(最大2人)')
+        .setLabel('既に決まっている参加者(最大2人)')
         .setUserSelectMenuComponent(
             new UserSelectMenuBuilder()
                 .setCustomId('attendees')

--- a/src/app/feat-recruit/modals/create_anarchy_modal.ts
+++ b/src/app/feat-recruit/modals/create_anarchy_modal.ts
@@ -1,9 +1,15 @@
 import {
     ActionRowBuilder,
     ButtonInteraction,
+    ChannelSelectMenuBuilder,
+    ChannelType,
+    LabelBuilder,
     ModalBuilder,
+    StringSelectMenuBuilder,
+    StringSelectMenuOptionBuilder,
     TextInputBuilder,
     TextInputStyle,
+    UserSelectMenuBuilder,
 } from 'discord.js';
 
 export async function createAnarchyModal(interaction: ButtonInteraction<'cached' | 'raw'>) {
@@ -30,10 +36,49 @@ export async function createAnarchyModal(interaction: ButtonInteraction<'cached'
         .setMaxLength(120)
         .setRequired(true);
 
+    const scheduleNumLabel = new LabelBuilder()
+        .setLabel('スケジュール')
+        .setStringSelectMenuComponent(
+            new StringSelectMenuBuilder()
+                .setCustomId('scheduleNum')
+                .setMinValues(1)
+                .setMaxValues(1)
+                .addOptions(
+                    new StringSelectMenuOptionBuilder()
+                        .setLabel('現在のスケジュール')
+                        .setValue('now')
+                        .setDefault(true),
+                    new StringSelectMenuOptionBuilder()
+                        .setLabel('次のスケジュール')
+                        .setValue('next'),
+                ),
+        );
+
+    const attendeesLabel = new LabelBuilder()
+        .setLabel('既にに決まっている参加者(最大2人)')
+        .setUserSelectMenuComponent(
+            new UserSelectMenuBuilder()
+                .setCustomId('attendees')
+                .setMinValues(0)
+                .setMaxValues(2)
+                .setRequired(false),
+        );
+
+    const voiceChannelLabel = new LabelBuilder()
+        .setLabel('使用するボイスチャンネル')
+        .setChannelSelectMenuComponent(
+            new ChannelSelectMenuBuilder()
+                .setCustomId('voiceChannel')
+                .setChannelTypes(ChannelType.GuildVoice)
+                .setMinValues(0)
+                .setMaxValues(1)
+                .setRequired(false),
+        );
+
     const row1 = new ActionRowBuilder<TextInputBuilder>().addComponents(recruitNumInput);
     const row2 = new ActionRowBuilder<TextInputBuilder>().addComponents(conditionInput);
 
-    modal.addComponents(row1, row2);
+    modal.addComponents(row1, row2, scheduleNumLabel, attendeesLabel, voiceChannelLabel);
 
     await interaction.showModal(modal);
 }

--- a/src/app/feat-recruit/modals/create_event_modal.ts
+++ b/src/app/feat-recruit/modals/create_event_modal.ts
@@ -1,9 +1,15 @@
 import {
     ActionRowBuilder,
     ButtonInteraction,
+    ChannelSelectMenuBuilder,
+    ChannelType,
+    LabelBuilder,
     ModalBuilder,
+    StringSelectMenuBuilder,
+    StringSelectMenuOptionBuilder,
     TextInputBuilder,
     TextInputStyle,
+    UserSelectMenuBuilder,
 } from 'discord.js';
 
 export async function createEventModal(interaction: ButtonInteraction<'cached' | 'raw'>) {
@@ -30,10 +36,49 @@ export async function createEventModal(interaction: ButtonInteraction<'cached' |
         .setMaxLength(120)
         .setRequired(true);
 
+    const scheduleNumLabel = new LabelBuilder()
+        .setLabel('スケジュール')
+        .setStringSelectMenuComponent(
+            new StringSelectMenuBuilder()
+                .setCustomId('scheduleNum')
+                .setMinValues(1)
+                .setMaxValues(1)
+                .addOptions(
+                    new StringSelectMenuOptionBuilder()
+                        .setLabel('現在のスケジュール')
+                        .setValue('now')
+                        .setDefault(true),
+                    new StringSelectMenuOptionBuilder()
+                        .setLabel('次のスケジュール')
+                        .setValue('next'),
+                ),
+        );
+
+    const attendeesLabel = new LabelBuilder()
+        .setLabel('既にに決まっている参加者(最大2人)')
+        .setUserSelectMenuComponent(
+            new UserSelectMenuBuilder()
+                .setCustomId('attendees')
+                .setMinValues(0)
+                .setMaxValues(2)
+                .setRequired(false),
+        );
+
+    const voiceChannelLabel = new LabelBuilder()
+        .setLabel('使用するボイスチャンネル')
+        .setChannelSelectMenuComponent(
+            new ChannelSelectMenuBuilder()
+                .setCustomId('voiceChannel')
+                .setChannelTypes(ChannelType.GuildVoice)
+                .setMinValues(0)
+                .setMaxValues(1)
+                .setRequired(false),
+        );
+
     const row1 = new ActionRowBuilder<TextInputBuilder>().addComponents(recruitNumInput);
     const row2 = new ActionRowBuilder<TextInputBuilder>().addComponents(conditionInput);
 
-    modal.addComponents(row1, row2);
+    modal.addComponents(row1, row2, scheduleNumLabel, attendeesLabel, voiceChannelLabel);
 
     await interaction.showModal(modal);
 }

--- a/src/app/feat-recruit/modals/create_event_modal.ts
+++ b/src/app/feat-recruit/modals/create_event_modal.ts
@@ -55,7 +55,7 @@ export async function createEventModal(interaction: ButtonInteraction<'cached' |
         );
 
     const attendeesLabel = new LabelBuilder()
-        .setLabel('既にに決まっている参加者(最大2人)')
+        .setLabel('既に決まっている参加者(最大2人)')
         .setUserSelectMenuComponent(
             new UserSelectMenuBuilder()
                 .setCustomId('attendees')

--- a/src/app/feat-recruit/modals/create_fest_modal.ts
+++ b/src/app/feat-recruit/modals/create_fest_modal.ts
@@ -59,7 +59,7 @@ export async function createFestModal(
         );
 
     const attendeesLabel = new LabelBuilder()
-        .setLabel('既にに決まっている参加者(最大2人)')
+        .setLabel('既に決まっている参加者(最大2人)')
         .setUserSelectMenuComponent(
             new UserSelectMenuBuilder()
                 .setCustomId('attendees')

--- a/src/app/feat-recruit/modals/create_fest_modal.ts
+++ b/src/app/feat-recruit/modals/create_fest_modal.ts
@@ -1,9 +1,15 @@
 import {
     ActionRowBuilder,
     ButtonInteraction,
+    ChannelSelectMenuBuilder,
+    ChannelType,
+    LabelBuilder,
     ModalBuilder,
+    StringSelectMenuBuilder,
+    StringSelectMenuOptionBuilder,
     TextInputBuilder,
     TextInputStyle,
+    UserSelectMenuBuilder,
 } from 'discord.js';
 
 export async function createFestModal(
@@ -34,10 +40,55 @@ export async function createFestModal(
         .setMaxLength(120)
         .setRequired(true);
 
+    const scheduleNumLabel = new LabelBuilder()
+        .setLabel('スケジュール')
+        .setStringSelectMenuComponent(
+            new StringSelectMenuBuilder()
+                .setCustomId('scheduleNum')
+                .setMinValues(1)
+                .setMaxValues(1)
+                .addOptions(
+                    new StringSelectMenuOptionBuilder()
+                        .setLabel('現在のスケジュール')
+                        .setValue('now')
+                        .setDefault(true),
+                    new StringSelectMenuOptionBuilder()
+                        .setLabel('次のスケジュール')
+                        .setValue('next'),
+                ),
+        );
+
+    const attendeesLabel = new LabelBuilder()
+        .setLabel('既にに決まっている参加者(最大2人)')
+        .setUserSelectMenuComponent(
+            new UserSelectMenuBuilder()
+                .setCustomId('attendees')
+                .setMinValues(0)
+                .setMaxValues(2)
+                .setRequired(false),
+        );
+
+    const voiceChannelLabel = new LabelBuilder()
+        .setLabel('使用するボイスチャンネル')
+        .setChannelSelectMenuComponent(
+            new ChannelSelectMenuBuilder()
+                .setCustomId('voiceChannel')
+                .setChannelTypes(ChannelType.GuildVoice)
+                .setMinValues(0)
+                .setMaxValues(1)
+                .setRequired(false),
+        );
+
     const actionRow1 = new ActionRowBuilder<TextInputBuilder>().addComponents(recruitNumInput);
     const actionRow2 = new ActionRowBuilder<TextInputBuilder>().addComponents(conditionInput);
 
-    modal.addComponents(actionRow1, actionRow2);
+    modal.addComponents(
+        actionRow1,
+        actionRow2,
+        scheduleNumLabel,
+        attendeesLabel,
+        voiceChannelLabel,
+    );
 
     await interaction.showModal(modal);
 }

--- a/src/app/feat-recruit/modals/create_regular_modal.ts
+++ b/src/app/feat-recruit/modals/create_regular_modal.ts
@@ -55,7 +55,7 @@ export async function createRegularModal(interaction: ButtonInteraction<'cached'
         );
 
     const attendeesLabel = new LabelBuilder()
-        .setLabel('既にに決まっている参加者(最大3人)')
+        .setLabel('既に決まっている参加者(最大3人)')
         .setUserSelectMenuComponent(
             new UserSelectMenuBuilder()
                 .setCustomId('attendees')

--- a/src/app/feat-recruit/modals/create_regular_modal.ts
+++ b/src/app/feat-recruit/modals/create_regular_modal.ts
@@ -1,9 +1,15 @@
 import {
     ActionRowBuilder,
     ButtonInteraction,
+    ChannelSelectMenuBuilder,
+    ChannelType,
+    LabelBuilder,
     ModalBuilder,
+    StringSelectMenuBuilder,
+    StringSelectMenuOptionBuilder,
     TextInputBuilder,
     TextInputStyle,
+    UserSelectMenuBuilder,
 } from 'discord.js';
 
 export async function createRegularModal(interaction: ButtonInteraction<'cached' | 'raw'>) {
@@ -30,10 +36,55 @@ export async function createRegularModal(interaction: ButtonInteraction<'cached'
         .setMaxLength(120)
         .setRequired(true);
 
+    const scheduleNumLabel = new LabelBuilder()
+        .setLabel('スケジュール')
+        .setStringSelectMenuComponent(
+            new StringSelectMenuBuilder()
+                .setCustomId('scheduleNum')
+                .setMinValues(1)
+                .setMaxValues(1)
+                .addOptions(
+                    new StringSelectMenuOptionBuilder()
+                        .setLabel('現在のスケジュール')
+                        .setValue('now')
+                        .setDefault(true),
+                    new StringSelectMenuOptionBuilder()
+                        .setLabel('次のスケジュール')
+                        .setValue('next'),
+                ),
+        );
+
+    const attendeesLabel = new LabelBuilder()
+        .setLabel('既にに決まっている参加者(最大3人)')
+        .setUserSelectMenuComponent(
+            new UserSelectMenuBuilder()
+                .setCustomId('attendees')
+                .setMinValues(0)
+                .setMaxValues(3)
+                .setRequired(false),
+        );
+
+    const voiceChannelLabel = new LabelBuilder()
+        .setLabel('使用するボイスチャンネル')
+        .setChannelSelectMenuComponent(
+            new ChannelSelectMenuBuilder()
+                .setCustomId('voiceChannel')
+                .setChannelTypes(ChannelType.GuildVoice)
+                .setMinValues(0)
+                .setMaxValues(1)
+                .setRequired(false),
+        );
+
     const actionRow1 = new ActionRowBuilder<TextInputBuilder>().addComponents(recruitNumInput);
     const actionRow2 = new ActionRowBuilder<TextInputBuilder>().addComponents(conditionInput);
 
-    modal.addComponents(actionRow1, actionRow2);
+    modal.addComponents(
+        actionRow1,
+        actionRow2,
+        scheduleNumLabel,
+        attendeesLabel,
+        voiceChannelLabel,
+    );
 
     await interaction.showModal(modal);
 }

--- a/src/app/feat-recruit/modals/create_salmon_modal.ts
+++ b/src/app/feat-recruit/modals/create_salmon_modal.ts
@@ -35,7 +35,7 @@ export async function createSalmonModal(interaction: ButtonInteraction<'cached' 
         .setRequired(true);
 
     const attendeesLabel = new LabelBuilder()
-        .setLabel('既にに決まっている参加者(最大2人)')
+        .setLabel('既に決まっている参加者(最大2人)')
         .setUserSelectMenuComponent(
             new UserSelectMenuBuilder()
                 .setCustomId('attendees')

--- a/src/app/feat-recruit/modals/create_salmon_modal.ts
+++ b/src/app/feat-recruit/modals/create_salmon_modal.ts
@@ -1,9 +1,13 @@
 import {
     ActionRowBuilder,
     ButtonInteraction,
+    ChannelSelectMenuBuilder,
+    ChannelType,
+    LabelBuilder,
     ModalBuilder,
     TextInputBuilder,
     TextInputStyle,
+    UserSelectMenuBuilder,
 } from 'discord.js';
 
 export async function createSalmonModal(interaction: ButtonInteraction<'cached' | 'raw'>) {
@@ -30,10 +34,31 @@ export async function createSalmonModal(interaction: ButtonInteraction<'cached' 
         .setMaxLength(120)
         .setRequired(true);
 
+    const attendeesLabel = new LabelBuilder()
+        .setLabel('既にに決まっている参加者(最大2人)')
+        .setUserSelectMenuComponent(
+            new UserSelectMenuBuilder()
+                .setCustomId('attendees')
+                .setMinValues(0)
+                .setMaxValues(2)
+                .setRequired(false),
+        );
+
+    const voiceChannelLabel = new LabelBuilder()
+        .setLabel('使用するボイスチャンネル')
+        .setChannelSelectMenuComponent(
+            new ChannelSelectMenuBuilder()
+                .setCustomId('voiceChannel')
+                .setChannelTypes(ChannelType.GuildVoice)
+                .setMinValues(0)
+                .setMaxValues(1)
+                .setRequired(false),
+        );
+
     const actionRow1 = new ActionRowBuilder<TextInputBuilder>().addComponents(recruitNumInput);
     const actionRow2 = new ActionRowBuilder<TextInputBuilder>().addComponents(conditionInput);
 
-    modal.addComponents(actionRow1, actionRow2);
+    modal.addComponents(actionRow1, actionRow2, attendeesLabel, voiceChannelLabel);
 
     await interaction.showModal(modal);
 }


### PR DESCRIPTION
## 概要
### 背景
- discord.js 14.23.0 で モーダルの新コンポーネントが利用可能になった。
- 今までスラッシュコマンドでしか利用できなかったコンポーネントが利用可能になったため、同等の機能を提供する。
### 作業したこと
- Modal コンポーネントに各種 LabelBuilder を追加し、submit の interaction から受け取る処理を追加
- 簡易募集表記を削除

## 補足
大規模リファクタリングがやってくる予定