### PR TITLE
chore: git-pr-release に必要な権限を付与

### DIFF
--- a/.github/workflows/git-pr-release.yaml
+++ b/.github/workflows/git-pr-release.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   git-pr-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/test/fetch_retry.test.ts
+++ b/test/fetch_retry.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-    isTemporaryFetchError,
-    withTemporaryFetchRetry,
-} from '../src/app/common/fetch_retry';
+import { isTemporaryFetchError, withTemporaryFetchRetry } from '../src/app/common/fetch_retry';
 
 // テスト用に短い待機時間を使用
 const ONE_SECOND_MS = 1000;


### PR DESCRIPTION
## 概要

`git-pr-release` ワークフローに PR 作成・更新に必要な権限を付与する。

### 背景

デフォルトの `GITHUB_TOKEN` 権限では `pull-requests: write` が付与されていない構成（組織/リポジトリ設定）の場合、git-pr-release が PR を作成・更新できない。明示的に必要最小限の権限をジョブに指定することで、権限設定に依存せず安定して動作するようにする。

### 作業内容

- `.github/workflows/git-pr-release.yaml` にジョブレベルの `permissions` を追加
  - `contents: read`
  - `pull-requests: write`
- 併せて lefthook による無関係ファイルの自動 lint/format 修正を別コミットで取り込み