### PR TITLE
Refactor: 募集カード canvas 群を共通化

### DIFF
--- a/src/app/feat-recruit/common/canvases/anarchy_canvas.ts
+++ b/src/app/feat-recruit/common/canvases/anarchy_canvas.ts
@@ -1,398 +1,112 @@
-import path from 'path';
-
-import { Member } from '@prisma/client';
 import Canvas from 'canvas';
 
 import { MatchInfo } from '@/app/common/apis/splatoon3.ink/splatoon3_ink';
-import { createRoundRect, drawArcImage, fillTextWithStroke } from '@/app/common/canvas_components';
+import { fillTextWithStroke } from '@/app/common/canvas_components';
 import { dateformat, formatDatetime } from '@/app/common/convert_datetime';
-import { exists, notExists } from '@/app/common/others';
-import { modalRecruit } from '@/constant';
 
-import { RecruitOpCode } from './regenerate_canvas';
+import {
+    RecruitCanvasOptions,
+    RecruitCardLayout,
+    createCanvasContext,
+    drawRecruitCard,
+    drawStageRuleCanvas,
+} from './canvas_base';
 
-Canvas.registerFont(path.resolve('./fonts/Splatfont.ttf'), {
-    family: 'Splatfont',
-});
-Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Medium.ttf'), {
-    family: 'Genshin',
-});
-Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Bold.ttf'), {
-    family: 'Genshin-Bold',
-});
-Canvas.registerFont(path.resolve('./fonts/SEGUISYM.TTF'), { family: 'SEGUI' });
+const ANARCHY_ICON_URL =
+    'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/anarchy_icon.png';
+const RULE_ICON_X = 570;
+const RULE_ICON_Y = 10;
+const RULE_ICON_WIDTH = 120;
+const RULE_ICON_HEIGHT = 120;
+const RECRUIT_LAYOUT: RecruitCardLayout = {
+    recruiterAvatar: { x: 40, y: 120, radius: 50 },
+    participantCount: 4,
+    participantAvatar: (index) => ({ x: index * 118 + 158, y: 120, radius: 50 }),
+    squid: { x: 90, y: 172, width: 75, height: 75 },
+    channel: { font: '37px "Splatfont"', x: 30, y: 520 },
+    recruitCount: { font: '39px "Splatfont"', x: 525, y: 155 },
+    remaining: { font: '42px "Splatfont"', x: 605, y: 218 },
+    conditionTitle: { font: '43px "Splatfont"', x: 35, y: 290 },
+    condition: {
+        font: '30px "Genshin", "SEGUI"',
+        width: 600,
+        lineHeight: 40,
+        maxLines: 4,
+        x: 65,
+        y: 345,
+    },
+};
+export type RecruitAnarchyCanvasOptions = RecruitCanvasOptions & { rank: string | null };
 
-/*
- * 募集用のキャンバス(1枚目)を作成する
- */
-export async function recruitAnarchyCanvas(
-    opCode: number,
-    remaining: number,
-    count: number,
-    recruiter: Member,
-    user1: Member | null,
-    user2: Member | null,
-    user3: Member | null,
-    condition: string,
-    rank: string | null,
-    channelName: string | null,
-) {
-    const blankAvatarUrl =
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/blank_avatar.png'; // blankのアバター画像URL
-
-    const recruitCanvas = Canvas.createCanvas(720, 550);
-    const recruitCtx = recruitCanvas.getContext('2d');
-
-    // 下地
-    createRoundRect(recruitCtx, 1, 1, 718, 548, 30);
-    recruitCtx.fillStyle = '#2F3136';
-    recruitCtx.fill();
-    recruitCtx.strokeStyle = '#FFFFFF';
-    recruitCtx.lineWidth = 4;
-    recruitCtx.stroke();
-
-    const anarchyIcon = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/anarchy_icon.png',
+export async function recruitAnarchyCanvas(options: RecruitAnarchyCanvasOptions) {
+    const { canvas, ctx } = createCanvasContext();
+    await drawRecruitCard(
+        ctx,
+        options,
+        RECRUIT_LAYOUT,
+        async (context) => {
+            const icon = await Canvas.loadImage(ANARCHY_ICON_URL);
+            context.drawImage(icon, 18, 15, 86, 86);
+            fillTextWithStroke(
+                context,
+                'バンカラマッチ',
+                '51px Splatfont',
+                '#000000',
+                '#F14400',
+                3,
+                115,
+                80,
+            );
+        },
+        (context) => {
+            context.save();
+            context.textAlign = 'right';
+            fillTextWithStroke(
+                context,
+                '募集ウデマエ: ' + (options.rank ?? 'ERROR'),
+                '38px "Splatfont"',
+                '#FFFFFF',
+                '#2D3130',
+                1,
+                690,
+                520,
+            );
+            context.restore();
+        },
     );
-    recruitCtx.drawImage(anarchyIcon, 18, 15, 86, 86);
-
-    fillTextWithStroke(
-        recruitCtx,
-        'バンカラマッチ',
-        '51px Splatfont',
-        '#000000',
-        '#F14400',
-        3,
-        115,
-        80,
-    );
-
-    // 募集主の画像
-    const recruiterImage = await Canvas.loadImage(recruiter.iconUrl ?? modalRecruit.placeHold);
-    recruitCtx.save();
-    drawArcImage(recruitCtx, recruiterImage, 40, 120, 50);
-    recruitCtx.strokeStyle = '#1e1f23';
-    recruitCtx.lineWidth = 9;
-    recruitCtx.stroke();
-    recruitCtx.restore();
-
-    const memberIcons = [];
-
-    if (exists(user1)) {
-        memberIcons.push(user1.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user2)) {
-        memberIcons.push(user2.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user3)) {
-        memberIcons.push(user3.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    for (let i = 0; i < 4; i++) {
-        if (count >= i + 2) {
-            const userUrl = memberIcons[i] ?? blankAvatarUrl;
-            const userImage = await Canvas.loadImage(userUrl);
-            recruitCtx.save();
-            drawArcImage(recruitCtx, userImage, i * 118 + 158, 120, 50);
-            recruitCtx.strokeStyle = '#1e1f23';
-            recruitCtx.lineWidth = 9;
-            recruitCtx.stroke();
-            recruitCtx.restore();
-        }
-    }
-
-    const recruiterIcon = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/squid.png',
-    );
-    recruitCtx.drawImage(
-        recruiterIcon,
-        0,
-        0,
-        recruiterIcon.width,
-        recruiterIcon.height,
-        90,
-        172,
-        75,
-        75,
-    );
-
-    fillTextWithStroke(
-        recruitCtx,
-        '募集人数',
-        '39px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        525,
-        155,
-    );
-
-    let remainingString;
-    if (opCode === RecruitOpCode.open || opCode === RecruitOpCode.cancel) {
-        remainingString = remaining > 0 ? '@' + remaining : '満員';
-    } else if (opCode === RecruitOpCode.close) {
-        remainingString = '受付終了';
-    } else {
-        remainingString = 'ERROR!';
-    }
-
-    recruitCtx.save();
-    recruitCtx.textAlign = 'center';
-    fillTextWithStroke(
-        recruitCtx,
-        remainingString,
-        '42px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        605,
-        218,
-    );
-    recruitCtx.restore();
-
-    fillTextWithStroke(
-        recruitCtx,
-        '参加条件',
-        '43px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        35,
-        290,
-    );
-
-    recruitCtx.font = '30px "Genshin", "SEGUI"';
-    const width = 600;
-    const size = 40;
-    const columnNum = 4;
-    const column = [''];
-    let line = 0;
-    condition = condition.replace(/\\n/g, '\n');
-
-    // 幅に合わせて自動改行
-    for (let i = 0; i < condition.length; i++) {
-        const char = condition.charAt(i);
-
-        if (char == '\n') {
-            line++;
-            column[line] = '';
-        } else if (recruitCtx.measureText(column[line] + char).width > width) {
-            line++;
-            column[line] = char;
-        } else {
-            column[line] += char;
-        }
-    }
-
-    if (column.length > columnNum) {
-        column[columnNum - 1] += '…';
-    }
-
-    for (let j = 0; j < column.length; j++) {
-        if (j < columnNum) {
-            recruitCtx.fillText(column[j], 65, 345 + size * j);
-        }
-    }
-
-    let channelString;
-    if (notExists(channelName)) {
-        channelString = '🔉 VC指定なし';
-    } else {
-        channelString = '🔉 ' + channelName;
-    }
-
-    fillTextWithStroke(
-        recruitCtx,
-        channelString,
-        '37px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        30,
-        520,
-    );
-
-    recruitCtx.save();
-    recruitCtx.textAlign = 'right';
-    fillTextWithStroke(
-        recruitCtx,
-        '募集ウデマエ: ' + (rank ?? 'ERROR'),
-        '38px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        690,
-        520,
-    );
-    recruitCtx.restore();
-
-    if (opCode === RecruitOpCode.cancel) {
-        recruitCtx.save();
-        recruitCtx.translate(220, -110);
-        recruitCtx.rotate((25 * Math.PI) / 180);
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/canceled_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            0,
-            0,
-            600,
-            600,
-        );
-        recruitCtx.restore();
-    } else if (opCode === RecruitOpCode.close) {
-        recruitCtx.save();
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/closed_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            130,
-            80,
-            500,
-            340,
-        );
-        recruitCtx.restore();
-    }
-
-    const recruit = recruitCanvas.toBuffer();
-    return recruit;
+    return canvas.toBuffer();
 }
 
-/*
- * ルール情報のキャンバス(2枚目)を作成する
- */
 export async function ruleAnarchyCanvas(anarchyData: MatchInfo | null, ruleIconURL: string) {
-    const ruleCanvas = Canvas.createCanvas(720, 550);
-    const ruleCtx = ruleCanvas.getContext('2d');
-
-    const date = anarchyData ? formatDatetime(anarchyData.startTime, dateformat.ymdw) : 'えらー';
-    const time = anarchyData
-        ? formatDatetime(anarchyData.startTime, dateformat.hm) +
-          ' - ' +
-          formatDatetime(anarchyData.endTime, dateformat.hm)
-        : 'えらー';
-    const rule = anarchyData && anarchyData.rule ? anarchyData.rule : 'えらー';
-    const stage1 = anarchyData && anarchyData.stage1 ? anarchyData.stage1 : 'えらー';
-    const stage2 = anarchyData && anarchyData.stage2 ? anarchyData.stage2 : 'えらー';
-
-    createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
-    ruleCtx.fillStyle = '#2F3136';
-    ruleCtx.fill();
-    ruleCtx.strokeStyle = '#FFFFFF';
-    ruleCtx.lineWidth = 4;
-    ruleCtx.stroke();
-
-    fillTextWithStroke(ruleCtx, 'ルール', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 80);
-
-    const ruleWidth = ruleCtx.measureText(rule).width;
-    fillTextWithStroke(
-        ruleCtx,
-        rule,
-        '45px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        (320 - ruleWidth) / 2,
-        145,
-    ); // 中央寄せ
-
-    fillTextWithStroke(ruleCtx, '日時', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 220);
-
-    const dateWidth = ruleCtx.measureText(date).width;
-    fillTextWithStroke(
-        ruleCtx,
-        date,
-        '35px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        (350 - dateWidth) / 2,
-        270,
-    ); // 中央寄せ
-    const timeWidth = ruleCtx.measureText(time).width;
-    fillTextWithStroke(
-        ruleCtx,
-        time,
-        '35px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        15 + (350 - timeWidth) / 2,
-        320,
-    ); // 中央寄せ
-
-    fillTextWithStroke(ruleCtx, 'ステージ', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 390);
-    ruleCtx.save();
-    ruleCtx.textAlign = 'center';
-    fillTextWithStroke(ruleCtx, stage1, '32px Splatfont', '#FFFFFF', '#2D3130', 1, 190, 440);
-    fillTextWithStroke(ruleCtx, stage2, '32px Splatfont', '#FFFFFF', '#2D3130', 1, 190, 490);
-
-    ruleCtx.restore();
-
-    if (exists(anarchyData) && exists(anarchyData.stageImage1) && exists(anarchyData.stageImage2)) {
-        const stage1Image = await Canvas.loadImage(anarchyData.stageImage1);
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 130, 308, 176, 10);
-        ruleCtx.clip();
-        ruleCtx.drawImage(stage1Image, 370, 130, 308, 176);
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-
-        const stage2Image = await Canvas.loadImage(anarchyData.stageImage2);
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 340, 308, 176, 10);
-        ruleCtx.clip();
-        ruleCtx.drawImage(stage2Image, 370, 340, 308, 176);
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-    } else {
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 130, 308, 176, 10);
-        ruleCtx.fillStyle = '#000000';
-        ruleCtx.fill();
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 340, 308, 176, 10);
-        ruleCtx.fillStyle = '#000000';
-        ruleCtx.fill();
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-    }
-
-    ruleCtx.save();
-    const ruleImage = await Canvas.loadImage(ruleIconURL);
-    ruleCtx.drawImage(ruleImage, 0, 0, ruleImage.width, ruleImage.height, 570, 10, 120, 120);
-    ruleCtx.restore();
-
-    createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
-    ruleCtx.clip();
-
-    const buffer = ruleCanvas.toBuffer();
-    return buffer;
+    return drawStageRuleCanvas(
+        anarchyData,
+        {
+            date: anarchyData ? formatDatetime(anarchyData.startTime, dateformat.ymdw) : 'えらー',
+            time: anarchyData
+                ? formatDatetime(anarchyData.startTime, dateformat.hm) +
+                  ' - ' +
+                  formatDatetime(anarchyData.endTime, dateformat.hm)
+                : 'えらー',
+            rule: anarchyData?.rule ?? 'えらー',
+            stage1: anarchyData?.stage1 ?? 'えらー',
+            stage2: anarchyData?.stage2 ?? 'えらー',
+        },
+        undefined,
+        async (context) => {
+            const image = await Canvas.loadImage(ruleIconURL);
+            context.save();
+            context.drawImage(
+                image,
+                0,
+                0,
+                image.width,
+                image.height,
+                RULE_ICON_X,
+                RULE_ICON_Y,
+                RULE_ICON_WIDTH,
+                RULE_ICON_HEIGHT,
+            );
+            context.restore();
+        },
+    );
 }

--- a/src/app/feat-recruit/common/canvases/big_run_canvas.ts
+++ b/src/app/feat-recruit/common/canvases/big_run_canvas.ts
@@ -1,265 +1,68 @@
-import { Member } from '@prisma/client';
 import Canvas from 'canvas';
 
 import { SalmonInfo } from '@/app/common/apis/splatoon3.ink/splatoon3_ink.js';
-import { createRoundRect, drawArcImage, fillTextWithStroke } from '@/app/common/canvas_components';
+import { createRoundRect, fillTextWithStroke } from '@/app/common/canvas_components';
 import { dateformat, formatDatetime } from '@/app/common/convert_datetime';
-import { exists, notExists } from '@/app/common/others.js';
-import { modalRecruit, placeHold } from '@/constant.js';
+import { exists } from '@/app/common/others.js';
+import { placeHold } from '@/constant.js';
 
-import { RecruitOpCode } from './regenerate_canvas.js';
+import {
+    RecruitCanvasOptions,
+    RecruitCardLayout,
+    createCanvasContext,
+    drawCanvasBackground,
+    drawRecruitCard,
+} from './canvas_base.js';
 
-/*
- * 募集用のキャンバス(1枚目)を作成する
- */
-export async function recruitBigRunCanvas(
-    opCode: number,
-    remaining: number,
-    count: number,
-    recruiter: Member,
-    user1: Member | null,
-    user2: Member | null,
-    user3: Member | null,
-    condition: string,
-    channelName: string | null,
-) {
-    const blankAvatarUrl =
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/blank_avatar.png'; // blankのアバター画像URL
-
-    const recruitCanvas = Canvas.createCanvas(720, 550);
-    const recruitCtx = recruitCanvas.getContext('2d');
-
-    // 下地
-    createRoundRect(recruitCtx, 1, 1, 718, 548, 30);
-    recruitCtx.fillStyle = '#2F3136';
-    recruitCtx.fill();
-    recruitCtx.strokeStyle = '#FFFFFF';
-    recruitCtx.lineWidth = 4;
-    recruitCtx.stroke();
-
-    const bigRunLogo = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/BIGRUN_logo.png',
-    );
-    recruitCtx.drawImage(bigRunLogo, 25, 32, 400, 60);
-
-    // 募集主の画像
-    const recruiterImage = await Canvas.loadImage(recruiter.iconUrl ?? modalRecruit.placeHold);
-    recruitCtx.save();
-    drawArcImage(recruitCtx, recruiterImage, 40, 120, 50);
-    recruitCtx.strokeStyle = '#1e1f23';
-    recruitCtx.lineWidth = 9;
-    recruitCtx.stroke();
-    recruitCtx.restore();
-
-    const memberIcons = [];
-
-    if (exists(user1)) {
-        memberIcons.push(user1.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user2)) {
-        memberIcons.push(user2.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user3)) {
-        memberIcons.push(user3.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    for (let i = 0; i < 4; i++) {
-        if (count >= i + 2) {
-            const userUrl = memberIcons[i] ?? blankAvatarUrl;
-            const userImage = await Canvas.loadImage(userUrl);
-            recruitCtx.save();
-            drawArcImage(recruitCtx, userImage, i * 118 + 158, 120, 50);
-            recruitCtx.strokeStyle = '#1e1f23';
-            recruitCtx.lineWidth = 9;
-            recruitCtx.stroke();
-            recruitCtx.restore();
-        }
-    }
-
-    const recruiterIcon = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/squid.png',
-    );
-    recruitCtx.drawImage(
-        recruiterIcon,
-        0,
-        0,
-        recruiterIcon.width,
-        recruiterIcon.height,
-        90,
-        172,
-        75,
-        75,
-    );
-
-    fillTextWithStroke(
-        recruitCtx,
-        '募集人数',
-        '39px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        525,
-        155,
-    );
-
-    let remainingString;
-    if (opCode === RecruitOpCode.open || opCode === RecruitOpCode.cancel) {
-        remainingString = remaining > 0 ? '@' + remaining : '満員';
-    } else if (opCode === RecruitOpCode.close) {
-        remainingString = '受付終了';
-    } else {
-        remainingString = 'ERROR!';
-    }
-
-    recruitCtx.save();
-    recruitCtx.textAlign = 'center';
-    fillTextWithStroke(
-        recruitCtx,
-        remainingString,
-        '42px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        605,
-        218,
-    );
-    recruitCtx.restore();
-
-    fillTextWithStroke(
-        recruitCtx,
-        '参加条件',
-        '43px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        35,
-        290,
-    );
-
-    recruitCtx.font = '30px "Genshin", "SEGUI"';
-    const width = 600;
-    const size = 40;
-    const columnNum = 4;
-    const column = [''];
-    let line = 0;
-    condition = condition.replace(/\\n/g, '\n');
-
-    // 幅に合わせて自動改行
-    for (let i = 0; i < condition.length; i++) {
-        const char = condition.charAt(i);
-
-        if (char == '\n') {
-            line++;
-            column[line] = '';
-        } else if (recruitCtx.measureText(column[line] + char).width > width) {
-            line++;
-            column[line] = char;
-        } else {
-            column[line] += char;
-        }
-    }
-
-    if (column.length > columnNum) {
-        column[columnNum - 1] += '…';
-    }
-
-    for (let j = 0; j < column.length; j++) {
-        if (j < columnNum) {
-            recruitCtx.fillText(column[j], 65, 345 + size * j);
-        }
-    }
-
-    let channelString;
-    if (notExists(channelName)) {
-        channelString = '🔉 VC指定なし';
-    } else {
-        channelString = '🔉 ' + channelName;
-    }
-
-    fillTextWithStroke(
-        recruitCtx,
-        channelString,
-        '37px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        30,
-        520,
-    );
-
-    if (opCode === RecruitOpCode.cancel) {
-        recruitCtx.save();
-        recruitCtx.translate(220, -110);
-        recruitCtx.rotate((25 * Math.PI) / 180);
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/canceled_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            0,
-            0,
-            600,
-            600,
-        );
-        recruitCtx.restore;
-    } else if (opCode === RecruitOpCode.close) {
-        recruitCtx.save();
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/closed_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            130,
-            80,
-            500,
-            340,
-        );
-        recruitCtx.restore;
-    }
-
-    const recruit = recruitCanvas.toBuffer();
-    return recruit;
+const BIG_RUN_LOGO_URL =
+    'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/BIGRUN_logo.png';
+const BIG_RUN_ILLUST_URL =
+    'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/BIGRUN_illust.png';
+const BIG_RUN_FOOTER_URL =
+    'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/BIGRUN_footer.png';
+const RECRUIT_LAYOUT: RecruitCardLayout = {
+    recruiterAvatar: { x: 40, y: 120, radius: 50 },
+    participantCount: 4,
+    participantAvatar: (index) => ({ x: index * 118 + 158, y: 120, radius: 50 }),
+    squid: { x: 90, y: 172, width: 75, height: 75 },
+    channel: { font: '37px "Splatfont"', x: 30, y: 520 },
+    recruitCount: { font: '39px "Splatfont"', x: 525, y: 155 },
+    remaining: { font: '42px "Splatfont"', x: 605, y: 218 },
+    conditionTitle: { font: '43px "Splatfont"', x: 35, y: 290 },
+    condition: {
+        font: '30px "Genshin", "SEGUI"',
+        width: 600,
+        lineHeight: 40,
+        maxLines: 4,
+        x: 65,
+        y: 345,
+    },
+};
+export type RecruitBigRunCanvasOptions = RecruitCanvasOptions;
+export async function recruitBigRunCanvas(options: RecruitBigRunCanvasOptions) {
+    const { canvas, ctx } = createCanvasContext();
+    await drawRecruitCard(ctx, options, RECRUIT_LAYOUT, async (context) => {
+        const logo = await Canvas.loadImage(BIG_RUN_LOGO_URL);
+        context.drawImage(logo, 25, 32, 400, 60);
+    });
+    return canvas.toBuffer();
 }
 
-/*
- * ルール情報のキャンバス(2枚目)を作成する
- */
 export async function ruleBigRunCanvas(data: SalmonInfo | null) {
-    const ruleCanvas = Canvas.createCanvas(720, 550);
-    const ruleCtx = ruleCanvas.getContext('2d');
+    const { canvas: ruleCanvas, ctx: ruleCtx } = createCanvasContext();
     const errorWeaponImage = await Canvas.loadImage(placeHold.error100x100);
-
     const datetime = data
         ? formatDatetime(data.startTime, dateformat.mdwhm) +
           ' - ' +
           formatDatetime(data.endTime, dateformat.mdwhm)
         : 'えらー';
-
     const stage = data ? data.stage : 'えらー';
     const weapon1Image = data ? await Canvas.loadImage(data.weapon1) : errorWeaponImage;
     const weapon2Image = data ? await Canvas.loadImage(data.weapon2) : errorWeaponImage;
     const weapon3Image = data ? await Canvas.loadImage(data.weapon3) : errorWeaponImage;
     const weapon4Image = data ? await Canvas.loadImage(data.weapon4) : errorWeaponImage;
-
-    createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
-    ruleCtx.fillStyle = '#2F3136';
-    ruleCtx.fill();
-    ruleCtx.strokeStyle = '#FFFFFF';
-    ruleCtx.lineWidth = 4;
-    ruleCtx.stroke();
-
+    drawCanvasBackground(ruleCtx);
     fillTextWithStroke(ruleCtx, '日時', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 60);
-
     const dateWidth = ruleCtx.measureText(datetime).width;
     fillTextWithStroke(
         ruleCtx,
@@ -271,16 +74,12 @@ export async function ruleBigRunCanvas(data: SalmonInfo | null) {
         (650 - dateWidth) / 2,
         120,
     );
-
     fillTextWithStroke(ruleCtx, '武器', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 180);
-
     ruleCtx.drawImage(weapon1Image, 50, 205, 85, 85);
     ruleCtx.drawImage(weapon2Image, 150, 205, 85, 85);
     ruleCtx.drawImage(weapon3Image, 50, 305, 85, 85);
     ruleCtx.drawImage(weapon4Image, 150, 305, 85, 85);
-
     fillTextWithStroke(ruleCtx, 'ステージ', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 310, 180);
-
     const stageWidth = ruleCtx.measureText(stage).width;
     fillTextWithStroke(
         ruleCtx,
@@ -292,12 +91,8 @@ export async function ruleBigRunCanvas(data: SalmonInfo | null) {
         110 + (700 - stageWidth) / 2,
         235,
     );
-
-    const illust = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/BIGRUN_illust.png',
-    );
+    const illust = await Canvas.loadImage(BIG_RUN_ILLUST_URL);
     ruleCtx.drawImage(illust, 380, 240, 330, 160);
-
     ruleCtx.save();
     ruleCtx.beginPath();
     ruleCtx.rect(240, 410, 250, 135);
@@ -310,17 +105,12 @@ export async function ruleBigRunCanvas(data: SalmonInfo | null) {
         ruleCtx.fill();
     }
     ruleCtx.restore();
-
     ruleCtx.save();
     ruleCtx.beginPath();
     createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
     ruleCtx.clip();
-    const bigRunFotter = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/BIGRUN_footer.png',
-    );
-    ruleCtx.drawImage(bigRunFotter, -5, 400, 730, 160);
+    const footer = await Canvas.loadImage(BIG_RUN_FOOTER_URL);
+    ruleCtx.drawImage(footer, -5, 400, 730, 160);
     ruleCtx.restore();
-
-    const buffer = ruleCanvas.toBuffer();
-    return buffer;
+    return ruleCanvas.toBuffer();
 }

--- a/src/app/feat-recruit/common/canvases/canvas_base.ts
+++ b/src/app/feat-recruit/common/canvases/canvas_base.ts
@@ -1,0 +1,566 @@
+import path from 'path';
+
+import { Member } from '@prisma/client';
+import Canvas, { CanvasRenderingContext2D } from 'canvas';
+
+import { createRoundRect, drawArcImage, fillTextWithStroke } from '@/app/common/canvas_components';
+import { notExists } from '@/app/common/others';
+import { modalRecruit } from '@/constant';
+
+Canvas.registerFont(path.resolve('./fonts/Splatfont.ttf'), { family: 'Splatfont' });
+Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Medium.ttf'), { family: 'Genshin' });
+Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Bold.ttf'), { family: 'Genshin-Bold' });
+Canvas.registerFont(path.resolve('./fonts/SEGUISYM.TTF'), { family: 'SEGUI' });
+
+export const BLANK_AVATAR_URL =
+    'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/blank_avatar.png';
+
+const CANVAS_WIDTH = 720;
+const CANVAS_HEIGHT = 550;
+const BACKGROUND_X = 1;
+const BACKGROUND_Y = 1;
+const BACKGROUND_WIDTH = 718;
+const BACKGROUND_HEIGHT = 548;
+const BACKGROUND_RADIUS = 30;
+const BACKGROUND_COLOR = '#2F3136';
+const BACKGROUND_BORDER_COLOR = '#FFFFFF';
+const BACKGROUND_BORDER_WIDTH = 4;
+const AVATAR_BORDER_COLOR = '#1e1f23';
+const AVATAR_BORDER_WIDTH = 9;
+const TEXT_COLOR = '#FFFFFF';
+const TEXT_STROKE_COLOR = '#2D3130';
+
+export type RecruitCanvasOptions = {
+    opCode: number;
+    remaining: number;
+    count: number;
+    recruiter: Member;
+    users: (Member | null)[];
+    condition: string;
+    channelName: string | null;
+};
+
+export type RecruitCardLayout = {
+    recruiterAvatar: { x: number; y: number; radius: number };
+    participantCount: number;
+    participantAvatar: (index: number) => { x: number; y: number; radius: number };
+    squid: { x: number; y: number; width: number; height: number };
+    channel: { font: string; x: number; y: number; align?: CanvasTextAlign };
+    recruitCount: { font: string; x: number; y: number };
+    remaining: { font: string; x: number; y: number };
+    conditionTitle: { font: string; x: number; y: number };
+    condition: {
+        font: string;
+        width: number;
+        lineHeight: number;
+        maxLines: number;
+        x: number;
+        y: number;
+    };
+    channelBeforeRecruitCount?: boolean;
+};
+
+export function createCanvasContext() {
+    const canvas = Canvas.createCanvas(CANVAS_WIDTH, CANVAS_HEIGHT);
+    return { canvas, ctx: canvas.getContext('2d') };
+}
+
+export function drawCanvasBackground(ctx: CanvasRenderingContext2D) {
+    createRoundRect(
+        ctx,
+        BACKGROUND_X,
+        BACKGROUND_Y,
+        BACKGROUND_WIDTH,
+        BACKGROUND_HEIGHT,
+        BACKGROUND_RADIUS,
+    );
+    ctx.fillStyle = BACKGROUND_COLOR;
+    ctx.fill();
+    ctx.strokeStyle = BACKGROUND_BORDER_COLOR;
+    ctx.lineWidth = BACKGROUND_BORDER_WIDTH;
+    ctx.stroke();
+}
+
+async function drawAvatar(
+    ctx: CanvasRenderingContext2D,
+    imageUrl: string,
+    x: number,
+    y: number,
+    radius: number,
+) {
+    const image = await Canvas.loadImage(imageUrl);
+    ctx.save();
+    drawArcImage(ctx, image, x, y, radius);
+    ctx.strokeStyle = AVATAR_BORDER_COLOR;
+    ctx.lineWidth = AVATAR_BORDER_WIDTH;
+    ctx.stroke();
+    ctx.restore();
+}
+
+export async function drawRecruiterAvatar(
+    ctx: CanvasRenderingContext2D,
+    recruiter: Member,
+    position: { x: number; y: number; radius: number },
+) {
+    await drawAvatar(
+        ctx,
+        recruiter.iconUrl ?? modalRecruit.placeHold,
+        position.x,
+        position.y,
+        position.radius,
+    );
+}
+
+export async function drawParticipantAvatars(
+    ctx: CanvasRenderingContext2D,
+    options: Pick<RecruitCanvasOptions, 'count' | 'users'>,
+    layout: Pick<RecruitCardLayout, 'participantCount' | 'participantAvatar'>,
+) {
+    const memberIcons = options.users
+        .filter((user): user is Member => user !== null)
+        .map((user) => user.iconUrl ?? modalRecruit.placeHold);
+
+    for (let i = 0; i < layout.participantCount; i++) {
+        if (options.count >= i + 2) {
+            const position = layout.participantAvatar(i);
+            await drawAvatar(
+                ctx,
+                memberIcons[i] ?? BLANK_AVATAR_URL,
+                position.x,
+                position.y,
+                position.radius,
+            );
+        }
+    }
+}
+
+function drawChannelName(
+    ctx: CanvasRenderingContext2D,
+    channelName: string | null,
+    layout: RecruitCardLayout['channel'],
+) {
+    const channelString = notExists(channelName) ? '🔉 VC指定なし' : '🔉 ' + channelName;
+    if (layout.align) {
+        ctx.save();
+        ctx.textAlign = layout.align;
+    }
+    fillTextWithStroke(
+        ctx,
+        channelString,
+        layout.font,
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        layout.x,
+        layout.y,
+    );
+    if (layout.align) ctx.restore();
+}
+
+function drawRecruitCount(
+    ctx: CanvasRenderingContext2D,
+    opCode: number,
+    remaining: number,
+    layout: Pick<RecruitCardLayout, 'squid' | 'recruitCount' | 'remaining'>,
+) {
+    return (async () => {
+        const squid = await Canvas.loadImage(
+            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/squid.png',
+        );
+        ctx.drawImage(
+            squid,
+            0,
+            0,
+            squid.width,
+            squid.height,
+            layout.squid.x,
+            layout.squid.y,
+            layout.squid.width,
+            layout.squid.height,
+        );
+        fillTextWithStroke(
+            ctx,
+            '募集人数',
+            layout.recruitCount.font,
+            TEXT_COLOR,
+            TEXT_STROKE_COLOR,
+            1,
+            layout.recruitCount.x,
+            layout.recruitCount.y,
+        );
+
+        const remainingString =
+            opCode === 0 || opCode === 2
+                ? remaining > 0
+                    ? '@' + remaining
+                    : '満員'
+                : opCode === 1
+                  ? '受付終了'
+                  : 'ERROR!';
+        ctx.save();
+        ctx.textAlign = 'center';
+        fillTextWithStroke(
+            ctx,
+            remainingString,
+            layout.remaining.font,
+            TEXT_COLOR,
+            TEXT_STROKE_COLOR,
+            1,
+            layout.remaining.x,
+            layout.remaining.y,
+        );
+        ctx.restore();
+    })();
+}
+
+function drawCondition(
+    ctx: CanvasRenderingContext2D,
+    condition: string,
+    layout: Pick<RecruitCardLayout, 'conditionTitle' | 'condition'>,
+) {
+    fillTextWithStroke(
+        ctx,
+        '参加条件',
+        layout.conditionTitle.font,
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        layout.conditionTitle.x,
+        layout.conditionTitle.y,
+    );
+    ctx.font = layout.condition.font;
+    const columns = [''];
+    let line = 0;
+    const normalizedCondition = condition.replace(/\\n/g, '\n');
+    for (let i = 0; i < normalizedCondition.length; i++) {
+        const char = normalizedCondition.charAt(i);
+        if (char === '\n') {
+            line++;
+            columns[line] = '';
+        } else if (ctx.measureText(columns[line] + char).width > layout.condition.width) {
+            line++;
+            columns[line] = char;
+        } else {
+            columns[line] += char;
+        }
+    }
+    if (columns.length > layout.condition.maxLines) columns[layout.condition.maxLines - 1] += '…';
+    for (let i = 0; i < columns.length; i++) {
+        if (i < layout.condition.maxLines)
+            ctx.fillText(
+                columns[i],
+                layout.condition.x,
+                layout.condition.y + layout.condition.lineHeight * i,
+            );
+    }
+}
+
+export async function drawRecruitCard(
+    ctx: CanvasRenderingContext2D,
+    options: RecruitCanvasOptions,
+    layout: RecruitCardLayout,
+    drawHeader: (ctx: CanvasRenderingContext2D) => Promise<void> | void,
+    drawExtra?: (ctx: CanvasRenderingContext2D) => Promise<void> | void,
+) {
+    drawCanvasBackground(ctx);
+    await drawHeader(ctx);
+    await drawRecruiterAvatar(ctx, options.recruiter, layout.recruiterAvatar);
+    await drawParticipantAvatars(ctx, options, layout);
+    if (layout.channelBeforeRecruitCount) drawChannelName(ctx, options.channelName, layout.channel);
+    await drawRecruitCount(ctx, options.opCode, options.remaining, layout);
+    drawCondition(ctx, options.condition, layout);
+    if (!layout.channelBeforeRecruitCount)
+        drawChannelName(ctx, options.channelName, layout.channel);
+    await drawExtra?.(ctx);
+    await drawRecruitStamp(ctx, options.opCode);
+}
+
+export async function drawRecruitStamp(ctx: CanvasRenderingContext2D, opCode: number) {
+    if (opCode === 2) {
+        ctx.save();
+        ctx.translate(220, -110);
+        ctx.rotate((25 * Math.PI) / 180);
+        const stamp = await Canvas.loadImage(
+            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/canceled_stamp.png',
+        );
+        ctx.drawImage(stamp, 0, 0, stamp.width, stamp.height, 0, 0, 600, 600);
+        ctx.restore();
+    } else if (opCode === 1) {
+        ctx.save();
+        const stamp = await Canvas.loadImage(
+            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/closed_stamp.png',
+        );
+        ctx.drawImage(stamp, 0, 0, stamp.width, stamp.height, 130, 80, 500, 340);
+        ctx.restore();
+    }
+}
+
+export type MatchRuleData = {
+    startTime: Date;
+    endTime: Date;
+    rule?: string | null;
+    stage1?: string | null;
+    stage2?: string | null;
+    stageImage1?: string | null;
+    stageImage2?: string | null;
+};
+
+export async function drawStageRuleCanvas(
+    data: MatchRuleData | null,
+    values: { date: string; time: string; rule: string; stage1: string; stage2: string },
+    drawHeader?: (ctx: CanvasRenderingContext2D) => Promise<void> | void,
+    drawAfterStages?: (ctx: CanvasRenderingContext2D) => Promise<void> | void,
+) {
+    const { canvas, ctx } = createCanvasContext();
+    drawCanvasBackground(ctx);
+    await drawHeader?.(ctx);
+    fillTextWithStroke(ctx, 'ルール', '33px Splatfont', TEXT_COLOR, TEXT_STROKE_COLOR, 1, 35, 80);
+    const ruleWidth = ctx.measureText(values.rule).width;
+    fillTextWithStroke(
+        ctx,
+        values.rule,
+        '45px Splatfont',
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        (320 - ruleWidth) / 2,
+        145,
+    );
+    fillTextWithStroke(ctx, '日時', '32px Splatfont', TEXT_COLOR, TEXT_STROKE_COLOR, 1, 35, 220);
+    const dateWidth = ctx.measureText(values.date).width;
+    fillTextWithStroke(
+        ctx,
+        values.date,
+        '35px Splatfont',
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        (350 - dateWidth) / 2,
+        270,
+    );
+    const timeWidth = ctx.measureText(values.time).width;
+    fillTextWithStroke(
+        ctx,
+        values.time,
+        '35px Splatfont',
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        15 + (350 - timeWidth) / 2,
+        320,
+    );
+    fillTextWithStroke(
+        ctx,
+        'ステージ',
+        '33px Splatfont',
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        35,
+        390,
+    );
+    ctx.save();
+    ctx.textAlign = 'center';
+    fillTextWithStroke(
+        ctx,
+        values.stage1,
+        '32px Splatfont',
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        190,
+        440,
+    );
+    fillTextWithStroke(
+        ctx,
+        values.stage2,
+        '32px Splatfont',
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        190,
+        490,
+    );
+    ctx.restore();
+    await drawStagePair(ctx, data?.stageImage1, data?.stageImage2);
+    await drawAfterStages?.(ctx);
+    createRoundRect(
+        ctx,
+        BACKGROUND_X,
+        BACKGROUND_Y,
+        BACKGROUND_WIDTH,
+        BACKGROUND_HEIGHT,
+        BACKGROUND_RADIUS,
+    );
+    ctx.clip();
+    return canvas.toBuffer();
+}
+
+async function drawStagePair(
+    ctx: CanvasRenderingContext2D,
+    stageImage1?: string | null,
+    stageImage2?: string | null,
+) {
+    const positions = [
+        { x: 370, y: 130 },
+        { x: 370, y: 340 },
+    ];
+    const urls = stageImage1 && stageImage2 ? [stageImage1, stageImage2] : [null, null];
+    for (let i = 0; i < positions.length; i++) {
+        ctx.save();
+        ctx.beginPath();
+        createRoundRect(ctx, positions[i].x, positions[i].y, 308, 176, 10);
+        const url = urls[i];
+        if (url) {
+            ctx.clip();
+            const image = await Canvas.loadImage(url);
+            ctx.drawImage(image, positions[i].x, positions[i].y, 308, 176);
+        } else {
+            ctx.fillStyle = '#000000';
+            ctx.fill();
+        }
+        ctx.strokeStyle = BACKGROUND_BORDER_COLOR;
+        ctx.lineWidth = 6.0;
+        ctx.stroke();
+        ctx.restore();
+    }
+}
+
+export type SalmonRuleData = {
+    startTime: Date;
+    endTime: Date;
+    stage: string;
+    stageImage?: string;
+    weapon1: string;
+    weapon2: string;
+    weapon3: string;
+    weapon4: string;
+};
+
+export type SalmonRuleLayout = {
+    dateLabelY: number;
+    dateY: number;
+    weaponLabelY: number;
+    weaponPositions: { x: number; y: number; width: number; height: number }[];
+    stageLabelX: number;
+    stageLabelY: number;
+    stageX: number;
+    stageY: number;
+    stageImage: { x: number; y: number; width: number; height: number };
+    drawExtra?: (ctx: CanvasRenderingContext2D) => Promise<void> | void;
+};
+
+export async function drawSalmonRuleCanvas(
+    data: SalmonRuleData | null,
+    datetime: string,
+    errorWeaponUrl: string,
+    layout: SalmonRuleLayout,
+) {
+    const { canvas, ctx } = createCanvasContext();
+    const errorWeaponImage = await Canvas.loadImage(errorWeaponUrl);
+    const weaponImages = data
+        ? await Promise.all(
+              [data.weapon1, data.weapon2, data.weapon3, data.weapon4].map((url) =>
+                  Canvas.loadImage(url),
+              ),
+          )
+        : [errorWeaponImage, errorWeaponImage, errorWeaponImage, errorWeaponImage];
+    const stage = data ? data.stage : 'えらー';
+    drawCanvasBackground(ctx);
+    fillTextWithStroke(
+        ctx,
+        '日時',
+        '32px Splatfont',
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        35,
+        layout.dateLabelY,
+    );
+    const dateWidth = ctx.measureText(datetime).width;
+    fillTextWithStroke(
+        ctx,
+        datetime,
+        '37px Splatfont',
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        (650 - dateWidth) / 2,
+        layout.dateY,
+    );
+    fillTextWithStroke(
+        ctx,
+        '武器',
+        '32px Splatfont',
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        35,
+        layout.weaponLabelY,
+    );
+    weaponImages.forEach((image, index) => {
+        const position = layout.weaponPositions[index];
+        ctx.drawImage(image, position.x, position.y, position.width, position.height);
+    });
+    fillTextWithStroke(
+        ctx,
+        'ステージ',
+        '33px Splatfont',
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        layout.stageLabelX,
+        layout.stageLabelY,
+    );
+    const stageWidth = ctx.measureText(stage).width;
+    fillTextWithStroke(
+        ctx,
+        stage,
+        '38px Splatfont',
+        TEXT_COLOR,
+        TEXT_STROKE_COLOR,
+        1,
+        layout.stageX + (700 - stageWidth) / 2,
+        layout.stageY,
+    );
+    const stagePosition = layout.stageImage;
+    ctx.save();
+    ctx.beginPath();
+    createRoundRect(
+        ctx,
+        stagePosition.x,
+        stagePosition.y,
+        stagePosition.width,
+        stagePosition.height,
+        10,
+    );
+    if (data?.stageImage) {
+        ctx.clip();
+        const image = await Canvas.loadImage(data.stageImage);
+        ctx.drawImage(
+            image,
+            stagePosition.x,
+            stagePosition.y,
+            stagePosition.width,
+            stagePosition.height,
+        );
+    } else {
+        ctx.fillStyle = '#000000';
+        ctx.fill();
+    }
+    ctx.strokeStyle = BACKGROUND_BORDER_COLOR;
+    ctx.lineWidth = 6.0;
+    ctx.stroke();
+    ctx.restore();
+    await layout.drawExtra?.(ctx);
+    createRoundRect(
+        ctx,
+        BACKGROUND_X,
+        BACKGROUND_Y,
+        BACKGROUND_WIDTH,
+        BACKGROUND_HEIGHT,
+        BACKGROUND_RADIUS,
+    );
+    ctx.clip();
+    return canvas.toBuffer();
+}

--- a/src/app/feat-recruit/common/canvases/event_canvas.ts
+++ b/src/app/feat-recruit/common/canvases/event_canvas.ts
@@ -1,385 +1,84 @@
-import path from 'path';
-
-import { Member } from '@prisma/client';
 import Canvas from 'canvas';
 
 import { EventMatchInfo } from '@/app/common/apis/splatoon3.ink/splatoon3_ink';
-import { createRoundRect, drawArcImage, fillTextWithStroke } from '@/app/common/canvas_components';
+import { fillTextWithStroke } from '@/app/common/canvas_components';
 import { dateformat, formatDatetime } from '@/app/common/convert_datetime';
-import { exists, notExists } from '@/app/common/others';
-import { modalRecruit } from '@/constant';
 
-import { RecruitOpCode } from './regenerate_canvas';
+import {
+    RecruitCanvasOptions,
+    RecruitCardLayout,
+    createCanvasContext,
+    drawRecruitCard,
+    drawStageRuleCanvas,
+} from './canvas_base';
 
-Canvas.registerFont(path.resolve('./fonts/Splatfont.ttf'), {
-    family: 'Splatfont',
-});
-Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Medium.ttf'), {
-    family: 'Genshin',
-});
-Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Bold.ttf'), {
-    family: 'Genshin-Bold',
-});
-Canvas.registerFont(path.resolve('./fonts/SEGUISYM.TTF'), { family: 'SEGUI' });
-
-/*
- * 募集用のキャンバス(1枚目)を作成する
- */
-export async function recruitEventCanvas(
-    opCode: number,
-    remaining: number,
-    count: number,
-    recruiter: Member,
-    user1: Member | null,
-    user2: Member | null,
-    user3: Member | null,
-    condition: string,
-    channelName: string | null,
-) {
-    const blankAvatarUrl =
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/blank_avatar.png'; // blankのアバター画像URL
-
-    const recruitCanvas = Canvas.createCanvas(720, 550);
-    const recruitCtx = recruitCanvas.getContext('2d');
-
-    // 下地
-    createRoundRect(recruitCtx, 1, 1, 718, 548, 30);
-    recruitCtx.fillStyle = '#2F3136';
-    recruitCtx.fill();
-    recruitCtx.strokeStyle = '#FFFFFF';
-    recruitCtx.lineWidth = 4;
-    recruitCtx.stroke();
-
-    const eventIcon = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/event_icon.png',
-    );
-    recruitCtx.drawImage(eventIcon, 19, 19, 77, 77);
-
-    fillTextWithStroke(
-        recruitCtx,
-        'イベントマッチ',
-        '51px Splatfont',
-        '#000000',
-        '#FF2F82',
-        3,
-        112,
-        80,
-    );
-
-    // 募集主の画像
-    const recruiterImage = await Canvas.loadImage(recruiter.iconUrl ?? modalRecruit.placeHold);
-    recruitCtx.save();
-    drawArcImage(recruitCtx, recruiterImage, 40, 120, 50);
-    recruitCtx.strokeStyle = '#1e1f23';
-    recruitCtx.lineWidth = 9;
-    recruitCtx.stroke();
-    recruitCtx.restore();
-
-    const memberIcons = [];
-
-    if (exists(user1)) {
-        memberIcons.push(user1.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user2)) {
-        memberIcons.push(user2.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user3)) {
-        memberIcons.push(user3.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    for (let i = 0; i < 4; i++) {
-        if (count >= i + 2) {
-            const userUrl = memberIcons[i] ?? blankAvatarUrl;
-            const userImage = await Canvas.loadImage(userUrl);
-            recruitCtx.save();
-            drawArcImage(recruitCtx, userImage, i * 118 + 158, 120, 50);
-            recruitCtx.strokeStyle = '#1e1f23';
-            recruitCtx.lineWidth = 9;
-            recruitCtx.stroke();
-            recruitCtx.restore();
-        }
-    }
-
-    const recruiterIcon = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/squid.png',
-    );
-    recruitCtx.drawImage(
-        recruiterIcon,
-        0,
-        0,
-        recruiterIcon.width,
-        recruiterIcon.height,
-        90,
-        172,
-        75,
-        75,
-    );
-
-    fillTextWithStroke(
-        recruitCtx,
-        '募集人数',
-        '39px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        525,
-        155,
-    );
-
-    let remainingString;
-    if (opCode === RecruitOpCode.open || opCode === RecruitOpCode.cancel) {
-        remainingString = remaining > 0 ? '@' + remaining : '満員';
-    } else if (opCode === RecruitOpCode.close) {
-        remainingString = '受付終了';
-    } else {
-        remainingString = 'ERROR!';
-    }
-
-    recruitCtx.save();
-    recruitCtx.textAlign = 'center';
-    fillTextWithStroke(
-        recruitCtx,
-        remainingString,
-        '42px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        605,
-        218,
-    );
-    recruitCtx.restore();
-
-    fillTextWithStroke(
-        recruitCtx,
-        '参加条件',
-        '43px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        35,
-        290,
-    );
-
-    recruitCtx.font = '30px "Genshin", "SEGUI"';
-    const width = 600;
-    const size = 40;
-    const columnNum = 4;
-    const column = [''];
-    let line = 0;
-    condition = condition.replace(/\\n/g, '\n');
-
-    // 幅に合わせて自動改行
-    for (let i = 0; i < condition.length; i++) {
-        const char = condition.charAt(i);
-
-        if (char == '\n') {
-            line++;
-            column[line] = '';
-        } else if (recruitCtx.measureText(column[line] + char).width > width) {
-            line++;
-            column[line] = char;
-        } else {
-            column[line] += char;
-        }
-    }
-
-    if (column.length > columnNum) {
-        column[columnNum - 1] += '…';
-    }
-
-    for (let j = 0; j < column.length; j++) {
-        if (j < columnNum) {
-            recruitCtx.fillText(column[j], 65, 345 + size * j);
-        }
-    }
-
-    let channelString;
-    if (notExists(channelName)) {
-        channelString = '🔉 VC指定なし';
-    } else {
-        channelString = '🔉 ' + channelName;
-    }
-
-    fillTextWithStroke(
-        recruitCtx,
-        channelString,
-        '37px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        30,
-        520,
-    );
-
-    if (opCode === RecruitOpCode.cancel) {
-        recruitCtx.save();
-        recruitCtx.translate(220, -110);
-        recruitCtx.rotate((25 * Math.PI) / 180);
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/canceled_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            0,
-            0,
-            600,
-            600,
-        );
-        recruitCtx.restore;
-    } else if (opCode === RecruitOpCode.close) {
-        recruitCtx.save();
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/closed_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            130,
+const EVENT_ICON_URL =
+    'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/event_icon.png';
+const RECRUIT_LAYOUT: RecruitCardLayout = {
+    recruiterAvatar: { x: 40, y: 120, radius: 50 },
+    participantCount: 4,
+    participantAvatar: (index) => ({ x: index * 118 + 158, y: 120, radius: 50 }),
+    squid: { x: 90, y: 172, width: 75, height: 75 },
+    channel: { font: '37px "Splatfont"', x: 30, y: 520 },
+    recruitCount: { font: '39px "Splatfont"', x: 525, y: 155 },
+    remaining: { font: '42px "Splatfont"', x: 605, y: 218 },
+    conditionTitle: { font: '43px "Splatfont"', x: 35, y: 290 },
+    condition: {
+        font: '30px "Genshin", "SEGUI"',
+        width: 600,
+        lineHeight: 40,
+        maxLines: 4,
+        x: 65,
+        y: 345,
+    },
+};
+export type RecruitEventCanvasOptions = RecruitCanvasOptions;
+export async function recruitEventCanvas(options: RecruitEventCanvasOptions) {
+    const { canvas, ctx } = createCanvasContext();
+    await drawRecruitCard(ctx, options, RECRUIT_LAYOUT, async (context) => {
+        const icon = await Canvas.loadImage(EVENT_ICON_URL);
+        context.drawImage(icon, 19, 19, 77, 77);
+        fillTextWithStroke(
+            context,
+            'イベントマッチ',
+            '51px Splatfont',
+            '#000000',
+            '#FF2F82',
+            3,
+            112,
             80,
-            500,
-            340,
         );
-        recruitCtx.restore;
-    }
-
-    const recruit = recruitCanvas.toBuffer();
-    return recruit;
+    });
+    return canvas.toBuffer();
 }
-
-/*
- * ルール情報のキャンバス(2枚目)を作成する
- */
 export async function ruleEventCanvas(eventData: EventMatchInfo | null) {
-    const ruleCanvas = Canvas.createCanvas(720, 550);
-    const ruleCtx = ruleCanvas.getContext('2d');
-
-    const title = eventData ? eventData.title : 'えらー';
-    const rule = eventData ? eventData.rule : 'えらー';
-    const date = eventData ? formatDatetime(eventData.startTime, dateformat.ymdw) : 'えらー';
-    const time = eventData
-        ? formatDatetime(eventData.startTime, dateformat.hm) +
-          ' - ' +
-          formatDatetime(eventData.endTime, dateformat.hm)
-        : 'えらー';
-    const stage1 = eventData ? eventData.stage1 : 'えらー';
-    const stage2 = eventData ? eventData.stage2 : 'えらー';
-
-    createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
-    ruleCtx.fillStyle = '#2F3136';
-    ruleCtx.fill();
-    ruleCtx.strokeStyle = '#FFFFFF';
-    ruleCtx.lineWidth = 4;
-    ruleCtx.stroke();
-
-    ruleCtx.save();
-    ruleCtx.textAlign = 'right';
-    fillTextWithStroke(ruleCtx, title, '38px Splatfont', '#FFE02EFB', '#2D3130', 1, 690, 65);
-    ruleCtx.restore();
-
-    fillTextWithStroke(ruleCtx, 'ルール', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 80);
-
-    const ruleWidth = ruleCtx.measureText(rule).width;
-    fillTextWithStroke(
-        ruleCtx,
-        rule,
-        '45px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        (320 - ruleWidth) / 2,
-        145,
-    ); // 中央寄せ
-
-    fillTextWithStroke(ruleCtx, '日時', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 220);
-
-    const dateWidth = ruleCtx.measureText(date).width;
-    fillTextWithStroke(
-        ruleCtx,
-        date,
-        '35px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        (350 - dateWidth) / 2,
-        270,
-    ); // 中央寄せ
-
-    const timeWidth = ruleCtx.measureText(time).width;
-    fillTextWithStroke(
-        ruleCtx,
-        time,
-        '35px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        15 + (350 - timeWidth) / 2,
-        320,
-    ); // 中央寄せ
-
-    fillTextWithStroke(ruleCtx, 'ステージ', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 390);
-
-    ruleCtx.save();
-    ruleCtx.textAlign = 'center';
-    fillTextWithStroke(ruleCtx, stage1, '32px Splatfont', '#FFFFFF', '#2D3130', 1, 190, 440);
-    fillTextWithStroke(ruleCtx, stage2, '32px Splatfont', '#FFFFFF', '#2D3130', 1, 190, 490);
-    ruleCtx.restore();
-
-    if (exists(eventData) && exists(eventData.stageImage1) && exists(eventData.stageImage2)) {
-        const stage1Image = await Canvas.loadImage(eventData.stageImage1);
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 130, 308, 176, 10);
-        ruleCtx.clip();
-        ruleCtx.drawImage(stage1Image, 370, 130, 308, 176);
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-
-        const stage2Image = await Canvas.loadImage(eventData.stageImage2);
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 340, 308, 176, 10);
-        ruleCtx.clip();
-        ruleCtx.drawImage(stage2Image, 370, 340, 308, 176);
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-    } else {
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 130, 308, 176, 10);
-        ruleCtx.fillStyle = '#000000';
-        ruleCtx.fill();
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 340, 308, 176, 10);
-        ruleCtx.fillStyle = '#000000';
-        ruleCtx.fill();
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-    }
-
-    createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
-    ruleCtx.clip();
-
-    const buffer = ruleCanvas.toBuffer();
-    return buffer;
+    return drawStageRuleCanvas(
+        eventData,
+        {
+            date: eventData ? formatDatetime(eventData.startTime, dateformat.ymdw) : 'えらー',
+            time: eventData
+                ? formatDatetime(eventData.startTime, dateformat.hm) +
+                  ' - ' +
+                  formatDatetime(eventData.endTime, dateformat.hm)
+                : 'えらー',
+            rule: eventData?.rule ?? 'えらー',
+            stage1: eventData?.stage1 ?? 'えらー',
+            stage2: eventData?.stage2 ?? 'えらー',
+        },
+        (context) => {
+            context.save();
+            context.textAlign = 'right';
+            fillTextWithStroke(
+                context,
+                eventData?.title ?? 'えらー',
+                '38px Splatfont',
+                '#FFE02EFB',
+                '#2D3130',
+                1,
+                690,
+                65,
+            );
+            context.restore();
+        },
+    );
 }

--- a/src/app/feat-recruit/common/canvases/fest_canvas.ts
+++ b/src/app/feat-recruit/common/canvases/fest_canvas.ts
@@ -1,377 +1,79 @@
-import path from 'path';
-
-import { Member } from '@prisma/client';
 import Canvas from 'canvas';
 
-import { MatchInfo } from '@/app/common/apis/splatoon3.ink/splatoon3_ink.js';
-import { createRoundRect, drawArcImage, fillTextWithStroke } from '@/app/common/canvas_components';
+import { MatchInfo } from '@/app/common/apis/splatoon3.ink/splatoon3_ink';
+import { fillTextWithStroke } from '@/app/common/canvas_components';
 import { dateformat, formatDatetime } from '@/app/common/convert_datetime';
-import { exists, notExists } from '@/app/common/others.js';
-import { modalRecruit } from '@/constant.js';
 
-import { RecruitOpCode } from './regenerate_canvas.js';
+import {
+    RecruitCanvasOptions,
+    RecruitCardLayout,
+    createCanvasContext,
+    drawRecruitCard,
+    drawStageRuleCanvas,
+} from './canvas_base';
 
-Canvas.registerFont(path.resolve('./fonts/Splatfont.ttf'), {
-    family: 'Splatfont',
-});
-Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Medium.ttf'), {
-    family: 'Genshin',
-});
-Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Bold.ttf'), {
-    family: 'Genshin-Bold',
-});
-Canvas.registerFont(path.resolve('./fonts/SEGUISYM.TTF'), { family: 'SEGUI' });
-
-/*
- * 募集用のキャンバス(1枚目)を作成する
- */
-export async function recruitFestCanvas(
-    opCode: number,
-    remaining: number,
-    count: number,
-    recruiter: Member,
-    user1: Member | null,
-    user2: Member | null,
-    user3: Member | null,
-    team: string,
-    color: string,
-    condition: string,
-    channelName: string | null,
-) {
-    const blankAvatarUrl =
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/blank_avatar.png'; // blankのアバター画像URL
-
-    const recruitCanvas = Canvas.createCanvas(720, 550);
-    const recruitCtx = recruitCanvas.getContext('2d');
-
-    // 下地
-    createRoundRect(recruitCtx, 1, 1, 718, 548, 30);
-    recruitCtx.fillStyle = '#2F3136';
-    recruitCtx.fill();
-    recruitCtx.strokeStyle = '#FFFFFF';
-    recruitCtx.lineWidth = 4;
-    recruitCtx.stroke();
-
-    const fesIcon = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/fes_icon.png',
-    );
-    recruitCtx.drawImage(fesIcon, 17, 20, 85, 85);
-
-    fillTextWithStroke(recruitCtx, 'フェスマッチ', '51px Splatfont', '#000000', color, 3, 115, 80);
-
-    recruitCtx.save();
-    recruitCtx.textAlign = 'right';
-    fillTextWithStroke(recruitCtx, team, '48px Splatfont', color, '#222222', 1.7, 690, 80);
-    recruitCtx.restore();
-
-    // 募集主の画像
-    const recruiterImage = await Canvas.loadImage(recruiter.iconUrl ?? modalRecruit.placeHold);
-    recruitCtx.save();
-    drawArcImage(recruitCtx, recruiterImage, 40, 120, 50);
-    recruitCtx.strokeStyle = '#1e1f23';
-    recruitCtx.lineWidth = 9;
-    recruitCtx.stroke();
-    recruitCtx.restore();
-
-    const memberIcons = [];
-
-    if (exists(user1)) {
-        memberIcons.push(user1.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user2)) {
-        memberIcons.push(user2.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user3)) {
-        memberIcons.push(user3.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    for (let i = 0; i < 4; i++) {
-        if (count >= i + 2) {
-            const userUrl = memberIcons[i] ?? blankAvatarUrl;
-            const userImage = await Canvas.loadImage(userUrl);
-            recruitCtx.save();
-            drawArcImage(recruitCtx, userImage, i * 118 + 158, 120, 50);
-            recruitCtx.strokeStyle = '#1e1f23';
-            recruitCtx.lineWidth = 9;
-            recruitCtx.stroke();
-            recruitCtx.restore();
-        }
-    }
-
-    const recruiterIcon = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/squid.png',
-    );
-    recruitCtx.drawImage(
-        recruiterIcon,
-        0,
-        0,
-        recruiterIcon.width,
-        recruiterIcon.height,
-        90,
-        172,
-        75,
-        75,
-    );
-
-    fillTextWithStroke(
-        recruitCtx,
-        '募集人数',
-        '39px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        525,
-        155,
-    );
-
-    let remainingString;
-    if (opCode === RecruitOpCode.open || opCode === RecruitOpCode.cancel) {
-        remainingString = remaining > 0 ? '@' + remaining : '満員';
-    } else if (opCode === RecruitOpCode.close) {
-        remainingString = '受付終了';
-    } else {
-        remainingString = 'ERROR!';
-    }
-
-    recruitCtx.save();
-    recruitCtx.textAlign = 'center';
-    fillTextWithStroke(
-        recruitCtx,
-        remainingString,
-        '42px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        605,
-        218,
-    );
-    recruitCtx.restore();
-
-    fillTextWithStroke(
-        recruitCtx,
-        '参加条件',
-        '43px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        35,
-        290,
-    );
-
-    recruitCtx.font = '30px "Genshin", "SEGUI"';
-    const width = 600;
-    const size = 40;
-    const columnNum = 4;
-    const column = [''];
-    let line = 0;
-    condition = condition.replace(/\\n/g, '\n');
-
-    // 幅に合わせて自動改行
-    for (let i = 0; i < condition.length; i++) {
-        const char = condition.charAt(i);
-
-        if (char == '\n') {
-            line++;
-            column[line] = '';
-        } else if (recruitCtx.measureText(column[line] + char).width > width) {
-            line++;
-            column[line] = char;
-        } else {
-            column[line] += char;
-        }
-    }
-
-    if (column.length > columnNum) {
-        column[columnNum - 1] += '…';
-    }
-
-    for (let j = 0; j < column.length; j++) {
-        if (j < columnNum) {
-            recruitCtx.fillText(column[j], 65, 345 + size * j);
-        }
-    }
-
-    let channelString;
-    if (notExists(channelName)) {
-        channelString = '🔉 VC指定なし';
-    } else {
-        channelString = '🔉 ' + channelName;
-    }
-
-    fillTextWithStroke(
-        recruitCtx,
-        channelString,
-        '37px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        30,
-        520,
-    );
-
-    if (opCode === RecruitOpCode.cancel) {
-        recruitCtx.save();
-        recruitCtx.translate(220, -110);
-        recruitCtx.rotate((25 * Math.PI) / 180);
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/canceled_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            0,
-            0,
-            600,
-            600,
-        );
-        recruitCtx.restore;
-    } else if (opCode === RecruitOpCode.close) {
-        recruitCtx.save();
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/closed_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            130,
+const FEST_ICON_URL =
+    'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/fes_icon.png';
+const RECRUIT_LAYOUT: RecruitCardLayout = {
+    recruiterAvatar: { x: 40, y: 120, radius: 50 },
+    participantCount: 4,
+    participantAvatar: (index) => ({ x: index * 118 + 158, y: 120, radius: 50 }),
+    squid: { x: 90, y: 172, width: 75, height: 75 },
+    channel: { font: '37px "Splatfont"', x: 30, y: 520 },
+    recruitCount: { font: '39px "Splatfont"', x: 525, y: 155 },
+    remaining: { font: '42px "Splatfont"', x: 605, y: 218 },
+    conditionTitle: { font: '43px "Splatfont"', x: 35, y: 290 },
+    condition: {
+        font: '30px "Genshin", "SEGUI"',
+        width: 600,
+        lineHeight: 40,
+        maxLines: 4,
+        x: 65,
+        y: 345,
+    },
+};
+export type RecruitFestCanvasOptions = RecruitCanvasOptions & { team: string; color: string };
+export async function recruitFestCanvas(options: RecruitFestCanvasOptions) {
+    const { canvas, ctx } = createCanvasContext();
+    await drawRecruitCard(ctx, options, RECRUIT_LAYOUT, async (context) => {
+        const icon = await Canvas.loadImage(FEST_ICON_URL);
+        context.drawImage(icon, 17, 20, 85, 85);
+        fillTextWithStroke(
+            context,
+            'フェスマッチ',
+            '51px Splatfont',
+            '#000000',
+            options.color,
+            3,
+            115,
             80,
-            500,
-            340,
         );
-        recruitCtx.restore;
-    }
-
-    const recruit = recruitCanvas.toBuffer();
-    return recruit;
+        context.save();
+        context.textAlign = 'right';
+        fillTextWithStroke(
+            context,
+            options.team,
+            '48px Splatfont',
+            options.color,
+            '#222222',
+            1.7,
+            690,
+            80,
+        );
+        context.restore();
+    });
+    return canvas.toBuffer();
 }
-
-/*
- * ルール情報のキャンバス(2枚目)を作成する
- */
 export async function ruleFestCanvas(fesData: MatchInfo | null) {
-    const ruleCanvas = Canvas.createCanvas(720, 550);
-    const ruleCtx = ruleCanvas.getContext('2d');
-
-    const date = fesData ? formatDatetime(fesData.startTime, dateformat.ymdw) : 'えらー';
-    const time = fesData
-        ? formatDatetime(fesData.startTime, dateformat.hm) +
-          ' - ' +
-          formatDatetime(fesData.endTime, dateformat.hm)
-        : 'えらー';
-    const rule = fesData && fesData.rule ? fesData.rule : 'えらー';
-    const stage1 = fesData && fesData.stage1 ? fesData.stage1 : 'えらー';
-    const stage2 = fesData && fesData.stage2 ? fesData.stage2 : 'えらー';
-
-    createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
-    ruleCtx.fillStyle = '#2F3136';
-    ruleCtx.fill();
-    ruleCtx.strokeStyle = '#FFFFFF';
-    ruleCtx.lineWidth = 4;
-    ruleCtx.stroke();
-
-    fillTextWithStroke(ruleCtx, 'ルール', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 80);
-
-    const ruleWidth = ruleCtx.measureText(rule).width;
-    fillTextWithStroke(
-        ruleCtx,
-        rule,
-        '45px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        (320 - ruleWidth) / 2,
-        145,
-    ); // 中央寄せ
-
-    fillTextWithStroke(ruleCtx, '日時', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 220);
-
-    const dateWidth = ruleCtx.measureText(date).width;
-    fillTextWithStroke(
-        ruleCtx,
-        date,
-        '35px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        (350 - dateWidth) / 2,
-        270,
-    ); // 中央寄せ
-
-    const timeWidth = ruleCtx.measureText(time).width;
-    fillTextWithStroke(
-        ruleCtx,
-        time,
-        '35px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        15 + (350 - timeWidth) / 2,
-        320,
-    ); // 中央寄せ
-
-    fillTextWithStroke(ruleCtx, 'ステージ', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 390);
-    ruleCtx.save();
-    ruleCtx.textAlign = 'center';
-    fillTextWithStroke(ruleCtx, stage1, '32px Splatfont', '#FFFFFF', '#2D3130', 1, 190, 440);
-    fillTextWithStroke(ruleCtx, stage2, '32px Splatfont', '#FFFFFF', '#2D3130', 1, 190, 490);
-
-    ruleCtx.restore();
-
-    if (exists(fesData) && exists(fesData.stageImage1) && exists(fesData.stageImage2)) {
-        const stage1Image = await Canvas.loadImage(fesData.stageImage1);
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 130, 308, 176, 10);
-        ruleCtx.clip();
-        ruleCtx.drawImage(stage1Image, 370, 130, 308, 176);
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-
-        const stage2Image = await Canvas.loadImage(fesData.stageImage2);
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 340, 308, 176, 10);
-        ruleCtx.clip();
-        ruleCtx.drawImage(stage2Image, 370, 340, 308, 176);
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-    } else {
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 130, 308, 176, 10);
-        ruleCtx.fillStyle = '#000000';
-        ruleCtx.fill();
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 340, 308, 176, 10);
-        ruleCtx.fillStyle = '#000000';
-        ruleCtx.fill();
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-    }
-
-    createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
-    ruleCtx.clip();
-
-    const buffer = ruleCanvas.toBuffer();
-    return buffer;
+    return drawStageRuleCanvas(fesData, {
+        date: fesData ? formatDatetime(fesData.startTime, dateformat.ymdw) : 'えらー',
+        time: fesData
+            ? formatDatetime(fesData.startTime, dateformat.hm) +
+              ' - ' +
+              formatDatetime(fesData.endTime, dateformat.hm)
+            : 'えらー',
+        rule: fesData?.rule ?? 'えらー',
+        stage1: fesData?.stage1 ?? 'えらー',
+        stage2: fesData?.stage2 ?? 'えらー',
+    });
 }

--- a/src/app/feat-recruit/common/canvases/regenerate_canvas.ts
+++ b/src/app/feat-recruit/common/canvases/regenerate_canvas.ts
@@ -112,21 +112,15 @@ async function regenRegularCanvas(
 
     if (notExists(submitMembersList[0])) return;
 
-    const recruitBuffer = await recruitRegularCanvas(
+    const recruitBuffer = await recruitRegularCanvas({
         opCode,
-        remainingNum,
+        remaining: remainingNum,
         count,
-        submitMembersList[0],
-        submitMembersList[1],
-        submitMembersList[2],
-        submitMembersList[3],
-        submitMembersList[4],
-        submitMembersList[5],
-        submitMembersList[6],
-        submitMembersList[7],
+        recruiter: submitMembersList[0],
+        users: submitMembersList.slice(1, 8),
         condition,
         channelName,
-    );
+    });
     const recruitImage = new AttachmentBuilder(recruitBuffer, {
         name: 'ikabu_recruit.png',
     });
@@ -160,17 +154,15 @@ async function regenEventCanvas(
 
     if (notExists(submitMembersList[0])) return;
 
-    const recruitBuffer = await recruitEventCanvas(
+    const recruitBuffer = await recruitEventCanvas({
         opCode,
-        remainingNum,
+        remaining: remainingNum,
         count,
-        submitMembersList[0],
-        submitMembersList[1],
-        submitMembersList[2],
-        submitMembersList[3],
+        recruiter: submitMembersList[0],
+        users: submitMembersList.slice(1, 4),
         condition,
         channelName,
-    );
+    });
     const recruitImage = new AttachmentBuilder(recruitBuffer, {
         name: 'ikabu_recruit.png',
     });
@@ -205,18 +197,16 @@ async function regenAnarchyCanvas(
 
     if (notExists(submitMembersList[0])) return;
 
-    const recruitBuffer = await recruitAnarchyCanvas(
+    const recruitBuffer = await recruitAnarchyCanvas({
         opCode,
-        remainingNum,
+        remaining: remainingNum,
         count,
-        submitMembersList[0],
-        submitMembersList[1],
-        submitMembersList[2],
-        submitMembersList[3],
+        recruiter: submitMembersList[0],
+        users: submitMembersList.slice(1, 4),
         condition,
         rank,
         channelName,
-    );
+    });
     const recruitImage = new AttachmentBuilder(recruitBuffer, {
         name: 'ikabu_recruit.png',
     });
@@ -251,18 +241,16 @@ async function regenSalmonCanvas(
 
     if (notExists(submitMembersList[0])) return;
 
-    const recruitBuffer = await recruitSalmonCanvas(
+    const recruitBuffer = await recruitSalmonCanvas({
         opCode,
-        remainingNum,
+        remaining: remainingNum,
         count,
-        submitMembersList[0],
-        submitMembersList[1],
-        submitMembersList[2],
-        submitMembersList[3],
+        recruiter: submitMembersList[0],
+        users: submitMembersList.slice(1, 4),
         condition,
         channelName,
-        isTeamContest ? 'コンテスト' : undefined,
-    );
+        subTitle: isTeamContest ? 'コンテスト' : undefined,
+    });
 
     const recruitImage = new AttachmentBuilder(recruitBuffer, {
         name: 'ikabu_recruit.png',
@@ -349,19 +337,17 @@ async function regenFesCanvas(
 
     if (notExists(submitMembersList[0])) return;
 
-    const recruitBuffer = await recruitFestCanvas(
+    const recruitBuffer = await recruitFestCanvas({
         opCode,
-        remainingNum,
+        remaining: remainingNum,
         count,
-        submitMembersList[0],
-        submitMembersList[1],
-        submitMembersList[2],
-        submitMembersList[3],
-        teamRole.name,
-        teamRole.hexColor,
+        recruiter: submitMembersList[0],
+        users: submitMembersList.slice(1, 4),
+        team: teamRole.name,
+        color: teamRole.hexColor,
         condition,
         channelName,
-    );
+    });
     const recruitImage = new AttachmentBuilder(recruitBuffer, {
         name: 'ikabu_recruit.png',
     });
@@ -394,17 +380,15 @@ async function regenBigRunCanvas(
 
     if (notExists(submitMembersList[0])) return;
 
-    const recruitBuffer = await recruitBigRunCanvas(
+    const recruitBuffer = await recruitBigRunCanvas({
         opCode,
-        remainingNum,
+        remaining: remainingNum,
         count,
-        submitMembersList[0],
-        submitMembersList[1],
-        submitMembersList[2],
-        submitMembersList[3],
+        recruiter: submitMembersList[0],
+        users: submitMembersList.slice(1, 4),
         condition,
         channelName,
-    );
+    });
 
     const recruitImage = new AttachmentBuilder(recruitBuffer, {
         name: 'ikabu_recruit.png',

--- a/src/app/feat-recruit/common/canvases/regular_canvas.ts
+++ b/src/app/feat-recruit/common/canvases/regular_canvas.ts
@@ -1,406 +1,70 @@
-import path from 'path';
-
-import { Member } from '@prisma/client';
 import Canvas from 'canvas';
 
 import { MatchInfo } from '@/app/common/apis/splatoon3.ink/splatoon3_ink.js';
-import { createRoundRect, drawArcImage, fillTextWithStroke } from '@/app/common/canvas_components';
+import { fillTextWithStroke } from '@/app/common/canvas_components';
 import { dateformat, formatDatetime } from '@/app/common/convert_datetime';
-import { exists, notExists } from '@/app/common/others.js';
-import { modalRecruit } from '@/constant.js';
 
-import { RecruitOpCode } from './regenerate_canvas.js';
+import {
+    RecruitCanvasOptions,
+    RecruitCardLayout,
+    createCanvasContext,
+    drawRecruitCard,
+    drawStageRuleCanvas,
+} from './canvas_base.js';
 
-Canvas.registerFont(path.resolve('./fonts/Splatfont.ttf'), {
-    family: 'Splatfont',
-});
-Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Medium.ttf'), {
-    family: 'Genshin',
-});
-Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Bold.ttf'), {
-    family: 'Genshin-Bold',
-});
-Canvas.registerFont(path.resolve('./fonts/SEGUISYM.TTF'), { family: 'SEGUI' });
-
-/*
- * 募集用のキャンバス(1枚目)を作成する
- */
-export async function recruitRegularCanvas(
-    opCode: number,
-    remaining: number,
-    count: number,
-    recruiter: Member,
-    user1: Member | null,
-    user2: Member | null,
-    user3: Member | null,
-    user4: Member | null,
-    user5: Member | null,
-    user6: Member | null,
-    user7: Member | null,
-    condition: string,
-    channelName: string | null,
-) {
-    const blankAvatarUrl =
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/blank_avatar.png'; // blankのアバター画像URL
-
-    const recruitCanvas = Canvas.createCanvas(720, 550);
-    const recruitCtx = recruitCanvas.getContext('2d');
-
-    // 下地
-    createRoundRect(recruitCtx, 1, 1, 718, 548, 30);
-    recruitCtx.fillStyle = '#2F3136';
-    recruitCtx.fill();
-    recruitCtx.strokeStyle = '#FFFFFF';
-    recruitCtx.lineWidth = 4;
-    recruitCtx.stroke();
-
-    const regularIcon = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/regular_icon.png',
-    );
-    recruitCtx.drawImage(regularIcon, 25, 25, 75, 75);
-
-    fillTextWithStroke(
-        recruitCtx,
-        'レギュラーマッチ',
-        '51px Splatfont',
-        '#000000',
-        '#B3FF00',
-        3,
-        115,
-        80,
-    );
-
-    // 募集主の画像
-    const recruiterImage = await Canvas.loadImage(recruiter.iconUrl ?? modalRecruit.placeHold);
-    recruitCtx.save();
-    drawArcImage(recruitCtx, recruiterImage, 40, 120, 40);
-    recruitCtx.strokeStyle = '#1e1f23';
-    recruitCtx.lineWidth = 9;
-    recruitCtx.stroke();
-    recruitCtx.restore();
-
-    const memberIcons = [];
-
-    if (exists(user1)) {
-        memberIcons.push(user1.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user2)) {
-        memberIcons.push(user2.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user3)) {
-        memberIcons.push(user3.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user4)) {
-        memberIcons.push(user4.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user5)) {
-        memberIcons.push(user5.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user6)) {
-        memberIcons.push(user6.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user7)) {
-        memberIcons.push(user7.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    for (let i = 0; i < 7; i++) {
-        if (count >= i + 2) {
-            const userUrl = memberIcons[i] ?? blankAvatarUrl;
-            const userImage = await Canvas.loadImage(userUrl);
-            recruitCtx.save();
-            if (i < 3) {
-                drawArcImage(recruitCtx, userImage, (i + 1) * 100 + 40, 120, 40);
-            } else {
-                drawArcImage(recruitCtx, userImage, (i - 3) * 100 + 40, 220, 40);
-            }
-            recruitCtx.strokeStyle = '#1e1f23';
-            recruitCtx.lineWidth = 9;
-            recruitCtx.stroke();
-            recruitCtx.restore();
-        }
-    }
-
-    const recruiterIcon = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/squid.png',
-    );
-    recruitCtx.drawImage(
-        recruiterIcon,
-        0,
-        0,
-        recruiterIcon.width,
-        recruiterIcon.height,
-        75,
-        155,
-        75,
-        75,
-    );
-
-    let channelString;
-    if (notExists(channelName)) {
-        channelString = '🔉 VC指定なし';
-    } else {
-        channelString = '🔉 ' + channelName;
-    }
-
-    recruitCtx.save();
-    recruitCtx.textAlign = 'right';
-    fillTextWithStroke(
-        recruitCtx,
-        channelString,
-        '33px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        680,
-        70,
-    );
-    recruitCtx.restore();
-
-    fillTextWithStroke(
-        recruitCtx,
-        '募集人数',
-        '41px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        490,
-        185,
-    );
-
-    let remainingString;
-    if (opCode === RecruitOpCode.open || opCode === RecruitOpCode.cancel) {
-        remainingString = remaining > 0 ? '@' + remaining : '満員';
-    } else if (opCode === RecruitOpCode.close) {
-        remainingString = '受付終了';
-    } else {
-        remainingString = 'ERROR!';
-    }
-
-    recruitCtx.save();
-    recruitCtx.textAlign = 'center';
-    fillTextWithStroke(
-        recruitCtx,
-        remainingString,
-        '43px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        560,
-        248,
-    );
-    recruitCtx.restore();
-
-    fillTextWithStroke(
-        recruitCtx,
-        '参加条件',
-        '43px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        35,
-        360,
-    );
-
-    recruitCtx.font = '31px "Genshin", "SEGUI"';
-    const width = 603;
-    const size = 40;
-    const columnNum = 3;
-    const column = [''];
-    let line = 0;
-    condition = condition.replace(/\\n/g, '\n');
-
-    // 幅に合わせて自動改行
-    for (let i = 0; i < condition.length; i++) {
-        const char = condition.charAt(i);
-
-        if (char == '\n') {
-            line++;
-            column[line] = '';
-        } else if (recruitCtx.measureText(column[line] + char).width > width) {
-            line++;
-            column[line] = char;
-        } else {
-            column[line] += char;
-        }
-    }
-
-    if (column.length > columnNum) {
-        column[columnNum - 1] += '…';
-    }
-
-    for (let j = 0; j < column.length; j++) {
-        if (j < columnNum) {
-            recruitCtx.fillText(column[j], 65, 415 + size * j);
-        }
-    }
-
-    if (opCode === RecruitOpCode.cancel) {
-        recruitCtx.save();
-        recruitCtx.translate(220, -110);
-        recruitCtx.rotate((25 * Math.PI) / 180);
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/canceled_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            0,
-            0,
-            600,
-            600,
-        );
-        recruitCtx.restore;
-    } else if (opCode === RecruitOpCode.close) {
-        recruitCtx.save();
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/closed_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            130,
+const REGULAR_ICON_URL =
+    'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/regular_icon.png';
+const RECRUIT_LAYOUT: RecruitCardLayout = {
+    recruiterAvatar: { x: 40, y: 120, radius: 40 },
+    participantCount: 7,
+    participantAvatar: (index) =>
+        index < 3
+            ? { x: (index + 1) * 100 + 40, y: 120, radius: 40 }
+            : { x: (index - 3) * 100 + 40, y: 220, radius: 40 },
+    squid: { x: 75, y: 155, width: 75, height: 75 },
+    channel: { font: '33px "Splatfont"', x: 680, y: 70, align: 'right' },
+    recruitCount: { font: '41px "Splatfont"', x: 490, y: 185 },
+    remaining: { font: '43px "Splatfont"', x: 560, y: 248 },
+    conditionTitle: { font: '43px "Splatfont"', x: 35, y: 360 },
+    condition: {
+        font: '31px "Genshin", "SEGUI"',
+        width: 603,
+        lineHeight: 40,
+        maxLines: 3,
+        x: 65,
+        y: 415,
+    },
+    channelBeforeRecruitCount: true,
+};
+export type RecruitRegularCanvasOptions = RecruitCanvasOptions;
+export async function recruitRegularCanvas(options: RecruitRegularCanvasOptions) {
+    const { canvas, ctx } = createCanvasContext();
+    await drawRecruitCard(ctx, options, RECRUIT_LAYOUT, async (context) => {
+        const icon = await Canvas.loadImage(REGULAR_ICON_URL);
+        context.drawImage(icon, 25, 25, 75, 75);
+        fillTextWithStroke(
+            context,
+            'レギュラーマッチ',
+            '51px Splatfont',
+            '#000000',
+            '#B3FF00',
+            3,
+            115,
             80,
-            500,
-            340,
         );
-        recruitCtx.restore;
-    }
-
-    const recruit = recruitCanvas.toBuffer();
-    return recruit;
+    });
+    return canvas.toBuffer();
 }
-
-/*
- * ルール情報のキャンバス(2枚目)を作成する
- */
 export async function ruleRegularCanvas(regularData: MatchInfo | null) {
-    const ruleCanvas = Canvas.createCanvas(720, 550);
-    const ruleCtx = ruleCanvas.getContext('2d');
-
-    const date = regularData ? formatDatetime(regularData.startTime, dateformat.ymdw) : 'えらー';
-    const time = regularData
-        ? formatDatetime(regularData.startTime, dateformat.hm) +
-          ' - ' +
-          formatDatetime(regularData.endTime, dateformat.hm)
-        : 'えらー';
-    const rule = regularData && regularData.rule ? regularData.rule : 'えらー';
-    const stage1 = regularData && regularData.stage1 ? regularData.stage1 : 'えらー';
-    const stage2 = regularData && regularData.stage2 ? regularData.stage2 : 'えらー';
-
-    createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
-    ruleCtx.fillStyle = '#2F3136';
-    ruleCtx.fill();
-    ruleCtx.strokeStyle = '#FFFFFF';
-    ruleCtx.lineWidth = 4;
-    ruleCtx.stroke();
-
-    fillTextWithStroke(ruleCtx, 'ルール', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 80);
-    const ruleWidth = ruleCtx.measureText(rule).width;
-    fillTextWithStroke(
-        ruleCtx,
-        rule,
-        '45px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        (320 - ruleWidth) / 2,
-        145,
-    ); // 中央寄せ
-
-    fillTextWithStroke(ruleCtx, '日時', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 220);
-
-    const dateWidth = ruleCtx.measureText(date).width;
-    fillTextWithStroke(
-        ruleCtx,
-        date,
-        '35px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        (350 - dateWidth) / 2,
-        270,
-    ); // 中央寄せ
-
-    const timeWidth = ruleCtx.measureText(time).width;
-    fillTextWithStroke(
-        ruleCtx,
-        time,
-        '35px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        15 + (350 - timeWidth) / 2,
-        320,
-    ); // 中央寄せ
-
-    fillTextWithStroke(ruleCtx, 'ステージ', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 390);
-
-    ruleCtx.save();
-    ruleCtx.textAlign = 'center';
-    fillTextWithStroke(ruleCtx, stage1, '32px Splatfont', '#FFFFFF', '#2D3130', 1, 190, 440);
-    fillTextWithStroke(ruleCtx, stage2, '32px Splatfont', '#FFFFFF', '#2D3130', 1, 190, 490);
-
-    ruleCtx.restore();
-
-    if (exists(regularData) && exists(regularData.stageImage1) && exists(regularData.stageImage2)) {
-        const stage1Image = await Canvas.loadImage(regularData.stageImage1);
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 130, 308, 176, 10);
-        ruleCtx.clip();
-        ruleCtx.drawImage(stage1Image, 370, 130, 308, 176);
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-
-        const stage2Image = await Canvas.loadImage(regularData.stageImage2);
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 340, 308, 176, 10);
-        ruleCtx.clip();
-        ruleCtx.drawImage(stage2Image, 370, 340, 308, 176);
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-    } else {
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 130, 308, 176, 10);
-        ruleCtx.fillStyle = '#000000';
-        ruleCtx.fill();
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 340, 308, 176, 10);
-        ruleCtx.fillStyle = '#000000';
-        ruleCtx.fill();
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-    }
-
-    createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
-    ruleCtx.clip();
-
-    const buffer = ruleCanvas.toBuffer();
-    return buffer;
+    return drawStageRuleCanvas(regularData, {
+        date: regularData ? formatDatetime(regularData.startTime, dateformat.ymdw) : 'えらー',
+        time: regularData
+            ? formatDatetime(regularData.startTime, dateformat.hm) +
+              ' - ' +
+              formatDatetime(regularData.endTime, dateformat.hm)
+            : 'えらー',
+        rule: regularData?.rule ?? 'えらー',
+        stage1: regularData?.stage1 ?? 'えらー',
+        stage2: regularData?.stage2 ?? 'えらー',
+    });
 }

--- a/src/app/feat-recruit/common/canvases/salmon_canvas.ts
+++ b/src/app/feat-recruit/common/canvases/salmon_canvas.ts
@@ -1,354 +1,82 @@
-import path from 'path';
-
-import { Member } from '@prisma/client';
 import Canvas from 'canvas';
 
 import { SalmonInfo } from '@/app/common/apis/splatoon3.ink/splatoon3_ink.js';
-import { createRoundRect, drawArcImage, fillTextWithStroke } from '@/app/common/canvas_components';
+import { fillTextWithStroke } from '@/app/common/canvas_components';
 import { dateformat, formatDatetime } from '@/app/common/convert_datetime';
-import { exists, notExists } from '@/app/common/others.js';
-import { modalRecruit, placeHold } from '@/constant.js';
+import { placeHold } from '@/constant.js';
 
-import { RecruitOpCode } from './regenerate_canvas.js';
+import {
+    RecruitCanvasOptions,
+    RecruitCardLayout,
+    SalmonRuleLayout,
+    createCanvasContext,
+    drawRecruitCard,
+    drawSalmonRuleCanvas,
+} from './canvas_base.js';
 
-Canvas.registerFont(path.resolve('./fonts/Splatfont.ttf'), {
-    family: 'Splatfont',
-});
-Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Medium.ttf'), {
-    family: 'Genshin',
-});
-Canvas.registerFont(path.resolve('./fonts/GenShinGothic-P-Bold.ttf'), {
-    family: 'Genshin-Bold',
-});
-Canvas.registerFont(path.resolve('./fonts/SEGUISYM.TTF'), { family: 'SEGUI' });
-
-/*
- * 募集用のキャンバス(1枚目)を作成する
- */
-export async function recruitSalmonCanvas(
-    opCode: number,
-    remaining: number,
-    count: number,
-    recruiter: Member,
-    user1: Member | null,
-    user2: Member | null,
-    user3: Member | null,
-    condition: string,
-    channelName: string | null,
-    subTitle?: string,
-) {
-    const blankAvatarUrl =
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/blank_avatar.png'; // blankのアバター画像URL
-
-    const recruitCanvas = Canvas.createCanvas(720, 550);
-    const recruitCtx = recruitCanvas.getContext('2d');
-
-    // 下地
-    createRoundRect(recruitCtx, 1, 1, 718, 548, 30);
-    recruitCtx.fillStyle = '#2F3136';
-    recruitCtx.fill();
-    recruitCtx.strokeStyle = '#FFFFFF';
-    recruitCtx.lineWidth = 4;
-    recruitCtx.stroke();
-
-    const salmonIcon = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/salmon_black_icon.png',
-    );
-    recruitCtx.drawImage(salmonIcon, 22, 32, 82, 60);
-
-    fillTextWithStroke(recruitCtx, 'SALMON', '51px Splatfont', '#000000', '#FF9900', 3, 115, 80);
-    fillTextWithStroke(recruitCtx, 'RUN', '51px Splatfont', '#000000', '#00FF00DA', 3, 350, 80);
-
-    if (typeof subTitle === 'string') {
-        fillTextWithStroke(
-            recruitCtx,
-            subTitle,
-            '49px Splatfont',
-            '#000000',
-            '#FFD900FB',
-            3,
-            510,
-            80,
-        );
-    }
-
-    // 募集主の画像
-    const recruiterImage = await Canvas.loadImage(recruiter.iconUrl ?? modalRecruit.placeHold);
-    recruitCtx.save();
-    drawArcImage(recruitCtx, recruiterImage, 40, 120, 50);
-    recruitCtx.strokeStyle = '#1e1f23';
-    recruitCtx.lineWidth = 9;
-    recruitCtx.stroke();
-    recruitCtx.restore();
-
-    const memberIcons = [];
-
-    if (exists(user1)) {
-        memberIcons.push(user1.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user2)) {
-        memberIcons.push(user2.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    if (exists(user3)) {
-        memberIcons.push(user3.iconUrl ?? modalRecruit.placeHold);
-    }
-
-    for (let i = 0; i < 4; i++) {
-        if (count >= i + 2) {
-            const userUrl = memberIcons[i] ?? blankAvatarUrl;
-            const userImage = await Canvas.loadImage(userUrl);
-            recruitCtx.save();
-            drawArcImage(recruitCtx, userImage, i * 118 + 158, 120, 50);
-            recruitCtx.strokeStyle = '#1e1f23';
-            recruitCtx.lineWidth = 9;
-            recruitCtx.stroke();
-            recruitCtx.restore();
-        }
-    }
-
-    const recruiterIcon = await Canvas.loadImage(
-        'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/squid.png',
-    );
-    recruitCtx.drawImage(
-        recruiterIcon,
-        0,
-        0,
-        recruiterIcon.width,
-        recruiterIcon.height,
-        90,
-        172,
-        75,
-        75,
-    );
-
-    fillTextWithStroke(
-        recruitCtx,
-        '募集人数',
-        '39px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        525,
-        155,
-    );
-
-    let remainingString;
-    if (opCode === RecruitOpCode.open || opCode === RecruitOpCode.cancel) {
-        remainingString = remaining > 0 ? '@' + remaining : '満員';
-    } else if (opCode === RecruitOpCode.close) {
-        remainingString = '受付終了';
-    } else {
-        remainingString = 'ERROR!';
-    }
-
-    recruitCtx.save();
-    recruitCtx.textAlign = 'center';
-    fillTextWithStroke(
-        recruitCtx,
-        remainingString,
-        '42px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        605,
-        218,
-    );
-    recruitCtx.restore();
-
-    fillTextWithStroke(
-        recruitCtx,
-        '参加条件',
-        '43px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        35,
-        290,
-    );
-
-    recruitCtx.font = '30px "Genshin", "SEGUI"';
-    const width = 600;
-    const size = 40;
-    const columnNum = 4;
-    const column = [''];
-    let line = 0;
-    condition = condition.replace(/\\n/g, '\n');
-
-    // 幅に合わせて自動改行
-    for (let i = 0; i < condition.length; i++) {
-        const char = condition.charAt(i);
-
-        if (char == '\n') {
-            line++;
-            column[line] = '';
-        } else if (recruitCtx.measureText(column[line] + char).width > width) {
-            line++;
-            column[line] = char;
-        } else {
-            column[line] += char;
-        }
-    }
-
-    if (column.length > columnNum) {
-        column[columnNum - 1] += '…';
-    }
-
-    for (let j = 0; j < column.length; j++) {
-        if (j < columnNum) {
-            recruitCtx.fillText(column[j], 65, 345 + size * j);
-        }
-    }
-
-    let channelString;
-    if (notExists(channelName)) {
-        channelString = '🔉 VC指定なし';
-    } else {
-        channelString = '🔉 ' + channelName;
-    }
-
-    fillTextWithStroke(
-        recruitCtx,
-        channelString,
-        '37px "Splatfont"',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        30,
-        520,
-    );
-
-    if (opCode === RecruitOpCode.cancel) {
-        recruitCtx.save();
-        recruitCtx.translate(220, -110);
-        recruitCtx.rotate((25 * Math.PI) / 180);
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/canceled_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            0,
-            0,
-            600,
-            600,
-        );
-        recruitCtx.restore;
-    } else if (opCode === RecruitOpCode.close) {
-        recruitCtx.save();
-        const cancelStamp = await Canvas.loadImage(
-            'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/closed_stamp.png',
-        );
-        recruitCtx.drawImage(
-            cancelStamp,
-            0,
-            0,
-            cancelStamp.width,
-            cancelStamp.height,
-            130,
-            80,
-            500,
-            340,
-        );
-        recruitCtx.restore;
-    }
-
-    const recruit = recruitCanvas.toBuffer();
-    return recruit;
+const SALMON_ICON_URL =
+    'https://raw.githubusercontent.com/shngmsw/ikabu/main/images/recruit/salmon_black_icon.png';
+const RECRUIT_LAYOUT: RecruitCardLayout = {
+    recruiterAvatar: { x: 40, y: 120, radius: 50 },
+    participantCount: 4,
+    participantAvatar: (index) => ({ x: index * 118 + 158, y: 120, radius: 50 }),
+    squid: { x: 90, y: 172, width: 75, height: 75 },
+    channel: { font: '37px "Splatfont"', x: 30, y: 520 },
+    recruitCount: { font: '39px "Splatfont"', x: 525, y: 155 },
+    remaining: { font: '42px "Splatfont"', x: 605, y: 218 },
+    conditionTitle: { font: '43px "Splatfont"', x: 35, y: 290 },
+    condition: {
+        font: '30px "Genshin", "SEGUI"',
+        width: 600,
+        lineHeight: 40,
+        maxLines: 4,
+        x: 65,
+        y: 345,
+    },
+};
+const RULE_LAYOUT: SalmonRuleLayout = {
+    dateLabelY: 80,
+    dateY: 145,
+    weaponLabelY: 245,
+    weaponPositions: [
+        { x: 50, y: 280, width: 110, height: 110 },
+        { x: 190, y: 280, width: 110, height: 110 },
+        { x: 50, y: 410, width: 110, height: 110 },
+        { x: 190, y: 410, width: 110, height: 110 },
+    ],
+    stageLabelX: 350,
+    stageLabelY: 245,
+    stageX: 150,
+    stageY: 300,
+    stageImage: { x: 370, y: 340, width: 308, height: 176 },
+};
+export type RecruitSalmonCanvasOptions = RecruitCanvasOptions & { subTitle?: string };
+export async function recruitSalmonCanvas(options: RecruitSalmonCanvasOptions) {
+    const { canvas, ctx } = createCanvasContext();
+    await drawRecruitCard(ctx, options, RECRUIT_LAYOUT, async (context) => {
+        const icon = await Canvas.loadImage(SALMON_ICON_URL);
+        context.drawImage(icon, 22, 32, 82, 60);
+        fillTextWithStroke(context, 'SALMON', '51px Splatfont', '#000000', '#FF9900', 3, 115, 80);
+        fillTextWithStroke(context, 'RUN', '51px Splatfont', '#000000', '#00FF00DA', 3, 350, 80);
+        if (typeof options.subTitle === 'string')
+            fillTextWithStroke(
+                context,
+                options.subTitle,
+                '49px Splatfont',
+                '#000000',
+                '#FFD900FB',
+                3,
+                510,
+                80,
+            );
+    });
+    return canvas.toBuffer();
 }
-
-/*
- * ルール情報のキャンバス(2枚目)を作成する
- */
 export async function ruleSalmonCanvas(data: SalmonInfo | null) {
-    const ruleCanvas = Canvas.createCanvas(720, 550);
-    const ruleCtx = ruleCanvas.getContext('2d');
-    const errorWeaponImage = await Canvas.loadImage(placeHold.error100x100);
-
     const datetime = data
         ? formatDatetime(data.startTime, dateformat.mdwhm) +
           ' - ' +
           formatDatetime(data.endTime, dateformat.mdwhm)
         : 'えらー';
-
-    const stage = data ? data.stage : 'えらー';
-    const weapon1Image = data ? await Canvas.loadImage(data.weapon1) : errorWeaponImage;
-    const weapon2Image = data ? await Canvas.loadImage(data.weapon2) : errorWeaponImage;
-    const weapon3Image = data ? await Canvas.loadImage(data.weapon3) : errorWeaponImage;
-    const weapon4Image = data ? await Canvas.loadImage(data.weapon4) : errorWeaponImage;
-
-    createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
-    ruleCtx.fillStyle = '#2F3136';
-    ruleCtx.fill();
-    ruleCtx.strokeStyle = '#FFFFFF';
-    ruleCtx.lineWidth = 4;
-    ruleCtx.stroke();
-
-    fillTextWithStroke(ruleCtx, '日時', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 80);
-
-    const dateWidth = ruleCtx.measureText(datetime).width;
-    fillTextWithStroke(
-        ruleCtx,
-        datetime,
-        '37px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        (650 - dateWidth) / 2,
-        145,
-    );
-
-    fillTextWithStroke(ruleCtx, '武器', '32px Splatfont', '#FFFFFF', '#2D3130', 1, 35, 245);
-
-    ruleCtx.drawImage(weapon1Image, 50, 280, 110, 110);
-    ruleCtx.drawImage(weapon2Image, 190, 280, 110, 110);
-    ruleCtx.drawImage(weapon3Image, 50, 410, 110, 110);
-    ruleCtx.drawImage(weapon4Image, 190, 410, 110, 110);
-
-    fillTextWithStroke(ruleCtx, 'ステージ', '33px Splatfont', '#FFFFFF', '#2D3130', 1, 350, 245);
-
-    const stageWidth = ruleCtx.measureText(stage).width;
-    fillTextWithStroke(
-        ruleCtx,
-        stage,
-        '38px Splatfont',
-        '#FFFFFF',
-        '#2D3130',
-        1,
-        150 + (700 - stageWidth) / 2,
-        300,
-    );
-
-    if (exists(data) && exists(data.stageImage)) {
-        const stageImage = await Canvas.loadImage(data.stageImage);
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 340, 308, 176, 10);
-        ruleCtx.clip();
-        ruleCtx.drawImage(stageImage, 370, 340, 308, 176);
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-    } else {
-        ruleCtx.save();
-        ruleCtx.beginPath();
-        createRoundRect(ruleCtx, 370, 340, 308, 176, 10);
-        ruleCtx.fillStyle = '#000000';
-        ruleCtx.fill();
-        ruleCtx.strokeStyle = '#FFFFFF';
-        ruleCtx.lineWidth = 6.0;
-        ruleCtx.stroke();
-        ruleCtx.restore();
-    }
-
-    createRoundRect(ruleCtx, 1, 1, 718, 548, 30);
-    ruleCtx.clip();
-
-    const buffer = ruleCanvas.toBuffer();
-    return buffer;
+    return drawSalmonRuleCanvas(data, datetime, placeHold.error100x100, RULE_LAYOUT);
 }

--- a/src/app/feat-recruit/create_recruit/anarchy_recruit.ts
+++ b/src/app/feat-recruit/create_recruit/anarchy_recruit.ts
@@ -129,18 +129,16 @@ async function getAnarchyImageBuffers(
     const voiceChannel = recruitData.voiceChannel;
     const voiceChannelName = voiceChannel ? voiceChannel.name : null;
 
-    const recruitBuffer = await recruitAnarchyCanvas(
-        RecruitOpCode.open,
-        recruitData.recruitNum,
-        recruitData.count,
-        recruitData.recruiter,
-        recruitData.attendee1,
-        recruitData.attendee2,
-        recruitData.attendee3,
-        recruitData.condition,
+    const recruitBuffer = await recruitAnarchyCanvas({
+        opCode: RecruitOpCode.open,
+        remaining: recruitData.recruitNum,
+        count: recruitData.count,
+        recruiter: recruitData.recruiter,
+        users: [recruitData.attendee1, recruitData.attendee2, recruitData.attendee3],
+        condition: recruitData.condition,
         rank,
-        voiceChannelName,
-    );
+        channelName: voiceChannelName,
+    });
 
     const ruleIconUrl = rule2image(anarchyData.rule);
     const ruleBuffer = await ruleAnarchyCanvas(anarchyData, ruleIconUrl);

--- a/src/app/feat-recruit/create_recruit/event_recruit.ts
+++ b/src/app/feat-recruit/create_recruit/event_recruit.ts
@@ -110,17 +110,15 @@ async function getEventImageBuffers(
     const voiceChannel = recruitData.voiceChannel;
     const voiceChannelName = voiceChannel ? voiceChannel.name : null;
 
-    const recruitBuffer = await recruitEventCanvas(
-        RecruitOpCode.open,
-        recruitData.recruitNum,
-        recruitData.count,
-        recruitData.recruiter,
-        recruitData.attendee1,
-        recruitData.attendee2,
-        recruitData.attendee3,
-        recruitData.condition,
-        voiceChannelName,
-    );
+    const recruitBuffer = await recruitEventCanvas({
+        opCode: RecruitOpCode.open,
+        remaining: recruitData.recruitNum,
+        count: recruitData.count,
+        recruiter: recruitData.recruiter,
+        users: [recruitData.attendee1, recruitData.attendee2, recruitData.attendee3],
+        condition: recruitData.condition,
+        channelName: voiceChannelName,
+    });
 
     const ruleBuffer = await ruleEventCanvas(eventData);
 

--- a/src/app/feat-recruit/create_recruit/fest_recruit.ts
+++ b/src/app/feat-recruit/create_recruit/fest_recruit.ts
@@ -116,19 +116,17 @@ async function getFestImageBuffers(
     const voiceChannel = recruitData.voiceChannel;
     const voiceChannelName = voiceChannel ? voiceChannel.name : null;
 
-    const recruitBuffer = await recruitFestCanvas(
-        RecruitOpCode.open,
-        recruitData.recruitNum,
-        recruitData.count,
-        recruitData.recruiter,
-        recruitData.attendee1,
-        recruitData.attendee2,
-        recruitData.attendee3,
-        teamRole.name,
-        teamRole.hexColor,
-        recruitData.condition,
-        voiceChannelName,
-    );
+    const recruitBuffer = await recruitFestCanvas({
+        opCode: RecruitOpCode.open,
+        remaining: recruitData.recruitNum,
+        count: recruitData.count,
+        recruiter: recruitData.recruiter,
+        users: [recruitData.attendee1, recruitData.attendee2, recruitData.attendee3],
+        team: teamRole.name,
+        color: teamRole.hexColor,
+        condition: recruitData.condition,
+        channelName: voiceChannelName,
+    });
 
     const ruleBuffer = await ruleFestCanvas(festData);
 

--- a/src/app/feat-recruit/create_recruit/regular_recruit.ts
+++ b/src/app/feat-recruit/create_recruit/regular_recruit.ts
@@ -111,21 +111,23 @@ async function getRegularImageBuffers(
     const voiceChannel = recruitData.voiceChannel;
     const voiceChannelName = voiceChannel ? voiceChannel.name : null;
 
-    const recruitBuffer = await recruitRegularCanvas(
-        RecruitOpCode.open,
-        recruitData.recruitNum,
-        recruitData.count,
-        recruitData.recruiter,
-        recruitData.attendee1,
-        recruitData.attendee2,
-        recruitData.attendee3,
-        null,
-        null,
-        null,
-        null,
-        recruitData.condition,
-        voiceChannelName,
-    );
+    const recruitBuffer = await recruitRegularCanvas({
+        opCode: RecruitOpCode.open,
+        remaining: recruitData.recruitNum,
+        count: recruitData.count,
+        recruiter: recruitData.recruiter,
+        users: [
+            recruitData.attendee1,
+            recruitData.attendee2,
+            recruitData.attendee3,
+            null,
+            null,
+            null,
+            null,
+        ],
+        condition: recruitData.condition,
+        channelName: voiceChannelName,
+    });
 
     const ruleBuffer = await ruleRegularCanvas(regularData);
 

--- a/src/app/feat-recruit/create_recruit/salmon_recruit.ts
+++ b/src/app/feat-recruit/create_recruit/salmon_recruit.ts
@@ -118,44 +118,38 @@ async function getSalmonImageBuffers(
     let recruitBuffer: Buffer;
     let ruleBuffer: Buffer;
     if (recruitType === RecruitType.SalmonRecruit) {
-        recruitBuffer = await recruitSalmonCanvas(
-            RecruitOpCode.open,
-            recruitData.recruitNum,
-            recruitData.count,
-            recruitData.recruiter,
-            recruitData.attendee1,
-            recruitData.attendee2,
-            null,
-            recruitData.condition,
-            voiceChannelName,
-        );
+        recruitBuffer = await recruitSalmonCanvas({
+            opCode: RecruitOpCode.open,
+            remaining: recruitData.recruitNum,
+            count: recruitData.count,
+            recruiter: recruitData.recruiter,
+            users: [recruitData.attendee1, recruitData.attendee2, null],
+            condition: recruitData.condition,
+            channelName: voiceChannelName,
+        });
         ruleBuffer = await ruleSalmonCanvas(await getSalmonData(recruitData.schedule, 0));
     } else if (recruitType === RecruitType.BigRunRecruit) {
-        recruitBuffer = await recruitBigRunCanvas(
-            RecruitOpCode.open,
-            recruitData.recruitNum,
-            recruitData.count,
-            recruitData.recruiter,
-            recruitData.attendee1,
-            recruitData.attendee2,
-            null,
-            recruitData.condition,
-            voiceChannelName,
-        );
+        recruitBuffer = await recruitBigRunCanvas({
+            opCode: RecruitOpCode.open,
+            remaining: recruitData.recruitNum,
+            count: recruitData.count,
+            recruiter: recruitData.recruiter,
+            users: [recruitData.attendee1, recruitData.attendee2, null],
+            condition: recruitData.condition,
+            channelName: voiceChannelName,
+        });
         ruleBuffer = await ruleBigRunCanvas(await getSalmonData(recruitData.schedule, 0));
     } else if (recruitType === RecruitType.TeamContestRecruit) {
-        recruitBuffer = await recruitSalmonCanvas(
-            RecruitOpCode.open,
-            recruitData.recruitNum,
-            recruitData.count,
-            recruitData.recruiter,
-            recruitData.attendee1,
-            recruitData.attendee2,
-            null,
-            recruitData.condition,
-            voiceChannelName,
-            'コンテスト',
-        );
+        recruitBuffer = await recruitSalmonCanvas({
+            opCode: RecruitOpCode.open,
+            remaining: recruitData.recruitNum,
+            count: recruitData.count,
+            recruiter: recruitData.recruiter,
+            users: [recruitData.attendee1, recruitData.attendee2, null],
+            condition: recruitData.condition,
+            channelName: voiceChannelName,
+            subTitle: 'コンテスト',
+        });
         ruleBuffer = await ruleSalmonCanvas(await getTeamContestData(recruitData.schedule, 0));
     } else {
         throw new Error('RecruitType not found');


### PR DESCRIPTION
## 背景

本 PR は、機能を変えない大規模リファクタリング（全 10 PR 構成のスタック PR）のうち PR6 にあたる。募集カード canvas 群は `anarchy` / `big_run` / `event` / `fest` / `regular` / `salmon` などで、背景、アバター、参加者表示、募集情報カード、スタンプ、ルールカードの描画処理が重複していた。

PR4（#789）の安全網と既存 canvas import テストを前提に、描画結果を変えない範囲で共通描画処理を `canvas_base.ts` に集約する。

## このPRで何が嬉しくなるか

- canvas の共通描画処理が 1 箇所にまとまり、募集カードのレイアウトや共通部品を追いやすくなる。
- 各 `xxx_canvas.ts` がタイトル、色、アイコン、固有差分を持つ薄い実装になり、レビュー対象が「何がその募集種別固有か」に絞られる。
- 位置引数の多い canvas 関数が型付きオプションオブジェクトになり、呼び出し側で引数順を取り違えるリスクが下がる。
- 後続 PR9 の `create_recruit` 共通フロー化で、新しい canvas シグネチャを前提にした整理へ進められる。

## 関連PR

- #789 - 本 PR の前提となる安全網テスト追加 PR（PR4）

## 変更内容の概要

- `src/app/feat-recruit/common/canvases/canvas_base.ts` を追加し、フォント登録、下地描画、アバター描画、参加者ループ描画、共通定数、募集情報カード、スタンプ、ルールカード描画を集約。
- `anarchy_canvas.ts` / `big_run_canvas.ts` / `event_canvas.ts` / `fest_canvas.ts` / `regular_canvas.ts` / `salmon_canvas.ts` を薄い実装へ整理。
- canvas 関数の位置引数を単一のオプションオブジェクトへ変更し、`create_recruit/*.ts`、再描画経路、ボタン経路など全呼び出し元を追随修正。
- `regenerate_canvas.ts` の `RecruitOpCode` エクスポートは維持。
- `raiders_canvas.ts` は対象外だが、共通シグネチャ変更に必要な最小限の追随のみ実施。

## 動作検証

### Local（確認項目）

- [ ] `mise exec -- pnpm run compile` が成功することを確認
- [ ] `mise exec -- pnpm run lint` が成功することを確認
- [ ] `mise exec -- pnpm test` が成功することを確認
- [ ] 全呼び出し元が新しいオプションオブジェクト形式に追随していることを確認

## 備考

- 機能変更ではなく、描画処理の構造整理が目的。
- 座標・色・フォント指定は既存値を移設する方針で、描画仕様を変えない。
- Wave 1 の並列 PR のため、スタック上では PR4（#789）以降に積まれる想定。
