### PR TITLE
Refactor: DB層の定型エラー処理を集約

### DIFF
--- a/src/db/channel_service.ts
+++ b/src/db/channel_service.ts
@@ -1,7 +1,7 @@
 import { ChannelType } from 'discord.js';
 
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 
 const logger = log4js_obj.getLogger('database');
@@ -15,7 +15,7 @@ export class ChannelService {
         position: number,
         parentId?: string | null,
     ) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.channel.upsert({
                 where: {
                     guildId_channelId: {
@@ -41,14 +41,11 @@ export class ChannelService {
                     isAdminChannel: false,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async setVCToolsEnabled(guildId: string, channelId: string, isVCToolsEnabled = true) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.channel.update({
                 where: {
                     guildId_channelId: {
@@ -60,14 +57,11 @@ export class ChannelService {
                     isVCToolsEnabled: isVCToolsEnabled,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async setAdminChannel(guildId: string, channelId: string, isAdminChannel = true) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.channel.update({
                 where: {
                     guildId_channelId: {
@@ -79,14 +73,11 @@ export class ChannelService {
                     isAdminChannel: isAdminChannel,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async delete(guildId: string, channelId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.channel.delete({
                 where: {
                     guildId_channelId: {
@@ -95,14 +86,11 @@ export class ChannelService {
                     },
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getChannel(guildId: string, channelId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.channel.findUnique({
                 where: {
                     guildId_channelId: {
@@ -111,45 +99,33 @@ export class ChannelService {
                     },
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getChannelsByCategoryId(guildId: string, categoryId: string) {
-        try {
+        return dbCall(logger, [], async () => {
             return await prisma.channel.findMany({
                 where: {
                     guildId: guildId,
                     parentId: categoryId,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 
     static async getAllGuildChannels(guildId: string) {
-        try {
+        return dbCall(logger, [], async () => {
             return await prisma.channel.findMany({
                 where: {
                     guildId: guildId,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 
     static async getAllChannels() {
-        try {
+        return dbCall(logger, [], async () => {
             return await prisma.channel.findMany();
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 }

--- a/src/db/db_call.ts
+++ b/src/db/db_call.ts
@@ -1,0 +1,12 @@
+import { sendErrorLogs } from '../app/logs/error/send_error_logs.js';
+
+import type { Logger } from 'log4js';
+
+export async function dbCall<T>(logger: Logger, fallback: T, fn: () => Promise<T>): Promise<T> {
+    try {
+        return await fn();
+    } catch (error) {
+        await sendErrorLogs(logger, error);
+        return fallback;
+    }
+}

--- a/src/db/friend_code_service.ts
+++ b/src/db/friend_code_service.ts
@@ -1,12 +1,12 @@
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 
 const logger = log4js_obj.getLogger('database');
 
 export class FriendCodeService {
     static async save(userId: string, code: string, url: string | null) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.friendCode.upsert({
                 where: {
                     userId: userId,
@@ -21,13 +21,11 @@ export class FriendCodeService {
                     url: url,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async getFriendCodeObjByUserId(userId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             const friendCode = await prisma.friendCode.findUnique({
                 where: {
                     userId: userId,
@@ -35,9 +33,6 @@ export class FriendCodeService {
             });
 
             return friendCode;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 }

--- a/src/db/member_service.ts
+++ b/src/db/member_service.ts
@@ -1,11 +1,11 @@
 import { Member } from '@prisma/client';
 import { GuildMember } from 'discord.js';
 
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
 import { UniqueRoleService } from './unique_role_service';
 import { exists } from '../app/common/others';
 import { RoleKeySet } from '../app/constant/role_key';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { modalRecruit } from '../constant';
 import { log4js_obj } from '../log4js_settings';
 const logger = log4js_obj.getLogger('database');
@@ -29,7 +29,7 @@ export class MemberService {
         joinedAt: Date,
         isRookie: boolean,
     ): Promise<Member | null> {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.member.upsert({
                 where: {
                     guildId_userId: {
@@ -52,10 +52,7 @@ export class MemberService {
                     isRookie: isRookie,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     /**
@@ -68,7 +65,7 @@ export class MemberService {
         member: GuildMember,
         isRookie?: boolean,
     ): Promise<Member | null> {
-        try {
+        return dbCall(logger, null, async () => {
             const iconUrl = member
                 .displayAvatarURL()
                 .replace('.webp', '.png')
@@ -117,10 +114,7 @@ export class MemberService {
                     isRookie: hasRookieRole,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async updateJoinedAt(
@@ -128,7 +122,7 @@ export class MemberService {
         userId: string,
         joinedAt: Date,
     ): Promise<Member | null> {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.member.update({
                 where: {
                     guildId_userId: {
@@ -140,10 +134,7 @@ export class MemberService {
                     joinedAt: joinedAt,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async setRookieFlag(
@@ -151,7 +142,7 @@ export class MemberService {
         userId: string,
         isRookie: boolean,
     ): Promise<Member | null> {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.member.update({
                 where: {
                     guildId_userId: {
@@ -163,14 +154,11 @@ export class MemberService {
                     isRookie: isRookie,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getMemberByUserId(guildId: string, userId: string): Promise<Member | null> {
-        try {
+        return dbCall(logger, null, async () => {
             const member = await prisma.member.findUnique({
                 where: {
                     guildId_userId: {
@@ -181,14 +169,11 @@ export class MemberService {
             });
 
             return member;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getMemberGuildIdsByUserId(userId: string): Promise<string[]> {
-        try {
+        return dbCall(logger, [], async () => {
             const members = await prisma.member.findMany({
                 where: {
                     userId: userId,
@@ -199,15 +184,12 @@ export class MemberService {
                 guildIds.push(member.guildId);
             }
             return guildIds;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 
     // ダミーを作らないとModalでエラーが出るため
     static async createDummyUser(guildId: string) {
-        try {
+        return dbCall(logger, undefined, async () => {
             // 既存のメンバーを検索します
             const members = await prisma.member.findMany({
                 where: {
@@ -263,8 +245,6 @@ export class MemberService {
                     logger.info(`dummy user created: ${user.userId}`);
                 }
             }
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 }

--- a/src/db/message_count_service.ts
+++ b/src/db/message_count_service.ts
@@ -1,11 +1,11 @@
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 const logger = log4js_obj.getLogger('database');
 
 export class MessageCountService {
     static async save(userId: string, count: number) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.messageCount.upsert({
                 where: {
                     userId: userId,
@@ -18,22 +18,17 @@ export class MessageCountService {
                     count: count,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async getMemberByUserId(userId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             const member = await prisma.messageCount.findUnique({
                 where: {
                     userId: userId,
                 },
             });
             return member;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 }

--- a/src/db/participant_service.ts
+++ b/src/db/participant_service.ts
@@ -1,8 +1,8 @@
 import { Member } from '@prisma/client';
 
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma.js';
 import { RecruitService } from './recruit_service.js';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs.js';
 import { log4js_obj } from '../log4js_settings.js';
 const logger = log4js_obj.getLogger('database');
 
@@ -20,7 +20,7 @@ export class ParticipantService {
         userType: number,
         joinedAt: Date,
     ) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.participant.upsert({
                 where: {
                     guildId_messageId_userId: {
@@ -41,9 +41,7 @@ export class ParticipantService {
                     joinedAt: joinedAt,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async registerParticipantFromMember(
@@ -52,7 +50,7 @@ export class ParticipantService {
         member: Member,
         userType: number,
     ) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.participant.upsert({
                 where: {
                     guildId_messageId_userId: {
@@ -71,13 +69,11 @@ export class ParticipantService {
                     userType: userType,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async deleteParticipant(guildId: string, messageId: string, userId: string) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.participant.delete({
                 where: {
                     guildId_messageId_userId: {
@@ -87,26 +83,22 @@ export class ParticipantService {
                     },
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async deleteAllParticipant(guildId: string, messageId: string) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.participant.deleteMany({
                 where: {
                     guildId: guildId,
                     messageId: messageId,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async deleteUnuseParticipant() {
-        try {
+        return dbCall(logger, undefined, async () => {
             const messageIdList = await RecruitService.getAllMessageId();
 
             await prisma.participant.deleteMany({
@@ -116,9 +108,7 @@ export class ParticipantService {
                     },
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async getParticipant(
@@ -126,7 +116,7 @@ export class ParticipantService {
         messageId: string,
         userId: string,
     ): Promise<ParticipantMember | null> {
-        try {
+        return dbCall(logger, null, async () => {
             const participant = await prisma.participant.findUnique({
                 where: {
                     guildId_messageId_userId: {
@@ -143,17 +133,14 @@ export class ParticipantService {
                 },
             });
             return participant;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getAllParticipants(
         guildId: string,
         messageId: string,
     ): Promise<ParticipantMember[]> {
-        try {
+        return dbCall(logger, [], async () => {
             const participants = await prisma.participant.findMany({
                 where: {
                     guildId: guildId,
@@ -176,9 +163,6 @@ export class ParticipantService {
             });
 
             return participants;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 }

--- a/src/db/reaction_service.ts
+++ b/src/db/reaction_service.ts
@@ -1,11 +1,11 @@
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 const logger = log4js_obj.getLogger('database');
 
 export class ReactionService {
     static async save(emojiId: string, emojiName: string, count: number) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.reaction.upsert({
                 where: {
                     emojiId_emojiName: {
@@ -22,13 +22,11 @@ export class ReactionService {
                     count: count,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async update(reactionSeq: number, count: number) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.reaction.update({
                 where: {
                     reactionSeq: reactionSeq,
@@ -37,13 +35,11 @@ export class ReactionService {
                     count: count,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async getTotalReactionByEmoji(emojiId: string, emojiName: string) {
-        try {
+        return dbCall(logger, null, async () => {
             const result = await prisma.reaction.findUnique({
                 where: {
                     emojiId_emojiName: {
@@ -53,9 +49,6 @@ export class ReactionService {
                 },
             });
             return result;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 }

--- a/src/db/recruit_count_service.ts
+++ b/src/db/recruit_count_service.ts
@@ -1,11 +1,11 @@
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 const logger = log4js_obj.getLogger('database');
 
 export class RecruitCountService {
     static async saveRecruitCount(userId: string, count: number) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.recruitCount.upsert({
                 where: {
                     userId: userId,
@@ -19,13 +19,11 @@ export class RecruitCountService {
                     joinCount: 0,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async saveJoinCount(userId: string, count: number) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.recruitCount.upsert({
                 where: {
                     userId: userId,
@@ -39,22 +37,17 @@ export class RecruitCountService {
                     joinCount: count,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async getCountByUserId(userId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             const counter = await prisma.recruitCount.findUnique({
                 where: {
                     userId: userId,
                 },
             });
             return counter;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 }

--- a/src/db/recruit_service.ts
+++ b/src/db/recruit_service.ts
@@ -1,6 +1,6 @@
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma.js';
 import { ObjectValueList } from '../app/constant/constant_common.js';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs.js';
 import { log4js_obj } from '../log4js_settings';
 const logger = log4js_obj.getLogger('database');
 
@@ -35,7 +35,7 @@ export class RecruitService {
         recruitType: number,
         option?: string | null,
     ) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.recruit.create({
                 data: {
                     guildId: guildId,
@@ -50,13 +50,11 @@ export class RecruitService {
                     option: option,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async deleteRecruit(guildId: string, messageId: string) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.recruit.delete({
                 where: {
                     guildId_messageId: {
@@ -65,13 +63,11 @@ export class RecruitService {
                     },
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async updateRecruitNum(guildId: string, messageId: string, recruitNum: number) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.recruit.update({
                 where: {
                     guildId_messageId: {
@@ -83,13 +79,11 @@ export class RecruitService {
                     recruitNum: recruitNum,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async updateCondition(guildId: string, messageId: string, condition: string) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.recruit.update({
                 where: {
                     guildId_messageId: {
@@ -101,13 +95,11 @@ export class RecruitService {
                     condition: condition,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async getRecruit(guildId: string, messageId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             const recruit = await prisma.recruit.findUnique({
                 where: {
                     guildId_messageId: {
@@ -117,14 +109,11 @@ export class RecruitService {
                 },
             });
             return recruit;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getRecruitByEventId(guildId: string, eventId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             const recruit = await prisma.recruit.findFirst({
                 where: {
                     guildId: guildId,
@@ -132,14 +121,11 @@ export class RecruitService {
                 },
             });
             return recruit;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getRecruitsByRecruitType(guildId: string, recruitType: number) {
-        try {
+        return dbCall(logger, [], async () => {
             const recruits = await prisma.recruit.findMany({
                 where: {
                     guildId: guildId,
@@ -147,14 +133,11 @@ export class RecruitService {
                 },
             });
             return recruits;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 
     static async getRecruitsByChannelId(guildId: string, channelId: string) {
-        try {
+        return dbCall(logger, [], async () => {
             const recruits = await prisma.recruit.findMany({
                 where: {
                     guildId: guildId,
@@ -162,14 +145,11 @@ export class RecruitService {
                 },
             });
             return recruits;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 
     static async getAllMessageId() {
-        try {
+        return dbCall(logger, [], async () => {
             const recruits = await prisma.recruit.findMany({
                 select: {
                     messageId: true,
@@ -182,9 +162,6 @@ export class RecruitService {
             });
 
             return result;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 }

--- a/src/db/role_service.ts
+++ b/src/db/role_service.ts
@@ -1,7 +1,7 @@
 import { ColorResolvable } from 'discord.js';
 
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 
 const logger = log4js_obj.getLogger('database');
@@ -15,7 +15,7 @@ export class RoleService {
         color: ColorResolvable,
         position: number,
     ) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.role.upsert({
                 where: {
                     guildId_roleId: {
@@ -40,14 +40,11 @@ export class RoleService {
                     position: position,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async delete(guildId: string, roleId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.role.delete({
                 where: {
                     guildId_roleId: {
@@ -56,14 +53,11 @@ export class RoleService {
                     },
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getRole(guildId: string, roleId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.role.findUnique({
                 where: {
                     guildId_roleId: {
@@ -72,45 +66,33 @@ export class RoleService {
                     },
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async searchRole(guildId: string, roleName: string) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.role.findFirst({
                 where: {
                     guildId: guildId,
                     name: roleName,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getAllGuildRoles(guildId: string) {
-        try {
+        return dbCall(logger, [], async () => {
             return await prisma.role.findMany({
                 where: {
                     guildId: guildId,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 
     static async getAllRoles() {
-        try {
+        return dbCall(logger, [], async () => {
             return await prisma.role.findMany();
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 }

--- a/src/db/sticky_service.ts
+++ b/src/db/sticky_service.ts
@@ -1,5 +1,5 @@
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 const logger = log4js_obj.getLogger('database');
 
@@ -10,7 +10,7 @@ export class StickyService {
         key: string,
         messageId: string,
     ) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.sticky.upsert({
                 where: {
                     guildId_channelId_key: {
@@ -29,13 +29,11 @@ export class StickyService {
                     messageId: messageId,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async getMessageId(guildId: string, channelId: string, key: string) {
-        try {
+        return dbCall(logger, null, async () => {
             const sticky = await prisma.sticky.findUnique({
                 where: {
                     guildId_channelId_key: {
@@ -50,9 +48,6 @@ export class StickyService {
             } else {
                 return null;
             }
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 }

--- a/src/db/team_divider_service.ts
+++ b/src/db/team_divider_service.ts
@@ -1,7 +1,7 @@
 import { TeamDivider } from '@prisma/client';
 
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 const logger = log4js_obj.getLogger('database');
 
@@ -33,7 +33,7 @@ export class TeamDividerService {
         forceSpectate: boolean,
         hideWin: boolean,
     ) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.teamDivider.upsert({
                 where: {
                     messageId_memberId_matchNum: {
@@ -62,22 +62,18 @@ export class TeamDividerService {
                     hideWin: hideWin,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async deleteMemberFromDB(messageId: string, memberId: string) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.teamDivider.deleteMany({
                 where: {
                     messageId: messageId,
                     memberId: memberId,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     /**
@@ -86,7 +82,7 @@ export class TeamDividerService {
      * @returns 表示用メッセージ
      */
     static async registeredMembersStrings(messageId: string) {
-        try {
+        return dbCall(logger, { text: '', memberCount: 0 }, async () => {
             const members = await prisma.teamDivider.findMany({
                 where: {
                     messageId: messageId,
@@ -102,10 +98,7 @@ export class TeamDividerService {
                 usersString = usersString + `\n${member.memberName}`;
             }
             return { text: usersString, memberCount: members.length };
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return { text: '', memberCount: 0 };
-        }
+        });
     }
 
     /**
@@ -116,7 +109,7 @@ export class TeamDividerService {
      * @returns 取得結果
      */
     static async selectMemberFromDB(messageId: string, matchNum: number, memberId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             const member = await prisma.teamDivider.findUnique({
                 where: {
                     messageId_memberId_matchNum: {
@@ -127,10 +120,7 @@ export class TeamDividerService {
                 },
             });
             return member;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     /**
@@ -140,7 +130,7 @@ export class TeamDividerService {
      * @returns 取得結果
      */
     static async selectAllMemberFromDB(messageId: string, matchNum: number) {
-        try {
+        return dbCall(logger, [], async () => {
             const members = await prisma.teamDivider.findMany({
                 where: {
                     messageId: messageId,
@@ -148,10 +138,7 @@ export class TeamDividerService {
                 },
             });
             return members;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 
     /**
@@ -159,15 +146,13 @@ export class TeamDividerService {
      * @param messageId 登録メッセージID
      */
     static async deleteAllMemberFromDB(messageId: string) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.teamDivider.deleteMany({
                 where: {
                     messageId: messageId,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     /**
@@ -178,7 +163,7 @@ export class TeamDividerService {
      * @param team 該当チーム(alfa=0, bravo=1, 観戦=2)
      */
     static async setTeam(messageId: string, memberId: string, matchNum: number, team: number) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.teamDivider.updateMany({
                 where: {
                     messageId: messageId,
@@ -189,9 +174,7 @@ export class TeamDividerService {
                     team: team,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     /**
@@ -202,7 +185,7 @@ export class TeamDividerService {
      * @param count 試合参加回数
      */
     static async setCount(messageId: string, memberId: string, matchNum: number, count: number) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.teamDivider.updateMany({
                 where: {
                     messageId: messageId,
@@ -213,9 +196,7 @@ export class TeamDividerService {
                     joinedMatchCount: count,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     /**
@@ -226,7 +207,7 @@ export class TeamDividerService {
      * @param winCount 勝利数
      */
     static async setWin(messageId: string, memberId: string, matchNum: number, winCount: number) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.teamDivider.updateMany({
                 where: {
                     messageId: messageId,
@@ -237,9 +218,7 @@ export class TeamDividerService {
                     win: winCount,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     /**
@@ -248,7 +227,7 @@ export class TeamDividerService {
      * @param flag true=隠す or false=表示
      */
     static async setHideWin(messageId: string, flag: boolean) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.teamDivider.updateMany({
                 where: {
                     messageId: messageId,
@@ -257,9 +236,7 @@ export class TeamDividerService {
                     hideWin: flag,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     /**
@@ -275,7 +252,7 @@ export class TeamDividerService {
         matchNum: number,
         flag: boolean,
     ) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.teamDivider.updateMany({
                 where: {
                     messageId: messageId,
@@ -286,9 +263,7 @@ export class TeamDividerService {
                     forceSpectate: flag,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     /**
@@ -304,7 +279,7 @@ export class TeamDividerService {
         team: number,
     ): Promise<TeamMember[]> {
         let members: TeamDivider[] = [];
-        try {
+        await dbCall(logger, undefined, async () => {
             members = await prisma.teamDivider.findMany({
                 where: {
                     messageId: messageId,
@@ -312,9 +287,7 @@ export class TeamDividerService {
                     team: team,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
 
         const result = members.map((member) => {
             let winRate = 0;
@@ -347,7 +320,7 @@ export class TeamDividerService {
      */
     static async getForceSpectate(messageId: string, matchNum: number): Promise<TeamMember[]> {
         let members: TeamDivider[] = [];
-        try {
+        await dbCall(logger, undefined, async () => {
             members = await prisma.teamDivider.findMany({
                 where: {
                     messageId: messageId,
@@ -355,9 +328,7 @@ export class TeamDividerService {
                     forceSpectate: true,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
 
         const result = members.map((member) => {
             let winRate = 0;
@@ -395,7 +366,7 @@ export class TeamDividerService {
         teamNum: number,
     ): Promise<TeamMember[]> {
         let members: TeamDivider[] = [];
-        try {
+        await dbCall(logger, undefined, async () => {
             members = await prisma.teamDivider.findMany({
                 where: {
                     messageId: messageId,
@@ -407,9 +378,7 @@ export class TeamDividerService {
                 },
                 take: teamNum * 2,
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
 
         const result = members.map((member) => {
             let winRate = 0;
@@ -440,15 +409,13 @@ export class TeamDividerService {
      * @param matchNum 該当試合数
      */
     static async deleteMatchingResult(messageId: string, matchNum: number) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.teamDivider.deleteMany({
                 where: {
                     messageId: messageId,
                     matchNum: matchNum,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 }

--- a/src/db/unique_channel_service.ts
+++ b/src/db/unique_channel_service.ts
@@ -1,14 +1,14 @@
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
 import { notExists } from '../app/common/others';
 import { ChannelKey, isChannelKey } from '../app/constant/channel_key';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 
 const logger = log4js_obj.getLogger('database');
 
 export class UniqueChannelService {
     static async save(guildId: string, key: ChannelKey, channelId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.uniqueChannel.upsert({
                 where: {
                     guildId_key: {
@@ -25,14 +25,11 @@ export class UniqueChannelService {
                     key: key,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getChannelIdByKey(guildId: string, key: ChannelKey) {
-        try {
+        return dbCall(logger, null, async () => {
             const result = await prisma.uniqueChannel.findUnique({
                 where: {
                     guildId_key: {
@@ -43,14 +40,11 @@ export class UniqueChannelService {
             });
             if (notExists(result)) return null;
             return result.channelId;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getAllUniqueChannels(guildId: string) {
-        try {
+        return dbCall(logger, [], async () => {
             const results = await prisma.uniqueChannel.findMany({
                 where: {
                     guildId: guildId,
@@ -74,14 +68,11 @@ export class UniqueChannelService {
             }
 
             return filteredResults;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 
     static async delete(guildId: string, key: ChannelKey) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.uniqueChannel.delete({
                 where: {
                     guildId_key: {
@@ -90,9 +81,6 @@ export class UniqueChannelService {
                     },
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 }

--- a/src/db/unique_role_service.ts
+++ b/src/db/unique_role_service.ts
@@ -1,14 +1,14 @@
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
 import { notExists } from '../app/common/others';
 import { RoleKey, isRoleKey } from '../app/constant/role_key';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 
 const logger = log4js_obj.getLogger('database');
 
 export class UniqueRoleService {
     static async save(guildId: string, key: RoleKey, roleId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.uniqueRole.upsert({
                 where: {
                     guildId_key: {
@@ -25,14 +25,11 @@ export class UniqueRoleService {
                     key: key,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getRoleIdByKey(guildId: string, key: RoleKey) {
-        try {
+        return dbCall(logger, null, async () => {
             const result = await prisma.uniqueRole.findUnique({
                 where: {
                     guildId_key: {
@@ -43,14 +40,11 @@ export class UniqueRoleService {
             });
             if (notExists(result)) return null;
             return result.roleId;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getAllUniqueRoles(guildId: string) {
-        try {
+        return dbCall(logger, [], async () => {
             const results = await prisma.uniqueRole.findMany({
                 where: {
                     guildId: guildId,
@@ -74,14 +68,11 @@ export class UniqueRoleService {
             }
 
             return filteredResults;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 
     static async delete(guildId: string, key: RoleKey) {
-        try {
+        return dbCall(logger, null, async () => {
             return await prisma.uniqueRole.delete({
                 where: {
                     guildId_key: {
@@ -90,9 +81,6 @@ export class UniqueRoleService {
                     },
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 }

--- a/src/db/user_reaction_service.ts
+++ b/src/db/user_reaction_service.ts
@@ -1,5 +1,5 @@
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 const logger = log4js_obj.getLogger('database');
 
@@ -11,7 +11,7 @@ export class UserReactionService {
         year: string,
         count: number,
     ) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.userReaction.upsert({
                 where: {
                     userId_reactionSeq_year_channelId: {
@@ -32,9 +32,7 @@ export class UserReactionService {
                     count: count,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async getReactionCountByPK(
@@ -43,7 +41,7 @@ export class UserReactionService {
         channelId: string,
         year: string,
     ) {
-        try {
+        return dbCall(logger, null, async () => {
             const result = await prisma.userReaction.findUnique({
                 where: {
                     userId_reactionSeq_year_channelId: {
@@ -55,37 +53,28 @@ export class UserReactionService {
                 },
             });
             return result;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getReactionCountByUserId(userId: string) {
-        try {
+        return dbCall(logger, [], async () => {
             const result = await prisma.userReaction.findMany({
                 where: {
                     userId: userId,
                 },
             });
             return result;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 
     static async getReactionCountByReactionSeq(reactionSeq: number) {
-        try {
+        return dbCall(logger, [], async () => {
             const result = await prisma.userReaction.findMany({
                 where: {
                     reactionSeq: reactionSeq,
                 },
             });
             return result;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 }

--- a/src/db/voice_count_service.ts
+++ b/src/db/voice_count_service.ts
@@ -1,11 +1,11 @@
+import { dbCall } from './db_call.js';
 import { prisma } from './prisma';
-import { sendErrorLogs } from '../app/logs/error/send_error_logs';
 import { log4js_obj } from '../log4js_settings';
 const logger = log4js_obj.getLogger('database');
 
 export class VoiceCountService {
     static async saveVoiceCount(userId: string, totalSec: number) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.voiceCount.upsert({
                 where: {
                     userId: userId,
@@ -18,13 +18,11 @@ export class VoiceCountService {
                     totalSec: totalSec,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async saveStartTime(userId: string, startTime: Date | null) {
-        try {
+        return dbCall(logger, undefined, async () => {
             await prisma.voiceCount.upsert({
                 where: {
                     userId: userId,
@@ -38,27 +36,22 @@ export class VoiceCountService {
                     totalSec: 0,
                 },
             });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        });
     }
 
     static async getCountByUserId(userId: string) {
-        try {
+        return dbCall(logger, null, async () => {
             const counter = await prisma.voiceCount.findUnique({
                 where: {
                     userId: userId,
                 },
             });
             return counter;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        });
     }
 
     static async getInCallCount() {
-        try {
+        return dbCall(logger, [], async () => {
             const counter = await prisma.voiceCount.findMany({
                 where: {
                     startTime: {
@@ -67,9 +60,6 @@ export class VoiceCountService {
                 },
             });
             return counter;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        });
     }
 }


### PR DESCRIPTION
## 背景

本 PR は、機能を変えない大規模リファクタリング（全 10 PR 構成のスタック PR）のうち PR7 にあたる。`src/db/` 配下の各サービスは、Prisma 呼び出しを `try/catch` で包み、例外時に `sendErrorLogs` して `null` / `[]` / `undefined` などの fallback を返す定型処理を多数持っていた。

PR4（#789）で追加した DB 層テストを安全網として、呼び出し元の構文とエラー時の戻り値を変えずに定型処理を `dbCall` へ集約する。

## このPRで何が嬉しくなるか

- DB サービス層の例外処理パターンが `dbCall` にまとまり、各メソッドでは本来の Prisma 操作だけを読みやすくなる。
- エラー時のログ送信と fallback 返却の規約が 1 箇所に集まり、今後のサービス追加・修正時に挙動を揃えやすい。
- static class からメソッド持ちオブジェクトへ整理しつつ、`RecruitService.getRecruit(...)` のような呼び出し元の構文は維持される。
- PR4 の DB 層テストが無修正で通ることで、成功時・例外時の既存挙動を維持できていることを確認できる。

## 関連PR

- #789 - 本 PR の前提となる安全網テスト追加 PR（PR4）

## 変更内容の概要

- `src/db/db_call.ts` を追加し、`dbCall<T>(logger, fallback, fn): Promise<T>` を定義。
- `src/db/` 配下のサービスメソッドから定型 `try/catch` を削除し、`dbCall` 経由へ置換。
- `channel_service` / `member_service` / `recruit_service` / `unique_channel_service` / `unique_role_service` など、既存サービスの公開メソッド名・引数・戻り値型を維持。
- 例外時の fallback（`null` / `[]` / `undefined`）を既存と同じ値に維持。
- `RecruitType` など、サービスファイル内に同居している定数・型ガードは維持。

## 動作検証

### Local（確認項目）

- [ ] `mise exec -- pnpm run compile` が成功することを確認
- [ ] `mise exec -- pnpm run lint` が成功することを確認
- [ ] `mise exec -- pnpm test` が成功することを確認
- [ ] PR4 の DB 層テストが無修正で通ることを確認

## 備考

- 呼び出し元は変更していない。
- 機能変更ではなく、DB サービス層の定型エラー処理の集約が目的。
- Wave 1 の並列 PR のため、スタック上では PR4（#789）以降に積まれる想定。
