### PR TITLE
PR9: create_recruit スケルトンの共通化

### DIFF
--- a/src/app/feat-recruit/create_recruit/anarchy_recruit.ts
+++ b/src/app/feat-recruit/create_recruit/anarchy_recruit.ts
@@ -3,13 +3,12 @@ import { ChatInputCommandInteraction, ModalSubmitInteraction } from 'discord.js'
 import { getAnarchyOpenData, MatchInfo } from '@/app/common/apis/splatoon3.ink/splatoon3_ink';
 import {
     assertExistCheck,
-    sleep,
-    rule2image,
-    notExists,
-    getDeveloperMention,
     exists,
+    getDeveloperMention,
+    notExists,
+    rule2image,
 } from '@/app/common/others';
-import { RoleKeySet, isRoleKey, getUniqueRoleNameByKey } from '@/app/constant/role_key';
+import { getUniqueRoleNameByKey, isRoleKey, RoleKeySet } from '@/app/constant/role_key';
 import { sendErrorLogs } from '@/app/logs/error/send_error_logs';
 import { RecruitType } from '@/db/recruit_service';
 import { UniqueRoleService } from '@/db/unique_role_service';
@@ -17,114 +16,88 @@ import { log4js_obj } from '@/log4js_settings';
 
 import { arrangeCommandRecruitData } from './common/arrange_command_data';
 import { arrangeModalRecruitData } from './common/arrange_modal_data';
-import { registerRecruitData } from './common/register_recruit_data';
-import { removeDeleteButton } from './common/remove_delete_button';
-import { sendRecruitCanvas, RecruitImageBuffers } from './common/send_recruit_message';
-import { recruitAutoClose } from '../close_recruit/auto_close';
+import {
+    executeRecruitFlow,
+    RecruitArrangement,
+    RecruitFlowContext,
+    RecruitInteraction,
+} from './common/recruit_flow';
+import { RecruitImageBuffers } from './common/send_recruit_message';
 import { recruitAnarchyCanvas, ruleAnarchyCanvas } from '../common/canvases/anarchy_canvas';
 import { RecruitOpCode } from '../common/canvases/regenerate_canvas';
 import { RecruitData } from '../common/types/recruit_data';
-import { sendRecruitSticky } from '../sticky/recruit_sticky_messages';
-import { createRecruitEvent } from '../vc_reservation/recruit_event';
 
 const logger = log4js_obj.getLogger('recruit');
+const recruitName = 'バンカラ募集';
 
-export async function anarchyRecruit(
-    interaction: ChatInputCommandInteraction<'cached'> | ModalSubmitInteraction<'cached' | 'raw'>,
-) {
-    assertExistCheck(interaction.channel, 'channel');
-    // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({});
+type AnarchyContext = RecruitFlowContext & { rank: string };
 
-    const recruitName = 'バンカラ募集';
+export async function anarchyRecruit(interaction: RecruitInteraction) {
+    await executeRecruitFlow<MatchInfo, AnarchyContext>(interaction, {
+        resolveArrangement,
+        getMatchData: async (recruitData) => {
+            const anarchyData = await getAnarchyOpenData(
+                recruitData.schedule,
+                recruitData.scheduleNum,
+            );
+            assertExistCheck(anarchyData, 'anarchyOpenData');
+            return anarchyData;
+        },
+        getImageBuffers,
+        getEventTiming: (recruitData, anarchyData) => ({
+            title: `バンカラマッチ - ${recruitData.recruiter.displayName}`,
+            startTime: anarchyData.startTime,
+            endTime: anarchyData.endTime,
+        }),
+        getRegisterOption: (recruitData, anarchyData, context) => context.rank,
+        autoClose: true,
+    });
+}
+
+async function resolveArrangement(
+    interaction: RecruitInteraction,
+): Promise<RecruitArrangement<AnarchyContext> | null> {
     const recruitType = RecruitType.AnarchyRecruit;
     let recruitData: RecruitData;
-    let recruitRoleId: string | null;
-    let rank: string;
+    let context: AnarchyContext;
 
     if (interaction.isChatInputCommand()) {
         const recruitRankRole = await getAnarchyRecruitRole(interaction);
-        recruitRoleId = recruitRankRole.recruitRoleId;
-        rank = recruitRankRole.rank;
+        context = {
+            recruitType,
+            recruitRoleId: recruitRankRole.recruitRoleId,
+            rank: recruitRankRole.rank,
+        };
 
         try {
             recruitData = await arrangeCommandRecruitData(interaction, recruitName, recruitType);
         } catch (error) {
-            return;
+            return null;
         }
     } else if (interaction.isModalSubmit()) {
         const recruitRankRole = await getAnarchyRecruitRoleFromModal(interaction);
-        recruitRoleId = recruitRankRole.recruitRoleId;
-        rank = recruitRankRole.rank;
+        context = {
+            recruitType,
+            recruitRoleId: recruitRankRole.recruitRoleId,
+            rank: recruitRankRole.rank,
+        };
 
         try {
             recruitData = await arrangeModalRecruitData(interaction, recruitName, recruitType);
         } catch (error) {
-            return;
+            return null;
         }
     } else {
         throw new Error('interaction type is invalid');
     }
 
-    const anarchyData = await getAnarchyOpenData(recruitData.schedule, recruitData.scheduleNum);
-    assertExistCheck(anarchyData, 'anarchyOpenData');
-
-    const anarchyBuffers = await getAnarchyImageBuffers(recruitData, anarchyData, rank);
-
-    const recruitMessageList = await sendRecruitCanvas(
-        interaction,
-        recruitRoleId,
-        recruitData,
-        anarchyBuffers,
-    );
-
-    let eventId: string | null = null;
-    if (exists(recruitData.voiceChannel)) {
-        eventId = (
-            await createRecruitEvent(
-                recruitData.guild,
-                `バンカラマッチ - ${recruitData.recruiter.displayName}`,
-                recruitData.recruiter.userId,
-                recruitData.voiceChannel,
-                anarchyBuffers.ruleBuffer,
-                anarchyData.startTime,
-                anarchyData.endTime,
-            )
-        ).id;
-    }
-
-    await registerRecruitData(
-        recruitMessageList.recruitMessage.id,
-        recruitType,
-        recruitData,
-        eventId,
-        rank,
-    );
-
-    // 募集リスト更新
-    await sendRecruitSticky({
-        channelOpt: { guild: recruitData.guild, channelId: recruitData.recruitChannel.id },
-    });
-
-    // 15秒後に削除ボタンを消す
-    await sleep(15);
-
-    await removeDeleteButton(recruitData, recruitMessageList.deleteButtonMessage.id);
-
-    // 2時間後にボタンを無効化する
-    await sleep(7200 - 15);
-
-    await recruitAutoClose(
-        recruitData,
-        recruitMessageList.recruitMessage.id,
-        recruitMessageList.buttonMessage,
-    );
+    return { recruitData, context };
 }
 
-async function getAnarchyImageBuffers(
+async function getImageBuffers(
     recruitData: RecruitData,
     anarchyData: MatchInfo,
-    rank: string,
+    context: AnarchyContext,
 ): Promise<RecruitImageBuffers> {
     const voiceChannel = recruitData.voiceChannel;
     const voiceChannelName = voiceChannel ? voiceChannel.name : null;
@@ -136,7 +109,7 @@ async function getAnarchyImageBuffers(
         recruiter: recruitData.recruiter,
         users: [recruitData.attendee1, recruitData.attendee2, recruitData.attendee3],
         condition: recruitData.condition,
-        rank,
+        rank: context.rank,
         channelName: voiceChannelName,
     });
 

--- a/src/app/feat-recruit/create_recruit/common/recruit_flow.ts
+++ b/src/app/feat-recruit/create_recruit/common/recruit_flow.ts
@@ -1,0 +1,128 @@
+import { ChatInputCommandInteraction, ModalSubmitInteraction } from 'discord.js';
+
+import { assertExistCheck, exists, sleep } from '@/app/common/others';
+import { recruitAutoClose } from '@/app/feat-recruit/close_recruit/auto_close';
+import { RecruitData } from '@/app/feat-recruit/common/types/recruit_data';
+import { sendRecruitSticky } from '@/app/feat-recruit/sticky/recruit_sticky_messages';
+import { createRecruitEvent } from '@/app/feat-recruit/vc_reservation/recruit_event';
+import { RecruitType } from '@/db/recruit_service';
+
+import { registerRecruitData } from './register_recruit_data';
+import { removeDeleteButton } from './remove_delete_button';
+import { RecruitImageBuffers, sendRecruitCanvas } from './send_recruit_message';
+
+export type RecruitInteraction =
+    ChatInputCommandInteraction<'cached'> | ModalSubmitInteraction<'cached' | 'raw'>;
+
+export type RecruitFlowContext = {
+    recruitType: RecruitType;
+    recruitRoleId: string | null;
+};
+
+export type RecruitEventTiming = {
+    title: string;
+    startTime: Date;
+    endTime?: Date;
+};
+
+export type RecruitArrangement<TContext extends RecruitFlowContext> = {
+    recruitData: RecruitData;
+    context: TContext;
+};
+
+/*
+ * schedule 連動型募集（regular / anarchy / event / salmon / fest）に共通する骨格。
+ * コマンド/モーダル別の分岐・データ整形・エラー処理は各募集固有のため
+ * resolveArrangement に委譲し、既存の挙動をそのまま保存する。
+ */
+export type RecruitFlowConfig<TMatchData, TContext extends RecruitFlowContext> = {
+    resolveArrangement: (
+        interaction: RecruitInteraction,
+    ) => Promise<RecruitArrangement<TContext> | null>;
+    getMatchData: (recruitData: RecruitData, context: TContext) => Promise<TMatchData>;
+    getImageBuffers: (
+        recruitData: RecruitData,
+        matchData: TMatchData,
+        context: TContext,
+    ) => Promise<RecruitImageBuffers>;
+    getEventTiming: (
+        recruitData: RecruitData,
+        matchData: TMatchData,
+        context: TContext,
+    ) => RecruitEventTiming;
+    getRegisterOption: (
+        recruitData: RecruitData,
+        matchData: TMatchData,
+        context: TContext,
+    ) => string | null;
+    // 2時間後の自動クローズを行うか（サーモンラン系は行わない）
+    autoClose: boolean;
+};
+
+export async function executeRecruitFlow<TMatchData, TContext extends RecruitFlowContext>(
+    interaction: RecruitInteraction,
+    config: RecruitFlowConfig<TMatchData, TContext>,
+) {
+    assertExistCheck(interaction.channel, 'channel');
+    // 'インタラクションに失敗'が出ないようにするため
+    await interaction.deferReply({});
+
+    const arrangement = await config.resolveArrangement(interaction);
+    if (arrangement === null) return;
+    const { recruitData, context } = arrangement;
+
+    const matchData = await config.getMatchData(recruitData, context);
+    const buffers = await config.getImageBuffers(recruitData, matchData, context);
+
+    const recruitMessageList = await sendRecruitCanvas(
+        interaction,
+        context.recruitRoleId,
+        recruitData,
+        buffers,
+    );
+
+    let eventId: string | null = null;
+    if (exists(recruitData.voiceChannel)) {
+        const timing = config.getEventTiming(recruitData, matchData, context);
+        eventId = (
+            await createRecruitEvent(
+                recruitData.guild,
+                timing.title,
+                recruitData.recruiter.userId,
+                recruitData.voiceChannel,
+                buffers.ruleBuffer,
+                timing.startTime,
+                timing.endTime,
+            )
+        ).id;
+    }
+
+    await registerRecruitData(
+        recruitMessageList.recruitMessage.id,
+        context.recruitType,
+        recruitData,
+        eventId,
+        config.getRegisterOption(recruitData, matchData, context),
+    );
+
+    // 募集リスト更新
+    await sendRecruitSticky({
+        channelOpt: { guild: recruitData.guild, channelId: recruitData.recruitChannel.id },
+    });
+
+    // 15秒後に削除ボタンを消す
+    await sleep(15);
+
+    await removeDeleteButton(recruitData, recruitMessageList.deleteButtonMessage.id);
+
+    if (config.autoClose) {
+        // 2時間後にボタンを無効化する
+        await sleep(7200 - 15);
+
+        await recruitAutoClose(
+            recruitData,
+            recruitMessageList.recruitMessage.id,
+            recruitMessageList.buttonMessage,
+        );
+    }
+}

--- a/src/app/feat-recruit/create_recruit/event_recruit.ts
+++ b/src/app/feat-recruit/create_recruit/event_recruit.ts
@@ -1,109 +1,69 @@
-import { ChatInputCommandInteraction, ModalSubmitInteraction } from 'discord.js';
-
-import { getEventData, EventMatchInfo } from '@/app/common/apis/splatoon3.ink/splatoon3_ink';
-import { assertExistCheck, exists, sleep } from '@/app/common/others';
+import { EventMatchInfo, getEventData } from '@/app/common/apis/splatoon3.ink/splatoon3_ink';
 import { RoleKeySet } from '@/app/constant/role_key';
 import { RecruitType } from '@/db/recruit_service';
 import { UniqueRoleService } from '@/db/unique_role_service';
 
 import { arrangeCommandRecruitData } from './common/arrange_command_data';
 import { arrangeModalRecruitData } from './common/arrange_modal_data';
-import { registerRecruitData } from './common/register_recruit_data';
-import { removeDeleteButton } from './common/remove_delete_button';
-import { sendRecruitCanvas, RecruitImageBuffers } from './common/send_recruit_message';
-import { recruitAutoClose } from '../close_recruit/auto_close';
+import {
+    executeRecruitFlow,
+    RecruitArrangement,
+    RecruitFlowContext,
+    RecruitInteraction,
+} from './common/recruit_flow';
+import { RecruitImageBuffers } from './common/send_recruit_message';
 import { recruitEventCanvas, ruleEventCanvas } from '../common/canvases/event_canvas';
 import { RecruitOpCode } from '../common/canvases/regenerate_canvas';
 import { RecruitData } from '../common/types/recruit_data';
-import { sendRecruitSticky } from '../sticky/recruit_sticky_messages';
-import { createRecruitEvent } from '../vc_reservation/recruit_event';
 
-export async function eventRecruit(
-    interaction: ChatInputCommandInteraction<'cached'> | ModalSubmitInteraction<'cached' | 'raw'>,
-) {
-    assertExistCheck(interaction.channel, 'channel');
-    // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({});
+const recruitName = 'イベマ募集';
 
-    const recruitName = 'イベマ募集';
+export async function eventRecruit(interaction: RecruitInteraction) {
+    await executeRecruitFlow<EventMatchInfo | null, RecruitFlowContext>(interaction, {
+        resolveArrangement,
+        getMatchData: (recruitData) => getEventData(recruitData.schedule),
+        getImageBuffers,
+        getEventTiming: (recruitData, eventData) => ({
+            title: `イベントマッチ - ${recruitData.recruiter.displayName}`,
+            startTime: eventData?.startTime ?? new Date(),
+            endTime: eventData?.endTime ?? new Date(),
+        }),
+        getRegisterOption: (recruitData, eventData) => eventData?.title ?? 'えらー',
+        autoClose: true,
+    });
+}
+
+async function resolveArrangement(
+    interaction: RecruitInteraction,
+): Promise<RecruitArrangement<RecruitFlowContext> | null> {
     const recruitType = RecruitType.EventRecruit;
     const recruitRoleId = await UniqueRoleService.getRoleIdByKey(
         interaction.guildId,
         RoleKeySet.EventRecruit.key,
     );
+    const context: RecruitFlowContext = { recruitType, recruitRoleId };
 
     let recruitData: RecruitData;
     if (interaction.isChatInputCommand()) {
         try {
             recruitData = await arrangeCommandRecruitData(interaction, recruitName, recruitType);
         } catch (error) {
-            return;
+            return null;
         }
     } else if (interaction.isModalSubmit()) {
         try {
             recruitData = await arrangeModalRecruitData(interaction, recruitName, recruitType);
         } catch (error) {
-            return;
+            return null;
         }
     } else {
         throw new Error('interaction type is invalid');
     }
 
-    const eventData = await getEventData(recruitData.schedule);
-
-    const eventBuffers = await getEventImageBuffers(recruitData, eventData);
-
-    const recruitMessageList = await sendRecruitCanvas(
-        interaction,
-        recruitRoleId,
-        recruitData,
-        eventBuffers,
-    );
-
-    let eventId: string | null = null;
-    if (exists(recruitData.voiceChannel)) {
-        eventId = (
-            await createRecruitEvent(
-                recruitData.guild,
-                `イベントマッチ - ${recruitData.recruiter.displayName}`,
-                recruitData.recruiter.userId,
-                recruitData.voiceChannel,
-                eventBuffers.ruleBuffer,
-                eventData?.startTime ?? new Date(),
-                eventData?.endTime ?? new Date(),
-            )
-        ).id;
-    }
-
-    await registerRecruitData(
-        recruitMessageList.recruitMessage.id,
-        recruitType,
-        recruitData,
-        eventId,
-        eventData?.title ?? 'えらー',
-    );
-
-    // 募集リスト更新
-    await sendRecruitSticky({
-        channelOpt: { guild: recruitData.guild, channelId: recruitData.recruitChannel.id },
-    });
-
-    // 15秒後に削除ボタンを消す
-    await sleep(15);
-
-    await removeDeleteButton(recruitData, recruitMessageList.deleteButtonMessage.id);
-
-    // 2時間後にボタンを無効化する
-    await sleep(7200 - 15);
-
-    await recruitAutoClose(
-        recruitData,
-        recruitMessageList.recruitMessage.id,
-        recruitMessageList.buttonMessage,
-    );
+    return { recruitData, context };
 }
 
-async function getEventImageBuffers(
+async function getImageBuffers(
     recruitData: RecruitData,
     eventData: EventMatchInfo | null,
 ): Promise<RecruitImageBuffers> {

--- a/src/app/feat-recruit/create_recruit/fest_recruit.ts
+++ b/src/app/feat-recruit/create_recruit/fest_recruit.ts
@@ -1,117 +1,77 @@
 import { Role } from '@prisma/client';
-import { ChatInputCommandInteraction, ModalSubmitInteraction } from 'discord.js';
 
 import { getFesRegularData, MatchInfo } from '@/app/common/apis/splatoon3.ink/splatoon3_ink';
-import {
-    assertExistCheck,
-    sleep,
-    notExists,
-    getDeveloperMention,
-    exists,
-} from '@/app/common/others';
+import { assertExistCheck, getDeveloperMention, notExists } from '@/app/common/others';
 import { RecruitType } from '@/db/recruit_service';
 import { RoleService } from '@/db/role_service';
 
 import { arrangeCommandRecruitData } from './common/arrange_command_data';
 import { arrangeModalRecruitData } from './common/arrange_modal_data';
-import { registerRecruitData } from './common/register_recruit_data';
-import { removeDeleteButton } from './common/remove_delete_button';
-import { sendRecruitCanvas, RecruitImageBuffers } from './common/send_recruit_message';
-import { recruitAutoClose } from '../close_recruit/auto_close';
+import {
+    executeRecruitFlow,
+    RecruitArrangement,
+    RecruitFlowContext,
+    RecruitInteraction,
+} from './common/recruit_flow';
+import { RecruitImageBuffers } from './common/send_recruit_message';
 import { recruitFestCanvas, ruleFestCanvas } from '../common/canvases/fest_canvas';
 import { RecruitOpCode } from '../common/canvases/regenerate_canvas';
 import { RecruitData } from '../common/types/recruit_data';
-import { sendRecruitSticky } from '../sticky/recruit_sticky_messages';
-import { createRecruitEvent } from '../vc_reservation/recruit_event';
 
-export async function festRecruit(
-    interaction: ChatInputCommandInteraction<'cached'> | ModalSubmitInteraction<'cached' | 'raw'>,
-) {
-    assertExistCheck(interaction.channel, 'channel');
-    // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({});
+const recruitName = 'フェス募集';
 
-    const recruitName = 'フェス募集';
+type FestContext = RecruitFlowContext & { teamRole: Role };
+
+export async function festRecruit(interaction: RecruitInteraction) {
+    await executeRecruitFlow<MatchInfo, FestContext>(interaction, {
+        resolveArrangement,
+        getMatchData: async (recruitData) => {
+            const festData = await getFesRegularData(recruitData.schedule, recruitData.scheduleNum);
+            assertExistCheck(festData, 'festData');
+            return festData;
+        },
+        getImageBuffers,
+        getEventTiming: (recruitData, festData) => ({
+            title: `フェスマッチ - ${recruitData.recruiter.displayName}`,
+            startTime: festData.startTime,
+            endTime: festData.endTime,
+        }),
+        getRegisterOption: (recruitData, festData, context) => context.teamRole.name,
+        autoClose: true,
+    });
+}
+
+async function resolveArrangement(
+    interaction: RecruitInteraction,
+): Promise<RecruitArrangement<FestContext> | null> {
     const recruitType = RecruitType.FestivalRecruit;
-    const recruitRole = await getFestRecruitRole(interaction);
-    const teamName = recruitRole.name; // フェスのチーム名
+    const teamRole = await getFestRecruitRole(interaction);
+    const context: FestContext = { recruitType, recruitRoleId: teamRole.roleId, teamRole };
 
     let recruitData: RecruitData;
     if (interaction.isChatInputCommand()) {
         try {
             recruitData = await arrangeCommandRecruitData(interaction, recruitName, recruitType);
         } catch (error) {
-            return;
+            return null;
         }
     } else if (interaction.isModalSubmit()) {
         try {
             recruitData = await arrangeModalRecruitData(interaction, recruitName, recruitType);
         } catch (error) {
-            return;
+            return null;
         }
     } else {
         throw new Error('interaction type is invalid');
     }
 
-    const festData = await getFesRegularData(recruitData.schedule, recruitData.scheduleNum);
-    assertExistCheck(festData, 'festData');
-
-    const festBuffers = await getFestImageBuffers(recruitData, festData, recruitRole);
-
-    const recruitMessageList = await sendRecruitCanvas(
-        interaction,
-        recruitRole.roleId,
-        recruitData,
-        festBuffers,
-    );
-
-    let eventId: string | null = null;
-    if (exists(recruitData.voiceChannel)) {
-        eventId = (
-            await createRecruitEvent(
-                recruitData.guild,
-                `フェスマッチ - ${recruitData.recruiter.displayName}`,
-                recruitData.recruiter.userId,
-                recruitData.voiceChannel,
-                festBuffers.ruleBuffer,
-                festData.startTime,
-                festData.endTime,
-            )
-        ).id;
-    }
-
-    await registerRecruitData(
-        recruitMessageList.recruitMessage.id,
-        recruitType,
-        recruitData,
-        eventId,
-        teamName,
-    );
-
-    // 募集リスト更新
-    await sendRecruitSticky({
-        channelOpt: { guild: recruitData.guild, channelId: recruitData.recruitChannel.id },
-    });
-
-    // 15秒後に削除ボタンを消す
-    await sleep(15);
-
-    await removeDeleteButton(recruitData, recruitMessageList.deleteButtonMessage.id);
-
-    // 2時間後にボタンを無効化する
-    await sleep(7200 - 15);
-
-    await recruitAutoClose(
-        recruitData,
-        recruitMessageList.recruitMessage.id,
-        recruitMessageList.buttonMessage,
-    );
+    return { recruitData, context };
 }
 
-async function getFestImageBuffers(
+async function getImageBuffers(
     recruitData: RecruitData,
     festData: MatchInfo,
-    teamRole: Role,
+    context: FestContext,
 ): Promise<RecruitImageBuffers> {
     const voiceChannel = recruitData.voiceChannel;
     const voiceChannelName = voiceChannel ? voiceChannel.name : null;
@@ -122,8 +82,8 @@ async function getFestImageBuffers(
         count: recruitData.count,
         recruiter: recruitData.recruiter,
         users: [recruitData.attendee1, recruitData.attendee2, recruitData.attendee3],
-        team: teamRole.name,
-        color: teamRole.hexColor,
+        team: context.teamRole.name,
+        color: context.teamRole.hexColor,
         condition: recruitData.condition,
         channelName: voiceChannelName,
     });
@@ -133,10 +93,7 @@ async function getFestImageBuffers(
     return { recruitBuffer: recruitBuffer, ruleBuffer: ruleBuffer };
 }
 
-async function getFestRecruitRole(
-    interaction:
-        ChatInputCommandInteraction<'cached' | 'raw'> | ModalSubmitInteraction<'cached' | 'raw'>,
-): Promise<Role> {
+async function getFestRecruitRole(interaction: RecruitInteraction): Promise<Role> {
     assertExistCheck(interaction.channel, 'channel');
     const teamCharacterName = interaction.channel.name.slice(0, -2); // チャンネル名から'募集'を削除
     const team = teamCharacterName + '陣営';

--- a/src/app/feat-recruit/create_recruit/regular_recruit.ts
+++ b/src/app/feat-recruit/create_recruit/regular_recruit.ts
@@ -1,110 +1,74 @@
-import { ChatInputCommandInteraction, ModalSubmitInteraction } from 'discord.js';
-
 import { getRegularData, MatchInfo } from '@/app/common/apis/splatoon3.ink/splatoon3_ink';
-import { assertExistCheck, exists, sleep } from '@/app/common/others';
+import { assertExistCheck } from '@/app/common/others';
 import { RoleKeySet } from '@/app/constant/role_key';
 import { RecruitType } from '@/db/recruit_service';
 import { UniqueRoleService } from '@/db/unique_role_service';
 
 import { arrangeCommandRecruitData } from './common/arrange_command_data';
 import { arrangeModalRecruitData } from './common/arrange_modal_data';
-import { registerRecruitData } from './common/register_recruit_data';
-import { removeDeleteButton } from './common/remove_delete_button';
-import { sendRecruitCanvas, RecruitImageBuffers } from './common/send_recruit_message';
-import { recruitAutoClose } from '../close_recruit/auto_close';
+import {
+    executeRecruitFlow,
+    RecruitArrangement,
+    RecruitFlowContext,
+    RecruitInteraction,
+} from './common/recruit_flow';
+import { RecruitImageBuffers } from './common/send_recruit_message';
 import { RecruitOpCode } from '../common/canvases/regenerate_canvas';
 import { recruitRegularCanvas, ruleRegularCanvas } from '../common/canvases/regular_canvas';
 import { RecruitData } from '../common/types/recruit_data';
-import { sendRecruitSticky } from '../sticky/recruit_sticky_messages';
-import { createRecruitEvent } from '../vc_reservation/recruit_event';
 
-export async function regularRecruit(
-    interaction: ChatInputCommandInteraction<'cached'> | ModalSubmitInteraction<'cached' | 'raw'>,
-) {
-    assertExistCheck(interaction.channel, 'channel');
-    // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({});
+const recruitName = 'ナワバリ募集';
 
-    const recruitName = 'ナワバリ募集';
+export async function regularRecruit(interaction: RecruitInteraction) {
+    await executeRecruitFlow<MatchInfo, RecruitFlowContext>(interaction, {
+        resolveArrangement,
+        getMatchData: async (recruitData) => {
+            const regularData = await getRegularData(recruitData.schedule, recruitData.scheduleNum);
+            assertExistCheck(regularData, 'regularData');
+            return regularData;
+        },
+        getImageBuffers,
+        getEventTiming: (recruitData, regularData) => ({
+            title: `レギュラーマッチ - ${recruitData.recruiter.displayName}`,
+            startTime: regularData.startTime,
+            endTime: regularData.endTime,
+        }),
+        getRegisterOption: () => null,
+        autoClose: true,
+    });
+}
+
+async function resolveArrangement(
+    interaction: RecruitInteraction,
+): Promise<RecruitArrangement<RecruitFlowContext> | null> {
     const recruitType = RecruitType.RegularRecruit;
     const recruitRoleId = await UniqueRoleService.getRoleIdByKey(
         interaction.guildId,
         RoleKeySet.RegularRecruit.key,
     );
+    const context: RecruitFlowContext = { recruitType, recruitRoleId };
 
     let recruitData: RecruitData;
     if (interaction.isChatInputCommand()) {
         try {
             recruitData = await arrangeCommandRecruitData(interaction, recruitName, recruitType);
         } catch (error) {
-            return;
+            return null;
         }
     } else if (interaction.isModalSubmit()) {
         try {
             recruitData = await arrangeModalRecruitData(interaction, recruitName, recruitType);
         } catch (error) {
-            return;
+            return null;
         }
     } else {
         throw new Error('interaction type is invalid');
     }
 
-    const regularData = await getRegularData(recruitData.schedule, recruitData.scheduleNum);
-    assertExistCheck(regularData, 'regularData');
-
-    const regularBuffers = await getRegularImageBuffers(recruitData, regularData);
-
-    const recruitMessageList = await sendRecruitCanvas(
-        interaction,
-        recruitRoleId,
-        recruitData,
-        regularBuffers,
-    );
-
-    let eventId: string | null = null;
-    if (exists(recruitData.voiceChannel)) {
-        eventId = (
-            await createRecruitEvent(
-                recruitData.guild,
-                `レギュラーマッチ - ${recruitData.recruiter.displayName}`,
-                recruitData.recruiter.userId,
-                recruitData.voiceChannel,
-                regularBuffers.ruleBuffer,
-                regularData.startTime,
-                regularData.endTime,
-            )
-        ).id;
-    }
-
-    await registerRecruitData(
-        recruitMessageList.recruitMessage.id,
-        recruitType,
-        recruitData,
-        eventId,
-        null,
-    );
-
-    // 募集リスト更新
-    await sendRecruitSticky({
-        channelOpt: { guild: recruitData.guild, channelId: recruitData.recruitChannel.id },
-    });
-
-    // 15秒後に削除ボタンを消す
-    await sleep(15);
-
-    await removeDeleteButton(recruitData, recruitMessageList.deleteButtonMessage.id);
-
-    // 2時間後にボタンを無効化する
-    await sleep(7200 - 15);
-
-    await recruitAutoClose(
-        recruitData,
-        recruitMessageList.recruitMessage.id,
-        recruitMessageList.buttonMessage,
-    );
+    return { recruitData, context };
 }
 
-async function getRegularImageBuffers(
+async function getImageBuffers(
     recruitData: RecruitData,
     regularData: MatchInfo,
 ): Promise<RecruitImageBuffers> {

--- a/src/app/feat-recruit/create_recruit/salmon_recruit.ts
+++ b/src/app/feat-recruit/create_recruit/salmon_recruit.ts
@@ -1,50 +1,63 @@
-import { ChatInputCommandInteraction, ModalSubmitInteraction } from 'discord.js';
+import { ChatInputCommandInteraction } from 'discord.js';
 
 import {
-    getSchedule,
     checkBigRun,
     checkTeamContest,
     getSalmonData,
+    getSchedule,
     getTeamContestData,
 } from '@/app/common/apis/splatoon3.ink/splatoon3_ink';
-import { assertExistCheck, exists, sleep } from '@/app/common/others';
+import { assertExistCheck } from '@/app/common/others';
 import { RoleKeySet } from '@/app/constant/role_key';
 import { RecruitType } from '@/db/recruit_service';
 import { UniqueRoleService } from '@/db/unique_role_service';
 
 import { arrangeCommandRecruitData } from './common/arrange_command_data';
 import { arrangeModalRecruitData } from './common/arrange_modal_data';
-import { registerRecruitData } from './common/register_recruit_data';
-import { removeDeleteButton } from './common/remove_delete_button';
-import { sendRecruitCanvas, RecruitImageBuffers } from './common/send_recruit_message';
+import {
+    executeRecruitFlow,
+    RecruitArrangement,
+    RecruitFlowContext,
+    RecruitInteraction,
+} from './common/recruit_flow';
+import { RecruitImageBuffers } from './common/send_recruit_message';
 import { recruitBigRunCanvas, ruleBigRunCanvas } from '../common/canvases/big_run_canvas';
 import { RecruitOpCode } from '../common/canvases/regenerate_canvas';
 import { recruitSalmonCanvas, ruleSalmonCanvas } from '../common/canvases/salmon_canvas';
 import { RecruitData } from '../common/types/recruit_data';
-import { sendRecruitSticky } from '../sticky/recruit_sticky_messages';
-import { createRecruitEvent } from '../vc_reservation/recruit_event';
 
-export async function salmonRecruit(
-    interaction: ChatInputCommandInteraction<'cached'> | ModalSubmitInteraction<'cached' | 'raw'>,
-) {
-    assertExistCheck(interaction.channel, 'channel');
-    // 'インタラクションに失敗'が出ないようにするため
-    await interaction.deferReply({});
+const recruitName = 'バイト募集';
 
-    const recruitName = 'バイト募集';
-    let recruitType;
+export async function salmonRecruit(interaction: RecruitInteraction) {
+    await executeRecruitFlow<null, RecruitFlowContext>(interaction, {
+        resolveArrangement,
+        getMatchData: async () => null,
+        getImageBuffers,
+        getEventTiming: (recruitData) => ({
+            title: `サーモンラン - ${recruitData.recruiter.displayName}`,
+            startTime: new Date(),
+        }),
+        getRegisterOption: () => null,
+        autoClose: false,
+    });
+}
+
+async function resolveArrangement(
+    interaction: RecruitInteraction,
+): Promise<RecruitArrangement<RecruitFlowContext> | null> {
     const recruitRoleId = await UniqueRoleService.getRoleIdByKey(
         interaction.guildId,
         RoleKeySet.SalmonRecruit.key,
     );
 
+    let recruitType: RecruitType;
     let recruitData: RecruitData;
     if (interaction.isChatInputCommand()) {
         recruitType = getRecruitType(interaction);
         try {
             recruitData = await arrangeCommandRecruitData(interaction, recruitName, recruitType);
         } catch (error) {
-            return;
+            return null;
         }
     } else if (interaction.isModalSubmit()) {
         try {
@@ -60,64 +73,26 @@ export async function salmonRecruit(
 
             recruitData = await arrangeModalRecruitData(interaction, recruitName, recruitType);
         } catch (error) {
-            return;
+            return null;
         }
     } else {
         throw new Error('interaction type is invalid');
     }
 
-    const salmonBuffers = await getSalmonImageBuffers(recruitData, recruitType);
-
-    const recruitMessageList = await sendRecruitCanvas(
-        interaction,
-        recruitRoleId,
-        recruitData,
-        salmonBuffers,
-    );
-
-    let eventId: string | null = null;
-    if (exists(recruitData.voiceChannel)) {
-        eventId = (
-            await createRecruitEvent(
-                recruitData.guild,
-                `サーモンラン - ${recruitData.recruiter.displayName}`,
-                recruitData.recruiter.userId,
-                recruitData.voiceChannel,
-                salmonBuffers.ruleBuffer,
-                new Date(),
-            )
-        ).id;
-    }
-
-    await registerRecruitData(
-        recruitMessageList.recruitMessage.id,
-        recruitType,
-        recruitData,
-        eventId,
-        null,
-    );
-
-    // 募集リスト更新
-    await sendRecruitSticky({
-        channelOpt: { guild: recruitData.guild, channelId: recruitData.recruitChannel.id },
-    });
-
-    // 15秒後に削除ボタンを消す
-    await sleep(15);
-
-    await removeDeleteButton(recruitData, recruitMessageList.deleteButtonMessage.id);
+    return { recruitData, context: { recruitType, recruitRoleId } };
 }
 
-async function getSalmonImageBuffers(
+async function getImageBuffers(
     recruitData: RecruitData,
-    recruitType: RecruitType,
+    matchData: null,
+    context: RecruitFlowContext,
 ): Promise<RecruitImageBuffers> {
     const voiceChannel = recruitData.voiceChannel;
     const voiceChannelName = voiceChannel ? voiceChannel.name : null;
 
     let recruitBuffer: Buffer;
     let ruleBuffer: Buffer;
-    if (recruitType === RecruitType.SalmonRecruit) {
+    if (context.recruitType === RecruitType.SalmonRecruit) {
         recruitBuffer = await recruitSalmonCanvas({
             opCode: RecruitOpCode.open,
             remaining: recruitData.recruitNum,
@@ -128,7 +103,7 @@ async function getSalmonImageBuffers(
             channelName: voiceChannelName,
         });
         ruleBuffer = await ruleSalmonCanvas(await getSalmonData(recruitData.schedule, 0));
-    } else if (recruitType === RecruitType.BigRunRecruit) {
+    } else if (context.recruitType === RecruitType.BigRunRecruit) {
         recruitBuffer = await recruitBigRunCanvas({
             opCode: RecruitOpCode.open,
             remaining: recruitData.recruitNum,
@@ -139,7 +114,7 @@ async function getSalmonImageBuffers(
             channelName: voiceChannelName,
         });
         ruleBuffer = await ruleBigRunCanvas(await getSalmonData(recruitData.schedule, 0));
-    } else if (recruitType === RecruitType.TeamContestRecruit) {
+    } else if (context.recruitType === RecruitType.TeamContestRecruit) {
         recruitBuffer = await recruitSalmonCanvas({
             opCode: RecruitOpCode.open,
             remaining: recruitData.recruitNum,


### PR DESCRIPTION
## 背景

`create_recruit/` 配下のスケジュール連動型募集コマンド（regular / anarchy / event / salmon / fest。big run・team contest 分岐を含む）は、`deferReply → コマンド/モーダル別データ整形 → マッチデータ取得 → 画像バッファ生成 → 募集メッセージ送信 → VC予約イベント作成 → DB登録 → sticky更新 → 15秒後に削除ボタン除去 → 2時間後に自動クローズ` という同一の骨格を5ファイルにコピペした状態だった。

本 PR は機能を変えない大規模リファクタリング（全10 PR構成、スタック PR）のうち PR9 にあたり、PR6（#792・canvas 共通化でオブジェクト引数化されたシグネチャ）の上にスタックしている。

## 変更内容

- 新規 `create_recruit/common/recruit_flow.ts` に `executeRecruitFlow(interaction, config)` を追加し、5ファイル共通の骨格を集約
- 各 `xxx_recruit.ts` は「コマンド/モーダル別のデータ整形・ロール解決」「マッチデータ取得」「画像バッファ生成」「イベント名生成」「DB登録オプション値」を config として渡す薄い実装にした
- `sleep(15)` → 削除ボタン除去 → `sleep(7200-15)` → 自動クローズ、というタイミング・順序は完全維持
- salmon のみ2時間後の自動クローズを行わない既存の非対称性は `autoClose` フラグで維持
- anarchy のロール/ランク解決、fest のチームロール解決など、コマンド/モーダルで分岐が異なる固有ロジックは各ファイルにそのまま残し、try/catch の対象範囲（エラー時に無言で return するか、上位へ伝播させるか）も元の挙動を一切変えていない
- 構造が大きく異なる `private_recruit.ts` / `other_game_recruit.ts` / `button_recruit.ts` は対象外。`raiders_recruit.ts` はスケジュールを持たないため「schedule 連動型」の定義から外れ対象外とした

## 動作検証

### Local

- [x] compile（`tsc` 含む）が成功することを確認
- [x] lint（ESLint）が成功することを確認（エラー・警告 0）
- [x] vitest（80テスト）が全て成功することを確認
- [x] 別コンテキストのレビュアーによる挙動保存の照合を実施（5ファイル全ての分岐・try/catchスコープ・イベントタイトル/時刻・登録オプション値・autoCloseの有無を旧実装と突合し、差異なしを確認）

## 備考

- 機能・挙動の変更は一切なし（純粋なリファクタリング）
- スタック PR 構成のため、マージ順は PR6（#792）が先行する必要がある