### PR TITLE
refactor: DBサービス層が握り潰していたエラーを呼び出し側へ伝える (#804 後編)

### DIFF
--- a/src/features/channel_settings/admin_channel_setting.ts
+++ b/src/features/channel_settings/admin_channel_setting.ts
@@ -11,7 +11,7 @@ import {
 import { ChannelService } from '@/infra/db/repositories/channel_service';
 import { log4js_obj } from '@/infra/logging/log4js';
 import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-import { exists, notExists } from '@/shared/assert';
+import { exists } from '@/shared/assert';
 import { getGuildByInteraction } from '@/shared/discord_helpers/guild_manager';
 
 const logger = log4js_obj.getLogger('interaction');
@@ -41,16 +41,10 @@ export async function adminChannelSetting(
                 storedChannel.channelId,
             );
 
+            // カテゴリ配下のチャンネルにも同じ設定を反映する。
+            // 更新に失敗すれば throw されるため、成否の確認は不要
             for (const channel of channels) {
-                const result = await ChannelService.setAdminChannel(
-                    guild.id,
-                    channel.channelId,
-                    isAdminChannel,
-                );
-
-                if (notExists(result)) {
-                    return null;
-                }
+                await ChannelService.setAdminChannel(guild.id, channel.channelId, isAdminChannel);
             }
         }
 

--- a/src/features/channel_settings/vcTools_setting.ts
+++ b/src/features/channel_settings/vcTools_setting.ts
@@ -11,7 +11,7 @@ import {
 import { ChannelService } from '@/infra/db/repositories/channel_service';
 import { log4js_obj } from '@/infra/logging/log4js';
 import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-import { exists, notExists } from '@/shared/assert';
+import { exists } from '@/shared/assert';
 import { getGuildByInteraction } from '@/shared/discord_helpers/guild_manager';
 
 const logger = log4js_obj.getLogger('interaction');
@@ -41,16 +41,14 @@ export async function vcToolsSetting(
                 storedChannel.channelId,
             );
 
+            // カテゴリ配下のチャンネルにも同じ設定を反映する。
+            // 更新に失敗すれば throw されるため、成否の確認は不要
             for (const channel of channels) {
-                const result = await ChannelService.setVCToolsEnabled(
+                await ChannelService.setVCToolsEnabled(
                     guild.id,
                     channel.channelId,
                     isVCToolsEnabled,
                 );
-
-                if (notExists(result)) {
-                    return null;
-                }
             }
         }
 

--- a/src/features/guild_sync/sync_member.ts
+++ b/src/features/guild_sync/sync_member.ts
@@ -2,15 +2,11 @@ import { Client, GuildMember, User } from 'discord.js';
 
 import { updateGuildRoles } from '@/features/guild_sync/store_role';
 import { MemberService } from '@/infra/db/repositories/member_service';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
 import { assertExistCheck, notExists } from '@/shared/assert';
 import { searchAPIMemberById } from '@/shared/discord_helpers/member_manager';
 
 /** メンバー情報が更新されたとき、ロール一覧と DB のメンバー情報を同期する */
 export async function syncMemberOnUpdate(newMember: GuildMember) {
-    const loggerMU = log4js_obj.getLogger('guildMemberUpdate');
-
     const guild = await newMember.guild.fetch();
     await updateGuildRoles(guild);
 
@@ -21,21 +17,12 @@ export async function syncMemberOnUpdate(newMember: GuildMember) {
 
     assertExistCheck(member.joinedAt, 'joinedAt');
 
-    // DBのメンバー情報を更新(ない場合は作成)
-    const storedMember = await MemberService.saveMemberFromGuildMember(member);
-
-    if (notExists(storedMember)) {
-        await sendErrorLogs(
-            loggerMU,
-            `failed to set member to DB. userId: ${userId}, guildId: ${guild.id}`,
-        );
-    }
+    // DBのメンバー情報を更新(ない場合は作成)。失敗すれば throw され、境界で通知される
+    await MemberService.saveMemberFromGuildMember(member);
 }
 
 /** ユーザー情報が更新されたとき、そのユーザーが所属する全ギルドの DB 情報を同期する */
 export async function syncMemberAcrossGuilds(client: Client, user: User) {
-    const loggerUU = log4js_obj.getLogger('userUpdate');
-
     const userId = user.id;
 
     const guildIdList = await MemberService.getMemberGuildIdsByUserId(userId);
@@ -47,14 +34,7 @@ export async function syncMemberAcrossGuilds(client: Client, user: User) {
         // 他鯖のテーブルには存在するが、実際には鯖から抜けている場合
         if (notExists(member)) continue;
 
-        // DBのメンバー情報を更新(ない場合は作成)
-        const storedMember = await MemberService.saveMemberFromGuildMember(member);
-
-        if (notExists(storedMember)) {
-            return await sendErrorLogs(
-                loggerUU,
-                `failed to set member to DB. userId: ${userId}, guildId: ${guildId}`,
-            );
-        }
+        // DBのメンバー情報を更新(ない場合は作成)。失敗すれば throw され、境界で通知される
+        await MemberService.saveMemberFromGuildMember(member);
     }
 }

--- a/src/features/unique_channel_settings/unset_unique_channel.ts
+++ b/src/features/unique_channel_settings/unset_unique_channel.ts
@@ -5,7 +5,7 @@ import { ChannelService } from '@/infra/db/repositories/channel_service';
 import { UniqueChannelService } from '@/infra/db/repositories/unique_channel_service';
 import { log4js_obj } from '@/infra/logging/log4js';
 import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-import { assertExistCheck, exists, notExists } from '@/shared/assert';
+import { assertExistCheck, notExists } from '@/shared/assert';
 
 const logger = log4js_obj.getLogger('interaction');
 
@@ -35,22 +35,22 @@ export async function unsetUniqueChannelCommand(
             return;
         }
 
-        const deletedChannel = await UniqueChannelService.delete(interaction.guildId, key);
+        // DB障害は throw されるようになったため、false は「解除する行が無かった」
+        // (取得してから解除するまでの間に他の経路で解除された) を意味する
+        const deleted = await UniqueChannelService.delete(interaction.guildId, key);
 
-        if (exists(deletedChannel)) {
-            const channel = await ChannelService.getChannel(
-                interaction.guildId,
-                deletedChannel.channelId,
-            );
-            assertExistCheck(channel, 'storedChannel');
-            await interaction.editReply({
-                content: `\`${channel.name}\`を\`${key}\`の設定から解除したでし！`,
-            });
-        } else {
+        if (!deleted) {
             await interaction.editReply({
                 content: '設定の解除に失敗したでし！',
             });
+            return;
         }
+
+        const channel = await ChannelService.getChannel(interaction.guildId, storedChannelId);
+        assertExistCheck(channel, 'storedChannel');
+        await interaction.editReply({
+            content: `\`${channel.name}\`を\`${key}\`の設定から解除したでし！`,
+        });
     } catch (error) {
         await sendErrorLogs(logger, error);
     }

--- a/src/features/unique_channel_settings/unset_unique_channel.ts
+++ b/src/features/unique_channel_settings/unset_unique_channel.ts
@@ -41,7 +41,7 @@ export async function unsetUniqueChannelCommand(
 
         if (!deleted) {
             await interaction.editReply({
-                content: '設定の解除に失敗したでし！',
+                content: 'その項目は既に解除されていたでし！',
             });
             return;
         }

--- a/src/features/unique_role_settings/unset_unique_role.ts
+++ b/src/features/unique_role_settings/unset_unique_role.ts
@@ -5,7 +5,7 @@ import { RoleService } from '@/infra/db/repositories/role_service';
 import { UniqueRoleService } from '@/infra/db/repositories/unique_role_service';
 import { log4js_obj } from '@/infra/logging/log4js';
 import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-import { assertExistCheck, exists, notExists } from '@/shared/assert';
+import { assertExistCheck, notExists } from '@/shared/assert';
 
 const logger = log4js_obj.getLogger('interaction');
 
@@ -32,19 +32,22 @@ export async function unsetUniqueRoleCommand(
             return;
         }
 
-        const deletedRole = await UniqueRoleService.delete(interaction.guildId, key);
+        // DB障害は throw されるようになったため、false は「解除する行が無かった」
+        // (取得してから解除するまでの間に他の経路で解除された) を意味する
+        const deleted = await UniqueRoleService.delete(interaction.guildId, key);
 
-        if (exists(deletedRole)) {
-            const role = await RoleService.getRole(interaction.guildId, deletedRole.roleId);
-            assertExistCheck(role, 'storedRole');
-            await interaction.editReply({
-                content: `\`${role.name}\`を\`${key}\`の設定から解除したでし！`,
-            });
-        } else {
+        if (!deleted) {
             await interaction.editReply({
                 content: '設定の解除に失敗したでし！',
             });
+            return;
         }
+
+        const role = await RoleService.getRole(interaction.guildId, storedRoleId);
+        assertExistCheck(role, 'storedRole');
+        await interaction.editReply({
+            content: `\`${role.name}\`を\`${key}\`の設定から解除したでし！`,
+        });
     } catch (error) {
         await sendErrorLogs(logger, error);
     }

--- a/src/features/unique_role_settings/unset_unique_role.ts
+++ b/src/features/unique_role_settings/unset_unique_role.ts
@@ -38,7 +38,7 @@ export async function unsetUniqueRoleCommand(
 
         if (!deleted) {
             await interaction.editReply({
-                content: '設定の解除に失敗したでし！',
+                content: 'その項目は既に解除されていたでし！',
             });
             return;
         }

--- a/src/infra/db/repositories/channel_service.ts
+++ b/src/infra/db/repositories/channel_service.ts
@@ -1,10 +1,7 @@
+import { Channel } from '@prisma/client';
 import { ChannelType } from 'discord.js';
 
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-
-const logger = log4js_obj.getLogger('database');
 
 export class ChannelService {
     static async save(
@@ -15,141 +12,126 @@ export class ChannelService {
         position: number,
         parentId?: string | null,
     ) {
-        try {
-            return await prisma.channel.upsert({
-                where: {
-                    guildId_channelId: {
-                        guildId: guildId,
-                        channelId: channelId,
-                    },
-                },
-                update: {
-                    guildId: guildId,
-                    name: channelName,
-                    type: channelType,
-                    position: position,
-                    parentId: parentId,
-                },
-                create: {
+        return await prisma.channel.upsert({
+            where: {
+                guildId_channelId: {
                     guildId: guildId,
                     channelId: channelId,
-                    name: channelName,
-                    type: channelType,
-                    position: position,
-                    parentId: parentId === undefined ? null : parentId,
-                    isVCToolsEnabled: false,
-                    isAdminChannel: false,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+            update: {
+                guildId: guildId,
+                name: channelName,
+                type: channelType,
+                position: position,
+                parentId: parentId,
+            },
+            create: {
+                guildId: guildId,
+                channelId: channelId,
+                name: channelName,
+                type: channelType,
+                position: position,
+                parentId: parentId === undefined ? null : parentId,
+                isVCToolsEnabled: false,
+                isAdminChannel: false,
+            },
+        });
     }
 
-    static async setVCToolsEnabled(guildId: string, channelId: string, isVCToolsEnabled = true) {
-        try {
-            return await prisma.channel.update({
-                where: {
-                    guildId_channelId: {
-                        guildId: guildId,
-                        channelId: channelId,
-                    },
+    // update() は対象行が無いと P2025 で throw するため、冪等に扱いたいここでは updateMany を使う。
+    // ただし updateMany は更新した行そのものを返さない（{count} のみ）ので、
+    // 呼び出し側が Channel レコード（type / channelId）を参照できるよう findUnique で取り直して返す。
+    // 戻り値の null は「そのチャンネルが DB に存在しない」ことを表す（DB 障害は throw される）。
+    static async setVCToolsEnabled(
+        guildId: string,
+        channelId: string,
+        isVCToolsEnabled = true,
+    ): Promise<Channel | null> {
+        await prisma.channel.updateMany({
+            where: {
+                guildId: guildId,
+                channelId: channelId,
+            },
+            data: {
+                isVCToolsEnabled: isVCToolsEnabled,
+            },
+        });
+
+        return await prisma.channel.findUnique({
+            where: {
+                guildId_channelId: {
+                    guildId: guildId,
+                    channelId: channelId,
                 },
-                data: {
-                    isVCToolsEnabled: isVCToolsEnabled,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+        });
     }
 
-    static async setAdminChannel(guildId: string, channelId: string, isAdminChannel = true) {
-        try {
-            return await prisma.channel.update({
-                where: {
-                    guildId_channelId: {
-                        guildId: guildId,
-                        channelId: channelId,
-                    },
+    // setVCToolsEnabled と同じ理由で updateMany + findUnique の組み合わせにしている。
+    static async setAdminChannel(
+        guildId: string,
+        channelId: string,
+        isAdminChannel = true,
+    ): Promise<Channel | null> {
+        await prisma.channel.updateMany({
+            where: {
+                guildId: guildId,
+                channelId: channelId,
+            },
+            data: {
+                isAdminChannel: isAdminChannel,
+            },
+        });
+
+        return await prisma.channel.findUnique({
+            where: {
+                guildId_channelId: {
+                    guildId: guildId,
+                    channelId: channelId,
                 },
-                data: {
-                    isAdminChannel: isAdminChannel,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+        });
     }
 
-    static async delete(guildId: string, channelId: string) {
-        try {
-            return await prisma.channel.delete({
-                where: {
-                    guildId_channelId: {
-                        guildId: guildId,
-                        channelId: channelId,
-                    },
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+    static async delete(guildId: string, channelId: string): Promise<void> {
+        await prisma.channel.deleteMany({
+            where: {
+                guildId: guildId,
+                channelId: channelId,
+            },
+        });
     }
 
     static async getChannel(guildId: string, channelId: string) {
-        try {
-            return await prisma.channel.findUnique({
-                where: {
-                    guildId_channelId: {
-                        guildId: guildId,
-                        channelId: channelId,
-                    },
+        return await prisma.channel.findUnique({
+            where: {
+                guildId_channelId: {
+                    guildId: guildId,
+                    channelId: channelId,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+        });
     }
 
     static async getChannelsByCategoryId(guildId: string, categoryId: string) {
-        try {
-            return await prisma.channel.findMany({
-                where: {
-                    guildId: guildId,
-                    parentId: categoryId,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        return await prisma.channel.findMany({
+            where: {
+                guildId: guildId,
+                parentId: categoryId,
+            },
+        });
     }
 
     static async getAllGuildChannels(guildId: string) {
-        try {
-            return await prisma.channel.findMany({
-                where: {
-                    guildId: guildId,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        return await prisma.channel.findMany({
+            where: {
+                guildId: guildId,
+            },
+        });
     }
 
     static async getAllChannels() {
-        try {
-            return await prisma.channel.findMany();
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        return await prisma.channel.findMany();
     }
 }

--- a/src/infra/db/repositories/friend_code_service.ts
+++ b/src/infra/db/repositories/friend_code_service.ts
@@ -1,43 +1,30 @@
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-
-const logger = log4js_obj.getLogger('database');
 
 export class FriendCodeService {
     static async save(userId: string, code: string, url: string | null) {
-        try {
-            await prisma.friendCode.upsert({
-                where: {
-                    userId: userId,
-                },
-                update: {
-                    code: code,
-                    url: url,
-                },
-                create: {
-                    userId: userId,
-                    code: code,
-                    url: url,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.friendCode.upsert({
+            where: {
+                userId: userId,
+            },
+            update: {
+                code: code,
+                url: url,
+            },
+            create: {
+                userId: userId,
+                code: code,
+                url: url,
+            },
+        });
     }
 
     static async getFriendCodeObjByUserId(userId: string) {
-        try {
-            const friendCode = await prisma.friendCode.findUnique({
-                where: {
-                    userId: userId,
-                },
-            });
+        const friendCode = await prisma.friendCode.findUnique({
+            where: {
+                userId: userId,
+            },
+        });
 
-            return friendCode;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        return friendCode;
     }
 }

--- a/src/infra/db/repositories/member_service.ts
+++ b/src/infra/db/repositories/member_service.ts
@@ -6,7 +6,6 @@ import { RoleKeySet } from '@/config/constants/role_key';
 import { prisma } from '@/infra/db/prisma';
 import { UniqueRoleService } from '@/infra/db/repositories/unique_role_service';
 import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
 import { exists } from '@/shared/assert';
 const logger = log4js_obj.getLogger('database');
 
@@ -28,34 +27,29 @@ export class MemberService {
         iconUrl: string,
         joinedAt: Date,
         isRookie: boolean,
-    ): Promise<Member | null> {
-        try {
-            return await prisma.member.upsert({
-                where: {
-                    guildId_userId: {
-                        guildId: guildId,
-                        userId: userId,
-                    },
-                },
-                update: {
-                    displayName: displayName,
-                    iconUrl: iconUrl,
-                    isRookie: isRookie,
-                },
-                create: {
+    ): Promise<Member> {
+        return await prisma.member.upsert({
+            where: {
+                guildId_userId: {
                     guildId: guildId,
                     userId: userId,
-                    displayName: displayName,
-                    mention: `<@${userId}>`,
-                    iconUrl: iconUrl,
-                    joinedAt: joinedAt,
-                    isRookie: isRookie,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+            update: {
+                displayName: displayName,
+                iconUrl: iconUrl,
+                isRookie: isRookie,
+            },
+            create: {
+                guildId: guildId,
+                userId: userId,
+                displayName: displayName,
+                mention: `<@${userId}>`,
+                iconUrl: iconUrl,
+                joinedAt: joinedAt,
+                isRookie: isRookie,
+            },
+        });
     }
 
     /**
@@ -67,204 +61,168 @@ export class MemberService {
     static async saveMemberFromGuildMember(
         member: GuildMember,
         isRookie?: boolean,
-    ): Promise<Member | null> {
-        try {
-            const iconUrl = member
-                .displayAvatarURL()
-                .replace('.webp', '.png')
-                .replace('.webm', '.gif');
+    ): Promise<Member> {
+        const iconUrl = member.displayAvatarURL().replace('.webp', '.png').replace('.webm', '.gif');
 
-            let hasRookieRole = false;
+        let hasRookieRole = false;
 
-            if (exists(isRookie)) {
-                // isRookieが指定されている場合はその値を使う
-                hasRookieRole = isRookie;
-            } else {
-                // isRookieが指定されていない場合は新入部員ロールを持っているか確認する
-                const rookieRoleId = await UniqueRoleService.getRoleIdByKey(
-                    member.guild.id,
-                    RoleKeySet.Rookie.key,
-                );
+        if (exists(isRookie)) {
+            // isRookieが指定されている場合はその値を使う
+            hasRookieRole = isRookie;
+        } else {
+            // isRookieが指定されていない場合は新入部員ロールを持っているか確認する
+            const rookieRoleId = await UniqueRoleService.getRoleIdByKey(
+                member.guild.id,
+                RoleKeySet.Rookie.key,
+            );
 
-                // rookieRoleが存在するサーバの場合、新入部員ロールを持っているか確認
-                if (exists(rookieRoleId)) {
-                    const memberRoles = member.roles.cache.get(rookieRoleId);
-                    if (exists(memberRoles)) {
-                        hasRookieRole = true;
-                    }
+            // rookieRoleが存在するサーバの場合、新入部員ロールを持っているか確認
+            if (exists(rookieRoleId)) {
+                const memberRoles = member.roles.cache.get(rookieRoleId);
+                if (exists(memberRoles)) {
+                    hasRookieRole = true;
                 }
             }
+        }
 
-            return await prisma.member.upsert({
-                where: {
-                    guildId_userId: {
-                        guildId: member.guild.id,
-                        userId: member.user.id,
-                    },
-                },
-                update: {
-                    displayName: member.displayName,
-                    iconUrl: iconUrl,
-                    isRookie: hasRookieRole,
-                },
-                create: {
+        return await prisma.member.upsert({
+            where: {
+                guildId_userId: {
                     guildId: member.guild.id,
                     userId: member.user.id,
-                    displayName: member.displayName,
-                    mention: `<@${member.user.id}>`,
-                    iconUrl: iconUrl,
-                    joinedAt: member.joinedAt,
-                    isRookie: hasRookieRole,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+            update: {
+                displayName: member.displayName,
+                iconUrl: iconUrl,
+                isRookie: hasRookieRole,
+            },
+            create: {
+                guildId: member.guild.id,
+                userId: member.user.id,
+                displayName: member.displayName,
+                mention: `<@${member.user.id}>`,
+                iconUrl: iconUrl,
+                joinedAt: member.joinedAt,
+                isRookie: hasRookieRole,
+            },
+        });
     }
 
-    static async updateJoinedAt(
-        guildId: string,
-        userId: string,
-        joinedAt: Date,
-    ): Promise<Member | null> {
-        try {
-            return await prisma.member.update({
-                where: {
-                    guildId_userId: {
-                        guildId: guildId,
-                        userId: userId,
-                    },
-                },
-                data: {
-                    joinedAt: joinedAt,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+    /**
+     * 対象メンバーがDBに存在しないのは正常系のため、
+     * 0件マッチで throw しない updateMany を使う。
+     */
+    static async updateJoinedAt(guildId: string, userId: string, joinedAt: Date): Promise<void> {
+        await prisma.member.updateMany({
+            where: {
+                guildId: guildId,
+                userId: userId,
+            },
+            data: {
+                joinedAt: joinedAt,
+            },
+        });
     }
 
-    static async setRookieFlag(
-        guildId: string,
-        userId: string,
-        isRookie: boolean,
-    ): Promise<Member | null> {
-        try {
-            return await prisma.member.update({
-                where: {
-                    guildId_userId: {
-                        guildId: guildId,
-                        userId: userId,
-                    },
-                },
-                data: {
-                    isRookie: isRookie,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+    /**
+     * 対象メンバーがDBに存在しないのは正常系のため、
+     * 0件マッチで throw しない updateMany を使う。
+     */
+    static async setRookieFlag(guildId: string, userId: string, isRookie: boolean): Promise<void> {
+        await prisma.member.updateMany({
+            where: {
+                guildId: guildId,
+                userId: userId,
+            },
+            data: {
+                isRookie: isRookie,
+            },
+        });
     }
 
     static async getMemberByUserId(guildId: string, userId: string): Promise<Member | null> {
-        try {
-            const member = await prisma.member.findUnique({
-                where: {
-                    guildId_userId: {
-                        guildId: guildId,
-                        userId: userId,
-                    },
+        const member = await prisma.member.findUnique({
+            where: {
+                guildId_userId: {
+                    guildId: guildId,
+                    userId: userId,
                 },
-            });
+            },
+        });
 
-            return member;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        return member;
     }
 
     static async getMemberGuildIdsByUserId(userId: string): Promise<string[]> {
-        try {
-            const members = await prisma.member.findMany({
-                where: {
-                    userId: userId,
-                },
-            });
-            const guildIds: string[] = [];
-            for (const member of members) {
-                guildIds.push(member.guildId);
-            }
-            return guildIds;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
+        const members = await prisma.member.findMany({
+            where: {
+                userId: userId,
+            },
+        });
+        const guildIds: string[] = [];
+        for (const member of members) {
+            guildIds.push(member.guildId);
         }
+        return guildIds;
     }
 
     // ダミーを作らないとModalでエラーが出るため
     static async createDummyUser(guildId: string) {
-        try {
-            // 既存のメンバーを検索します
-            const members = await prisma.member.findMany({
-                where: {
-                    guildId: guildId,
-                    userId: {
-                        startsWith: 'attendee',
-                    },
+        // 既存のメンバーを検索します
+        const members = await prisma.member.findMany({
+            where: {
+                guildId: guildId,
+                userId: {
+                    startsWith: 'attendee',
                 },
-            });
+            },
+        });
 
-            // 既存のメンバーが3人未満の場合はダミーユーザーを作成
-            if (members.length < 3) {
-                const dummyUsers = [
-                    {
-                        guildId: guildId,
-                        userId: 'attendee1',
-                        displayName: '参加確定者1',
-                        mention: '',
-                        iconUrl: modalRecruit.placeHold,
-                        joinedAt: new Date(),
-                    },
-                    {
-                        guildId: guildId,
-                        userId: 'attendee2',
-                        displayName: '参加確定者2',
-                        mention: '',
-                        iconUrl: modalRecruit.placeHold,
-                        joinedAt: new Date(),
-                    },
-                    {
-                        guildId: guildId,
-                        userId: 'attendee3',
-                        displayName: '参加確定者3',
-                        mention: '',
-                        iconUrl: modalRecruit.placeHold,
-                        joinedAt: new Date(),
-                    },
-                ];
+        // 既存のメンバーが3人未満の場合はダミーユーザーを作成
+        if (members.length < 3) {
+            const dummyUsers = [
+                {
+                    guildId: guildId,
+                    userId: 'attendee1',
+                    displayName: '参加確定者1',
+                    mention: '',
+                    iconUrl: modalRecruit.placeHold,
+                    joinedAt: new Date(),
+                },
+                {
+                    guildId: guildId,
+                    userId: 'attendee2',
+                    displayName: '参加確定者2',
+                    mention: '',
+                    iconUrl: modalRecruit.placeHold,
+                    joinedAt: new Date(),
+                },
+                {
+                    guildId: guildId,
+                    userId: 'attendee3',
+                    displayName: '参加確定者3',
+                    mention: '',
+                    iconUrl: modalRecruit.placeHold,
+                    joinedAt: new Date(),
+                },
+            ];
 
-                // 既存のダミーユーザーのuserIdを抽出
-                const existingUserIds = members.map((member) => member.userId);
+            // 既存のダミーユーザーのuserIdを抽出
+            const existingUserIds = members.map((member) => member.userId);
 
-                // 既に存在するダミーユーザーを除外
-                const usersToCreate = dummyUsers.filter(
-                    (user) => !existingUserIds.includes(user.userId),
-                );
+            // 既に存在するダミーユーザーを除外
+            const usersToCreate = dummyUsers.filter(
+                (user) => !existingUserIds.includes(user.userId),
+            );
 
-                // 新たに作成すべきダミーユーザーを追加
-                for (const user of usersToCreate) {
-                    await prisma.member.create({
-                        data: user,
-                    });
-                    logger.info(`dummy user created: ${user.userId}`);
-                }
+            // 新たに作成すべきダミーユーザーを追加
+            for (const user of usersToCreate) {
+                await prisma.member.create({
+                    data: user,
+                });
+                logger.info(`dummy user created: ${user.userId}`);
             }
-        } catch (error) {
-            await sendErrorLogs(logger, error);
         }
     }
 }

--- a/src/infra/db/repositories/message_count_service.ts
+++ b/src/infra/db/repositories/message_count_service.ts
@@ -1,39 +1,27 @@
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-const logger = log4js_obj.getLogger('database');
 
 export class MessageCountService {
     static async save(userId: string, count: number) {
-        try {
-            await prisma.messageCount.upsert({
-                where: {
-                    userId: userId,
-                },
-                update: {
-                    count: count,
-                },
-                create: {
-                    userId: userId,
-                    count: count,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.messageCount.upsert({
+            where: {
+                userId: userId,
+            },
+            update: {
+                count: count,
+            },
+            create: {
+                userId: userId,
+                count: count,
+            },
+        });
     }
 
     static async getMemberByUserId(userId: string) {
-        try {
-            const member = await prisma.messageCount.findUnique({
-                where: {
-                    userId: userId,
-                },
-            });
-            return member;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        const member = await prisma.messageCount.findUnique({
+            where: {
+                userId: userId,
+            },
+        });
+        return member;
     }
 }

--- a/src/infra/db/repositories/participant_service.ts
+++ b/src/infra/db/repositories/participant_service.ts
@@ -2,9 +2,6 @@ import { Member } from '@prisma/client';
 
 import { prisma } from '@/infra/db/prisma';
 import { RecruitService } from '@/infra/db/repositories/recruit_service';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-const logger = log4js_obj.getLogger('database');
 
 export type ParticipantMember = {
     member: Member;
@@ -20,30 +17,26 @@ export class ParticipantService {
         userType: number,
         joinedAt: Date,
     ) {
-        try {
-            await prisma.participant.upsert({
-                where: {
-                    guildId_messageId_userId: {
-                        guildId: guildId,
-                        messageId: messageId,
-                        userId: userId,
-                    },
-                },
-                update: {
-                    userType: userType,
-                    joinedAt: joinedAt,
-                },
-                create: {
+        await prisma.participant.upsert({
+            where: {
+                guildId_messageId_userId: {
                     guildId: guildId,
                     messageId: messageId,
                     userId: userId,
-                    userType: userType,
-                    joinedAt: joinedAt,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+            },
+            update: {
+                userType: userType,
+                joinedAt: joinedAt,
+            },
+            create: {
+                guildId: guildId,
+                messageId: messageId,
+                userId: userId,
+                userType: userType,
+                joinedAt: joinedAt,
+            },
+        });
     }
 
     static async registerParticipantFromMember(
@@ -52,73 +45,64 @@ export class ParticipantService {
         member: Member,
         userType: number,
     ) {
-        try {
-            await prisma.participant.upsert({
-                where: {
-                    guildId_messageId_userId: {
-                        guildId: guildId,
-                        messageId: messageId,
-                        userId: member.userId,
-                    },
-                },
-                update: {
-                    userType: userType,
-                },
-                create: {
+        await prisma.participant.upsert({
+            where: {
+                guildId_messageId_userId: {
                     guildId: guildId,
                     messageId: messageId,
                     userId: member.userId,
-                    userType: userType,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+            },
+            update: {
+                userType: userType,
+            },
+            create: {
+                guildId: guildId,
+                messageId: messageId,
+                userId: member.userId,
+                userType: userType,
+            },
+        });
     }
 
+    /**
+     * 参加者を削除する。
+     *
+     * キャンセルボタンの二重クリックなどで対象行が既に無いのは正常系のため、
+     * 0件マッチで throw しない deleteMany を使う。
+     */
     static async deleteParticipant(guildId: string, messageId: string, userId: string) {
-        try {
-            await prisma.participant.delete({
-                where: {
-                    guildId_messageId_userId: {
-                        guildId: guildId,
-                        messageId: messageId,
-                        userId: userId,
-                    },
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.participant.deleteMany({
+            where: {
+                guildId: guildId,
+                messageId: messageId,
+                userId: userId,
+            },
+        });
     }
 
     static async deleteAllParticipant(guildId: string, messageId: string) {
-        try {
-            await prisma.participant.deleteMany({
-                where: {
-                    guildId: guildId,
-                    messageId: messageId,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.participant.deleteMany({
+            where: {
+                guildId: guildId,
+                messageId: messageId,
+            },
+        });
     }
 
     static async deleteUnuseParticipant() {
-        try {
-            const messageIdList = await RecruitService.getAllMessageId();
+        // getAllMessageId() が DB エラー時に throw することで、ここに到達しない。
+        // 空配列は「募集が1件も存在しない」という正当な状態のみを意味する
+        // （notIn: [] は全行にマッチするため、DBエラーを握り潰してはならない）。
+        const messageIdList = await RecruitService.getAllMessageId();
 
-            await prisma.participant.deleteMany({
-                where: {
-                    messageId: {
-                        notIn: messageIdList,
-                    },
+        await prisma.participant.deleteMany({
+            where: {
+                messageId: {
+                    notIn: messageIdList,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+            },
+        });
     }
 
     static async getParticipant(
@@ -126,59 +110,49 @@ export class ParticipantService {
         messageId: string,
         userId: string,
     ): Promise<ParticipantMember | null> {
-        try {
-            const participant = await prisma.participant.findUnique({
-                where: {
-                    guildId_messageId_userId: {
-                        guildId: guildId,
-                        messageId: messageId,
-                        userId: userId,
-                    },
+        const participant = await prisma.participant.findUnique({
+            where: {
+                guildId_messageId_userId: {
+                    guildId: guildId,
+                    messageId: messageId,
+                    userId: userId,
                 },
-                select: {
-                    userId: true,
-                    userType: true,
-                    joinedAt: true,
-                    member: true,
-                },
-            });
-            return participant;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+            select: {
+                userId: true,
+                userType: true,
+                joinedAt: true,
+                member: true,
+            },
+        });
+        return participant;
     }
 
     static async getAllParticipants(
         guildId: string,
         messageId: string,
     ): Promise<ParticipantMember[]> {
-        try {
-            const participants = await prisma.participant.findMany({
-                where: {
-                    guildId: guildId,
-                    messageId: messageId,
+        const participants = await prisma.participant.findMany({
+            where: {
+                guildId: guildId,
+                messageId: messageId,
+            },
+            select: {
+                userId: true,
+                userType: true,
+                joinedAt: true,
+                member: true,
+            },
+            orderBy: [
+                {
+                    userType: 'asc',
                 },
-                select: {
-                    userId: true,
-                    userType: true,
-                    joinedAt: true,
-                    member: true,
+                {
+                    joinedAt: 'asc',
                 },
-                orderBy: [
-                    {
-                        userType: 'asc',
-                    },
-                    {
-                        joinedAt: 'asc',
-                    },
-                ],
-            });
+            ],
+        });
 
-            return participants;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        return participants;
     }
 }

--- a/src/infra/db/repositories/reaction_service.ts
+++ b/src/infra/db/repositories/reaction_service.ts
@@ -1,61 +1,45 @@
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-const logger = log4js_obj.getLogger('database');
 
 export class ReactionService {
     static async save(emojiId: string, emojiName: string, count: number) {
-        try {
-            await prisma.reaction.upsert({
-                where: {
-                    emojiId_emojiName: {
-                        emojiId: emojiId,
-                        emojiName: emojiName,
-                    },
-                },
-                update: {
-                    count: count,
-                },
-                create: {
+        await prisma.reaction.upsert({
+            where: {
+                emojiId_emojiName: {
                     emojiId: emojiId,
                     emojiName: emojiName,
-                    count: count,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+            },
+            update: {
+                count: count,
+            },
+            create: {
+                emojiId: emojiId,
+                emojiName: emojiName,
+                count: count,
+            },
+        });
     }
 
     static async update(reactionSeq: number, count: number) {
-        try {
-            await prisma.reaction.update({
-                where: {
-                    reactionSeq: reactionSeq,
-                },
-                data: {
-                    count: count,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.reaction.updateMany({
+            where: {
+                reactionSeq: reactionSeq,
+            },
+            data: {
+                count: count,
+            },
+        });
     }
 
     static async getTotalReactionByEmoji(emojiId: string, emojiName: string) {
-        try {
-            const result = await prisma.reaction.findUnique({
-                where: {
-                    emojiId_emojiName: {
-                        emojiId: emojiId,
-                        emojiName: emojiName,
-                    },
+        const result = await prisma.reaction.findUnique({
+            where: {
+                emojiId_emojiName: {
+                    emojiId: emojiId,
+                    emojiName: emojiName,
                 },
-            });
-            return result;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+        });
+        return result;
     }
 }

--- a/src/infra/db/repositories/recruit_count_service.ts
+++ b/src/infra/db/repositories/recruit_count_service.ts
@@ -1,60 +1,44 @@
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-const logger = log4js_obj.getLogger('database');
 
 export class RecruitCountService {
     static async saveRecruitCount(userId: string, count: number) {
-        try {
-            await prisma.recruitCount.upsert({
-                where: {
-                    userId: userId,
-                },
-                update: {
-                    recruitCount: count,
-                },
-                create: {
-                    userId: userId,
-                    recruitCount: count,
-                    joinCount: 0,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.recruitCount.upsert({
+            where: {
+                userId: userId,
+            },
+            update: {
+                recruitCount: count,
+            },
+            create: {
+                userId: userId,
+                recruitCount: count,
+                joinCount: 0,
+            },
+        });
     }
 
     static async saveJoinCount(userId: string, count: number) {
-        try {
-            await prisma.recruitCount.upsert({
-                where: {
-                    userId: userId,
-                },
-                update: {
-                    joinCount: count,
-                },
-                create: {
-                    userId: userId,
-                    recruitCount: 0,
-                    joinCount: count,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.recruitCount.upsert({
+            where: {
+                userId: userId,
+            },
+            update: {
+                joinCount: count,
+            },
+            create: {
+                userId: userId,
+                recruitCount: 0,
+                joinCount: count,
+            },
+        });
     }
 
     static async getCountByUserId(userId: string) {
-        try {
-            const counter = await prisma.recruitCount.findUnique({
-                where: {
-                    userId: userId,
-                },
-            });
-            return counter;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        const counter = await prisma.recruitCount.findUnique({
+            where: {
+                userId: userId,
+            },
+        });
+        return counter;
     }
 }

--- a/src/infra/db/repositories/recruit_service.ts
+++ b/src/infra/db/repositories/recruit_service.ts
@@ -1,8 +1,5 @@
 import { ObjectValueList } from '@/config/constants/constant_common';
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-const logger = log4js_obj.getLogger('database');
 
 export const RecruitType = {
     None: 0,
@@ -38,172 +35,126 @@ export class RecruitService {
         closeAt?: Date | null,
         buttonMessageId?: string | null,
     ) {
-        try {
-            await prisma.recruit.create({
-                data: {
-                    guildId: guildId,
-                    channelId: channelId,
-                    messageId: messageId,
-                    authorId: authorId,
-                    recruitNum: recruitNum,
-                    condition: condition,
-                    vcName: vcName,
-                    eventId: eventId,
-                    recruitType: recruitType,
-                    option: option,
-                    closeAt: closeAt,
-                    buttonMessageId: buttonMessageId,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.recruit.create({
+            data: {
+                guildId: guildId,
+                channelId: channelId,
+                messageId: messageId,
+                authorId: authorId,
+                recruitNum: recruitNum,
+                condition: condition,
+                vcName: vcName,
+                eventId: eventId,
+                recruitType: recruitType,
+                option: option,
+                closeAt: closeAt,
+                buttonMessageId: buttonMessageId,
+            },
+        });
     }
 
     /** 自動締切の期限を過ぎた募集を返す。 */
     static async getExpiredRecruits(now: Date) {
-        try {
-            return await prisma.recruit.findMany({
-                where: {
-                    closeAt: { not: null, lte: now },
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        return await prisma.recruit.findMany({
+            where: {
+                closeAt: { not: null, lte: now },
+            },
+        });
     }
 
+    /**
+     * 募集を削除する。
+     *
+     * 〆ボタン・自動締切ジョブ・キャンセル・sticky の掃除が競合して
+     * 二重削除になるのは正常系のため、0件マッチで throw しない deleteMany を使う。
+     */
     static async deleteRecruit(guildId: string, messageId: string) {
-        try {
-            await prisma.recruit.delete({
-                where: {
-                    guildId_messageId: {
-                        guildId: guildId,
-                        messageId: messageId,
-                    },
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.recruit.deleteMany({
+            where: {
+                guildId: guildId,
+                messageId: messageId,
+            },
+        });
     }
 
     static async updateRecruitNum(guildId: string, messageId: string, recruitNum: number) {
-        try {
-            await prisma.recruit.update({
-                where: {
-                    guildId_messageId: {
-                        guildId: guildId,
-                        messageId: messageId,
-                    },
-                },
-                data: {
-                    recruitNum: recruitNum,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.recruit.updateMany({
+            where: {
+                guildId: guildId,
+                messageId: messageId,
+            },
+            data: {
+                recruitNum: recruitNum,
+            },
+        });
     }
 
     static async updateCondition(guildId: string, messageId: string, condition: string) {
-        try {
-            await prisma.recruit.update({
-                where: {
-                    guildId_messageId: {
-                        guildId: guildId,
-                        messageId: messageId,
-                    },
-                },
-                data: {
-                    condition: condition,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.recruit.updateMany({
+            where: {
+                guildId: guildId,
+                messageId: messageId,
+            },
+            data: {
+                condition: condition,
+            },
+        });
     }
 
     static async getRecruit(guildId: string, messageId: string) {
-        try {
-            const recruit = await prisma.recruit.findUnique({
-                where: {
-                    guildId_messageId: {
-                        guildId: guildId,
-                        messageId: messageId,
-                    },
+        const recruit = await prisma.recruit.findUnique({
+            where: {
+                guildId_messageId: {
+                    guildId: guildId,
+                    messageId: messageId,
                 },
-            });
-            return recruit;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+        });
+        return recruit;
     }
 
     static async getRecruitByEventId(guildId: string, eventId: string) {
-        try {
-            const recruit = await prisma.recruit.findFirst({
-                where: {
-                    guildId: guildId,
-                    eventId: eventId,
-                },
-            });
-            return recruit;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        const recruit = await prisma.recruit.findFirst({
+            where: {
+                guildId: guildId,
+                eventId: eventId,
+            },
+        });
+        return recruit;
     }
 
     static async getRecruitsByRecruitType(guildId: string, recruitType: number) {
-        try {
-            const recruits = await prisma.recruit.findMany({
-                where: {
-                    guildId: guildId,
-                    recruitType: recruitType,
-                },
-            });
-            return recruits;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        const recruits = await prisma.recruit.findMany({
+            where: {
+                guildId: guildId,
+                recruitType: recruitType,
+            },
+        });
+        return recruits;
     }
 
     static async getRecruitsByChannelId(guildId: string, channelId: string) {
-        try {
-            const recruits = await prisma.recruit.findMany({
-                where: {
-                    guildId: guildId,
-                    channelId: channelId,
-                },
-            });
-            return recruits;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        const recruits = await prisma.recruit.findMany({
+            where: {
+                guildId: guildId,
+                channelId: channelId,
+            },
+        });
+        return recruits;
     }
 
     static async getAllMessageId() {
-        try {
-            const recruits = await prisma.recruit.findMany({
-                select: {
-                    messageId: true,
-                },
-                distinct: ['messageId'],
-            });
+        const recruits = await prisma.recruit.findMany({
+            select: {
+                messageId: true,
+            },
+            distinct: ['messageId'],
+        });
 
-            const result = recruits.map((recruit) => {
-                return recruit.messageId;
-            });
+        const result = recruits.map((recruit) => {
+            return recruit.messageId;
+        });
 
-            return result;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        return result;
     }
 }

--- a/src/infra/db/repositories/role_service.ts
+++ b/src/infra/db/repositories/role_service.ts
@@ -1,10 +1,6 @@
 import { ColorResolvable } from 'discord.js';
 
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-
-const logger = log4js_obj.getLogger('database');
 
 export class RoleService {
     static async save(
@@ -15,102 +11,71 @@ export class RoleService {
         color: ColorResolvable,
         position: number,
     ) {
-        try {
-            return await prisma.role.upsert({
-                where: {
-                    guildId_roleId: {
-                        guildId: guildId,
-                        roleId: roleId,
-                    },
-                },
-                update: {
-                    name: roleName,
-                    mention: `<@&${roleId}>`,
-                    memberCount: memberCount,
-                    hexColor: color.toString(),
-                    position: position,
-                },
-                create: {
+        return await prisma.role.upsert({
+            where: {
+                guildId_roleId: {
                     guildId: guildId,
                     roleId: roleId,
-                    name: roleName,
-                    mention: `<@&${roleId}>`,
-                    memberCount: memberCount,
-                    hexColor: color.toString(),
-                    position: position,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+            update: {
+                name: roleName,
+                mention: `<@&${roleId}>`,
+                memberCount: memberCount,
+                hexColor: color.toString(),
+                position: position,
+            },
+            create: {
+                guildId: guildId,
+                roleId: roleId,
+                name: roleName,
+                mention: `<@&${roleId}>`,
+                memberCount: memberCount,
+                hexColor: color.toString(),
+                position: position,
+            },
+        });
     }
 
-    static async delete(guildId: string, roleId: string) {
-        try {
-            return await prisma.role.delete({
-                where: {
-                    guildId_roleId: {
-                        guildId: guildId,
-                        roleId: roleId,
-                    },
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+    // delete() は対象行が無いと P2025 で throw するため、冪等性を保つために deleteMany を使う。
+    static async delete(guildId: string, roleId: string): Promise<void> {
+        await prisma.role.deleteMany({
+            where: {
+                guildId: guildId,
+                roleId: roleId,
+            },
+        });
     }
 
     static async getRole(guildId: string, roleId: string) {
-        try {
-            return await prisma.role.findUnique({
-                where: {
-                    guildId_roleId: {
-                        guildId: guildId,
-                        roleId: roleId,
-                    },
+        return await prisma.role.findUnique({
+            where: {
+                guildId_roleId: {
+                    guildId: guildId,
+                    roleId: roleId,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+        });
     }
 
     static async searchRole(guildId: string, roleName: string) {
-        try {
-            return await prisma.role.findFirst({
-                where: {
-                    guildId: guildId,
-                    name: roleName,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        return await prisma.role.findFirst({
+            where: {
+                guildId: guildId,
+                name: roleName,
+            },
+        });
     }
 
     static async getAllGuildRoles(guildId: string) {
-        try {
-            return await prisma.role.findMany({
-                where: {
-                    guildId: guildId,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        return await prisma.role.findMany({
+            where: {
+                guildId: guildId,
+            },
+        });
     }
 
     static async getAllRoles() {
-        try {
-            return await prisma.role.findMany();
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        return await prisma.role.findMany();
     }
 }

--- a/src/infra/db/repositories/sticky_service.ts
+++ b/src/infra/db/repositories/sticky_service.ts
@@ -1,7 +1,4 @@
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-const logger = log4js_obj.getLogger('database');
 
 export class StickyService {
     static async registerMessageId(
@@ -10,48 +7,39 @@ export class StickyService {
         key: string,
         messageId: string,
     ) {
-        try {
-            await prisma.sticky.upsert({
-                where: {
-                    guildId_channelId_key: {
-                        guildId: guildId,
-                        channelId: channelId,
-                        key: key,
-                    },
-                },
-                update: {
-                    messageId: messageId,
-                },
-                create: {
+        await prisma.sticky.upsert({
+            where: {
+                guildId_channelId_key: {
                     guildId: guildId,
                     channelId: channelId,
                     key: key,
-                    messageId: messageId,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+            },
+            update: {
+                messageId: messageId,
+            },
+            create: {
+                guildId: guildId,
+                channelId: channelId,
+                key: key,
+                messageId: messageId,
+            },
+        });
     }
 
     static async getMessageId(guildId: string, channelId: string, key: string) {
-        try {
-            const sticky = await prisma.sticky.findUnique({
-                where: {
-                    guildId_channelId_key: {
-                        guildId: guildId,
-                        channelId: channelId,
-                        key: key,
-                    },
+        const sticky = await prisma.sticky.findUnique({
+            where: {
+                guildId_channelId_key: {
+                    guildId: guildId,
+                    channelId: channelId,
+                    key: key,
                 },
-            });
-            if (sticky) {
-                return sticky.messageId;
-            } else {
-                return null;
-            }
-        } catch (error) {
-            await sendErrorLogs(logger, error);
+            },
+        });
+        if (sticky) {
+            return sticky.messageId;
+        } else {
             return null;
         }
     }

--- a/src/infra/db/repositories/team_divider_service.ts
+++ b/src/infra/db/repositories/team_divider_service.ts
@@ -1,9 +1,4 @@
-import { TeamDivider } from '@prisma/client';
-
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-const logger = log4js_obj.getLogger('database');
 
 export type TeamMember = {
     messageId: string;
@@ -33,51 +28,43 @@ export class TeamDividerService {
         forceSpectate: boolean,
         hideWin: boolean,
     ) {
-        try {
-            await prisma.teamDivider.upsert({
-                where: {
-                    messageId_memberId_matchNum: {
-                        messageId: messageId,
-                        memberId: memberId,
-                        matchNum: matchNum,
-                    },
-                },
-                create: {
+        await prisma.teamDivider.upsert({
+            where: {
+                messageId_memberId_matchNum: {
                     messageId: messageId,
                     memberId: memberId,
-                    memberName: memberName,
-                    team: team,
                     matchNum: matchNum,
-                    joinedMatchCount: joinedMatchCount,
-                    win: win,
-                    forceSpectate: forceSpectate,
-                    hideWin: hideWin,
                 },
-                update: {
-                    memberName: memberName,
-                    team: team,
-                    joinedMatchCount: joinedMatchCount,
-                    win: win,
-                    forceSpectate: forceSpectate,
-                    hideWin: hideWin,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+            },
+            create: {
+                messageId: messageId,
+                memberId: memberId,
+                memberName: memberName,
+                team: team,
+                matchNum: matchNum,
+                joinedMatchCount: joinedMatchCount,
+                win: win,
+                forceSpectate: forceSpectate,
+                hideWin: hideWin,
+            },
+            update: {
+                memberName: memberName,
+                team: team,
+                joinedMatchCount: joinedMatchCount,
+                win: win,
+                forceSpectate: forceSpectate,
+                hideWin: hideWin,
+            },
+        });
     }
 
     static async deleteMemberFromDB(messageId: string, memberId: string) {
-        try {
-            await prisma.teamDivider.deleteMany({
-                where: {
-                    messageId: messageId,
-                    memberId: memberId,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.teamDivider.deleteMany({
+            where: {
+                messageId: messageId,
+                memberId: memberId,
+            },
+        });
     }
 
     /**
@@ -86,26 +73,21 @@ export class TeamDividerService {
      * @returns 表示用メッセージ
      */
     static async registeredMembersStrings(messageId: string) {
-        try {
-            const members = await prisma.teamDivider.findMany({
-                where: {
-                    messageId: messageId,
-                    matchNum: 0,
-                },
-                orderBy: {
-                    createdAt: 'asc',
-                },
-            });
+        const members = await prisma.teamDivider.findMany({
+            where: {
+                messageId: messageId,
+                matchNum: 0,
+            },
+            orderBy: {
+                createdAt: 'asc',
+            },
+        });
 
-            let usersString = '';
-            for (const member of members) {
-                usersString = usersString + `\n${member.memberName}`;
-            }
-            return { text: usersString, memberCount: members.length };
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return { text: '', memberCount: 0 };
+        let usersString = '';
+        for (const member of members) {
+            usersString = usersString + `\n${member.memberName}`;
         }
+        return { text: usersString, memberCount: members.length };
     }
 
     /**
@@ -116,21 +98,16 @@ export class TeamDividerService {
      * @returns 取得結果
      */
     static async selectMemberFromDB(messageId: string, matchNum: number, memberId: string) {
-        try {
-            const member = await prisma.teamDivider.findUnique({
-                where: {
-                    messageId_memberId_matchNum: {
-                        messageId: messageId,
-                        memberId: memberId,
-                        matchNum: matchNum,
-                    },
+        const member = await prisma.teamDivider.findUnique({
+            where: {
+                messageId_memberId_matchNum: {
+                    messageId: messageId,
+                    memberId: memberId,
+                    matchNum: matchNum,
                 },
-            });
-            return member;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+        });
+        return member;
     }
 
     /**
@@ -140,18 +117,13 @@ export class TeamDividerService {
      * @returns 取得結果
      */
     static async selectAllMemberFromDB(messageId: string, matchNum: number) {
-        try {
-            const members = await prisma.teamDivider.findMany({
-                where: {
-                    messageId: messageId,
-                    matchNum: matchNum,
-                },
-            });
-            return members;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        const members = await prisma.teamDivider.findMany({
+            where: {
+                messageId: messageId,
+                matchNum: matchNum,
+            },
+        });
+        return members;
     }
 
     /**
@@ -159,15 +131,11 @@ export class TeamDividerService {
      * @param messageId 登録メッセージID
      */
     static async deleteAllMemberFromDB(messageId: string) {
-        try {
-            await prisma.teamDivider.deleteMany({
-                where: {
-                    messageId: messageId,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.teamDivider.deleteMany({
+            where: {
+                messageId: messageId,
+            },
+        });
     }
 
     /**
@@ -178,20 +146,16 @@ export class TeamDividerService {
      * @param team 該当チーム(alfa=0, bravo=1, 観戦=2)
      */
     static async setTeam(messageId: string, memberId: string, matchNum: number, team: number) {
-        try {
-            await prisma.teamDivider.updateMany({
-                where: {
-                    messageId: messageId,
-                    memberId: memberId,
-                    matchNum: matchNum,
-                },
-                data: {
-                    team: team,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.teamDivider.updateMany({
+            where: {
+                messageId: messageId,
+                memberId: memberId,
+                matchNum: matchNum,
+            },
+            data: {
+                team: team,
+            },
+        });
     }
 
     /**
@@ -202,20 +166,16 @@ export class TeamDividerService {
      * @param count 試合参加回数
      */
     static async setCount(messageId: string, memberId: string, matchNum: number, count: number) {
-        try {
-            await prisma.teamDivider.updateMany({
-                where: {
-                    messageId: messageId,
-                    memberId: memberId,
-                    matchNum: matchNum,
-                },
-                data: {
-                    joinedMatchCount: count,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.teamDivider.updateMany({
+            where: {
+                messageId: messageId,
+                memberId: memberId,
+                matchNum: matchNum,
+            },
+            data: {
+                joinedMatchCount: count,
+            },
+        });
     }
 
     /**
@@ -226,20 +186,16 @@ export class TeamDividerService {
      * @param winCount 勝利数
      */
     static async setWin(messageId: string, memberId: string, matchNum: number, winCount: number) {
-        try {
-            await prisma.teamDivider.updateMany({
-                where: {
-                    messageId: messageId,
-                    memberId: memberId,
-                    matchNum: matchNum,
-                },
-                data: {
-                    win: winCount,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.teamDivider.updateMany({
+            where: {
+                messageId: messageId,
+                memberId: memberId,
+                matchNum: matchNum,
+            },
+            data: {
+                win: winCount,
+            },
+        });
     }
 
     /**
@@ -248,18 +204,14 @@ export class TeamDividerService {
      * @param flag true=隠す or false=表示
      */
     static async setHideWin(messageId: string, flag: boolean) {
-        try {
-            await prisma.teamDivider.updateMany({
-                where: {
-                    messageId: messageId,
-                },
-                data: {
-                    hideWin: flag,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.teamDivider.updateMany({
+            where: {
+                messageId: messageId,
+            },
+            data: {
+                hideWin: flag,
+            },
+        });
     }
 
     /**
@@ -275,20 +227,16 @@ export class TeamDividerService {
         matchNum: number,
         flag: boolean,
     ) {
-        try {
-            await prisma.teamDivider.updateMany({
-                where: {
-                    messageId: messageId,
-                    memberId: memberId,
-                    matchNum: matchNum,
-                },
-                data: {
-                    forceSpectate: flag,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.teamDivider.updateMany({
+            where: {
+                messageId: messageId,
+                memberId: memberId,
+                matchNum: matchNum,
+            },
+            data: {
+                forceSpectate: flag,
+            },
+        });
     }
 
     /**
@@ -303,18 +251,13 @@ export class TeamDividerService {
         matchNum: number,
         team: number,
     ): Promise<TeamMember[]> {
-        let members: TeamDivider[] = [];
-        try {
-            members = await prisma.teamDivider.findMany({
-                where: {
-                    messageId: messageId,
-                    matchNum: matchNum,
-                    team: team,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        const members = await prisma.teamDivider.findMany({
+            where: {
+                messageId: messageId,
+                matchNum: matchNum,
+                team: team,
+            },
+        });
 
         const result = members.map((member) => {
             let winRate = 0;
@@ -346,18 +289,13 @@ export class TeamDividerService {
      * @returns 取得結果
      */
     static async getForceSpectate(messageId: string, matchNum: number): Promise<TeamMember[]> {
-        let members: TeamDivider[] = [];
-        try {
-            members = await prisma.teamDivider.findMany({
-                where: {
-                    messageId: messageId,
-                    matchNum: matchNum,
-                    forceSpectate: true,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        const members = await prisma.teamDivider.findMany({
+            where: {
+                messageId: messageId,
+                matchNum: matchNum,
+                forceSpectate: true,
+            },
+        });
 
         const result = members.map((member) => {
             let winRate = 0;
@@ -394,22 +332,17 @@ export class TeamDividerService {
         matchNum: number,
         teamNum: number,
     ): Promise<TeamMember[]> {
-        let members: TeamDivider[] = [];
-        try {
-            members = await prisma.teamDivider.findMany({
-                where: {
-                    messageId: messageId,
-                    matchNum: matchNum,
-                    forceSpectate: false,
-                },
-                orderBy: {
-                    joinedMatchCount: 'asc',
-                },
-                take: teamNum * 2,
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        const members = await prisma.teamDivider.findMany({
+            where: {
+                messageId: messageId,
+                matchNum: matchNum,
+                forceSpectate: false,
+            },
+            orderBy: {
+                joinedMatchCount: 'asc',
+            },
+            take: teamNum * 2,
+        });
 
         const result = members.map((member) => {
             let winRate = 0;
@@ -440,15 +373,11 @@ export class TeamDividerService {
      * @param matchNum 該当試合数
      */
     static async deleteMatchingResult(messageId: string, matchNum: number) {
-        try {
-            await prisma.teamDivider.deleteMany({
-                where: {
-                    messageId: messageId,
-                    matchNum: matchNum,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.teamDivider.deleteMany({
+            where: {
+                messageId: messageId,
+                matchNum: matchNum,
+            },
+        });
     }
 }

--- a/src/infra/db/repositories/unique_channel_service.ts
+++ b/src/infra/db/repositories/unique_channel_service.ts
@@ -1,98 +1,75 @@
 import { ChannelKey, isChannelKey } from '@/config/constants/channel_key';
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
 import { notExists } from '@/shared/assert';
-
-const logger = log4js_obj.getLogger('database');
 
 export class UniqueChannelService {
     static async save(guildId: string, key: ChannelKey, channelId: string) {
-        try {
-            return await prisma.uniqueChannel.upsert({
-                where: {
-                    guildId_key: {
-                        guildId: guildId,
-                        key: key,
-                    },
-                },
-                update: {
-                    channelId: channelId,
-                },
-                create: {
+        return await prisma.uniqueChannel.upsert({
+            where: {
+                guildId_key: {
                     guildId: guildId,
-                    channelId: channelId,
                     key: key,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+            update: {
+                channelId: channelId,
+            },
+            create: {
+                guildId: guildId,
+                channelId: channelId,
+                key: key,
+            },
+        });
     }
 
     static async getChannelIdByKey(guildId: string, key: ChannelKey) {
-        try {
-            const result = await prisma.uniqueChannel.findUnique({
-                where: {
-                    guildId_key: {
-                        guildId: guildId,
-                        key: key,
-                    },
+        const result = await prisma.uniqueChannel.findUnique({
+            where: {
+                guildId_key: {
+                    guildId: guildId,
+                    key: key,
                 },
-            });
-            if (notExists(result)) return null;
-            return result.channelId;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+        });
+        if (notExists(result)) return null;
+        return result.channelId;
     }
 
     static async getAllUniqueChannels(guildId: string) {
-        try {
-            const results = await prisma.uniqueChannel.findMany({
-                where: {
-                    guildId: guildId,
-                },
-            });
+        const results = await prisma.uniqueChannel.findMany({
+            where: {
+                guildId: guildId,
+            },
+        });
 
-            // ChannelKeyの型を保証するために、新しく配列を作り直す
-            const filteredResults: { guildId: string; key: ChannelKey; channelId: string }[] = [];
+        // ChannelKeyの型を保証するために、新しく配列を作り直す
+        const filteredResults: { guildId: string; key: ChannelKey; channelId: string }[] = [];
 
-            for (const result of results) {
-                if (isChannelKey(result.key)) {
-                    // ChannelKeyの値が正しいかどうかのチェック
-                    filteredResults.push({
-                        guildId: result.guildId,
-                        key: result.key,
-                        channelId: result.channelId,
-                    });
-                } else {
-                    throw new Error(`Invalid ChannelKey: ${result.key}`);
-                }
+        for (const result of results) {
+            if (isChannelKey(result.key)) {
+                // ChannelKeyの値が正しいかどうかのチェック
+                filteredResults.push({
+                    guildId: result.guildId,
+                    key: result.key,
+                    channelId: result.channelId,
+                });
+            } else {
+                throw new Error(`Invalid ChannelKey: ${result.key}`);
             }
-
-            return filteredResults;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
         }
+
+        return filteredResults;
     }
 
-    static async delete(guildId: string, key: ChannelKey) {
-        try {
-            return await prisma.uniqueChannel.delete({
-                where: {
-                    guildId_key: {
-                        guildId: guildId,
-                        key: key,
-                    },
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+    // delete() は対象行が無いと P2025 で throw するため、冪等性を保つために deleteMany を使う。
+    // deleteMany は削除した行そのものを返さないので、削除できたかどうかを boolean で返す。
+    static async delete(guildId: string, key: ChannelKey): Promise<boolean> {
+        const result = await prisma.uniqueChannel.deleteMany({
+            where: {
+                guildId: guildId,
+                key: key,
+            },
+        });
+        return result.count > 0;
     }
 }

--- a/src/infra/db/repositories/unique_role_service.ts
+++ b/src/infra/db/repositories/unique_role_service.ts
@@ -1,98 +1,75 @@
 import { RoleKey, isRoleKey } from '@/config/constants/role_key';
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
 import { notExists } from '@/shared/assert';
-
-const logger = log4js_obj.getLogger('database');
 
 export class UniqueRoleService {
     static async save(guildId: string, key: RoleKey, roleId: string) {
-        try {
-            return await prisma.uniqueRole.upsert({
-                where: {
-                    guildId_key: {
-                        guildId: guildId,
-                        key: key,
-                    },
-                },
-                update: {
-                    roleId: roleId,
-                },
-                create: {
+        return await prisma.uniqueRole.upsert({
+            where: {
+                guildId_key: {
                     guildId: guildId,
-                    roleId: roleId,
                     key: key,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+            update: {
+                roleId: roleId,
+            },
+            create: {
+                guildId: guildId,
+                roleId: roleId,
+                key: key,
+            },
+        });
     }
 
     static async getRoleIdByKey(guildId: string, key: RoleKey) {
-        try {
-            const result = await prisma.uniqueRole.findUnique({
-                where: {
-                    guildId_key: {
-                        guildId: guildId,
-                        key: key,
-                    },
+        const result = await prisma.uniqueRole.findUnique({
+            where: {
+                guildId_key: {
+                    guildId: guildId,
+                    key: key,
                 },
-            });
-            if (notExists(result)) return null;
-            return result.roleId;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+        });
+        if (notExists(result)) return null;
+        return result.roleId;
     }
 
     static async getAllUniqueRoles(guildId: string) {
-        try {
-            const results = await prisma.uniqueRole.findMany({
-                where: {
-                    guildId: guildId,
-                },
-            });
+        const results = await prisma.uniqueRole.findMany({
+            where: {
+                guildId: guildId,
+            },
+        });
 
-            // RoleKeyの型を保証するために、新しく配列を作り直す
-            const filteredResults: { guildId: string; key: RoleKey; roleId: string }[] = [];
+        // RoleKeyの型を保証するために、新しく配列を作り直す
+        const filteredResults: { guildId: string; key: RoleKey; roleId: string }[] = [];
 
-            for (const result of results) {
-                if (isRoleKey(result.key)) {
-                    // RoleKeyの値が正しいかどうかのチェック
-                    filteredResults.push({
-                        guildId: result.guildId,
-                        key: result.key,
-                        roleId: result.roleId,
-                    });
-                } else {
-                    throw new Error(`Invalid RoleKey: ${result.key}`);
-                }
+        for (const result of results) {
+            if (isRoleKey(result.key)) {
+                // RoleKeyの値が正しいかどうかのチェック
+                filteredResults.push({
+                    guildId: result.guildId,
+                    key: result.key,
+                    roleId: result.roleId,
+                });
+            } else {
+                throw new Error(`Invalid RoleKey: ${result.key}`);
             }
-
-            return filteredResults;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
         }
+
+        return filteredResults;
     }
 
-    static async delete(guildId: string, key: RoleKey) {
-        try {
-            return await prisma.uniqueRole.delete({
-                where: {
-                    guildId_key: {
-                        guildId: guildId,
-                        key: key,
-                    },
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+    // delete() は対象行が無いと P2025 で throw するため、冪等性を保つために deleteMany を使う。
+    // deleteMany は削除した行そのものを返さないので、削除できたかどうかを boolean で返す。
+    static async delete(guildId: string, key: RoleKey): Promise<boolean> {
+        const result = await prisma.uniqueRole.deleteMany({
+            where: {
+                guildId: guildId,
+                key: key,
+            },
+        });
+        return result.count > 0;
     }
 }

--- a/src/infra/db/repositories/user_reaction_service.ts
+++ b/src/infra/db/repositories/user_reaction_service.ts
@@ -1,7 +1,4 @@
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-const logger = log4js_obj.getLogger('database');
 
 export class UserReactionService {
     static async save(
@@ -11,30 +8,26 @@ export class UserReactionService {
         year: string,
         count: number,
     ) {
-        try {
-            await prisma.userReaction.upsert({
-                where: {
-                    userId_reactionSeq_year_channelId: {
-                        userId: userId,
-                        reactionSeq: reactionSeq,
-                        channelId: channelId,
-                        year: year,
-                    },
-                },
-                update: {
-                    count: count,
-                },
-                create: {
+        await prisma.userReaction.upsert({
+            where: {
+                userId_reactionSeq_year_channelId: {
                     userId: userId,
                     reactionSeq: reactionSeq,
                     channelId: channelId,
                     year: year,
-                    count: count,
                 },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+            },
+            update: {
+                count: count,
+            },
+            create: {
+                userId: userId,
+                reactionSeq: reactionSeq,
+                channelId: channelId,
+                year: year,
+                count: count,
+            },
+        });
     }
 
     static async getReactionCountByPK(
@@ -43,49 +36,34 @@ export class UserReactionService {
         channelId: string,
         year: string,
     ) {
-        try {
-            const result = await prisma.userReaction.findUnique({
-                where: {
-                    userId_reactionSeq_year_channelId: {
-                        userId: userId,
-                        reactionSeq: reactionSeq,
-                        channelId: channelId,
-                        year: year,
-                    },
+        const result = await prisma.userReaction.findUnique({
+            where: {
+                userId_reactionSeq_year_channelId: {
+                    userId: userId,
+                    reactionSeq: reactionSeq,
+                    channelId: channelId,
+                    year: year,
                 },
-            });
-            return result;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+            },
+        });
+        return result;
     }
 
     static async getReactionCountByUserId(userId: string) {
-        try {
-            const result = await prisma.userReaction.findMany({
-                where: {
-                    userId: userId,
-                },
-            });
-            return result;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        const result = await prisma.userReaction.findMany({
+            where: {
+                userId: userId,
+            },
+        });
+        return result;
     }
 
     static async getReactionCountByReactionSeq(reactionSeq: number) {
-        try {
-            const result = await prisma.userReaction.findMany({
-                where: {
-                    reactionSeq: reactionSeq,
-                },
-            });
-            return result;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+        const result = await prisma.userReaction.findMany({
+            where: {
+                reactionSeq: reactionSeq,
+            },
+        });
+        return result;
     }
 }

--- a/src/infra/db/repositories/voice_count_service.ts
+++ b/src/infra/db/repositories/voice_count_service.ts
@@ -1,75 +1,54 @@
 import { prisma } from '@/infra/db/prisma';
-import { log4js_obj } from '@/infra/logging/log4js';
-import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-const logger = log4js_obj.getLogger('database');
 
 export class VoiceCountService {
     static async saveVoiceCount(userId: string, totalSec: number) {
-        try {
-            await prisma.voiceCount.upsert({
-                where: {
-                    userId: userId,
-                },
-                update: {
-                    totalSec: totalSec,
-                },
-                create: {
-                    userId: userId,
-                    totalSec: totalSec,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.voiceCount.upsert({
+            where: {
+                userId: userId,
+            },
+            update: {
+                totalSec: totalSec,
+            },
+            create: {
+                userId: userId,
+                totalSec: totalSec,
+            },
+        });
     }
 
     static async saveStartTime(userId: string, startTime: Date | null) {
-        try {
-            await prisma.voiceCount.upsert({
-                where: {
-                    userId: userId,
-                },
-                update: {
-                    startTime: startTime,
-                },
-                create: {
-                    userId: userId,
-                    startTime: startTime,
-                    totalSec: 0,
-                },
-            });
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-        }
+        await prisma.voiceCount.upsert({
+            where: {
+                userId: userId,
+            },
+            update: {
+                startTime: startTime,
+            },
+            create: {
+                userId: userId,
+                startTime: startTime,
+                totalSec: 0,
+            },
+        });
     }
 
     static async getCountByUserId(userId: string) {
-        try {
-            const counter = await prisma.voiceCount.findUnique({
-                where: {
-                    userId: userId,
-                },
-            });
-            return counter;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return null;
-        }
+        const counter = await prisma.voiceCount.findUnique({
+            where: {
+                userId: userId,
+            },
+        });
+        return counter;
     }
 
     static async getInCallCount() {
-        try {
-            const counter = await prisma.voiceCount.findMany({
-                where: {
-                    startTime: {
-                        not: null,
-                    },
+        const counter = await prisma.voiceCount.findMany({
+            where: {
+                startTime: {
+                    not: null,
                 },
-            });
-            return counter;
-        } catch (error) {
-            await sendErrorLogs(logger, error);
-            return [];
-        }
+            },
+        });
+        return counter;
     }
 }

--- a/src/shared/discord_helpers/member_manager.ts
+++ b/src/shared/discord_helpers/member_manager.ts
@@ -5,7 +5,7 @@ import { Guild, GuildMember, Interaction, Message } from 'discord.js';
 import { MemberService } from '@/infra/db/repositories/member_service';
 import { log4js_obj } from '@/infra/logging/log4js';
 import { sendErrorLogs } from '@/infra/logging/send_error_logs';
-import { assertExistCheck, exists, notExists } from '@/shared/assert';
+import { assertExistCheck, notExists } from '@/shared/assert';
 import { getGuildByInteraction } from '@/shared/discord_helpers/guild_manager';
 
 const logger = log4js_obj.getLogger('MemberManager');
@@ -71,19 +71,12 @@ export async function searchDBMemberById(guild: Guild, userId: string): Promise<
 
         assertExistCheck(guildMember.joinedAt, 'joinedAt');
 
+        // 登録に失敗すれば throw され、境界で通知される
         const newMember = await MemberService.saveMemberFromGuildMember(guildMember);
 
-        if (exists(newMember)) {
-            logger.warn(
-                `member missing (ikabu DB) => member was registered successfully.\n [guildId: ${guild.id}, userId: ${userId}]`,
-            );
-        } else {
-            await sendErrorLogs(
-                logger,
-                `member missing (ikabu DB) => Failed to register.\n [guildId: ${guild.id}, userId: ${userId}]`,
-            );
-            return null;
-        }
+        logger.warn(
+            `member missing (ikabu DB) => member was registered successfully.\n [guildId: ${guild.id}, userId: ${userId}]`,
+        );
 
         return newMember;
     } else if (!(await isUrlValid(member.iconUrl))) {
@@ -97,19 +90,12 @@ export async function searchDBMemberById(guild: Guild, userId: string): Promise<
             return null;
         }
 
+        // 更新に失敗すれば throw され、境界で通知される
         const newMember = await MemberService.saveMemberFromGuildMember(guildMember);
 
-        if (exists(newMember)) {
-            logger.warn(
-                `member Icon invalid => Icon URL was updated successfully.\n [guildId: ${guild.id}, userId: ${userId}]`,
-            );
-        } else {
-            await sendErrorLogs(
-                logger,
-                `member Icon invalid => Failed to update Icon URL.\n [guildId: ${guild.id}, userId: ${userId}]`,
-            );
-            return null;
-        }
+        logger.warn(
+            `member Icon invalid => Icon URL was updated successfully.\n [guildId: ${guild.id}, userId: ${userId}]`,
+        );
 
         return newMember;
     } else {

--- a/test/infra/db/services.test.ts
+++ b/test/infra/db/services.test.ts
@@ -1,22 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-    sendErrorLogs: vi.fn(),
     recruit: {
         findUnique: vi.fn(),
         findMany: vi.fn(),
         create: vi.fn(),
-        delete: vi.fn(),
-        update: vi.fn(),
+        deleteMany: vi.fn(),
+        updateMany: vi.fn(),
         findFirst: vi.fn(),
     },
     member: { findUnique: vi.fn(), findMany: vi.fn(), upsert: vi.fn() },
-    uniqueChannel: { findUnique: vi.fn(), findMany: vi.fn(), upsert: vi.fn(), delete: vi.fn() },
-    uniqueRole: { findUnique: vi.fn(), findMany: vi.fn(), upsert: vi.fn(), delete: vi.fn() },
+    uniqueChannel: { findUnique: vi.fn(), findMany: vi.fn(), upsert: vi.fn(), deleteMany: vi.fn() },
+    uniqueRole: { findUnique: vi.fn(), findMany: vi.fn(), upsert: vi.fn(), deleteMany: vi.fn() },
 }));
 
 vi.mock('@/infra/db/prisma', () => ({ prisma: mocks }));
-vi.mock('@/infra/logging/send_error_logs', () => ({ sendErrorLogs: mocks.sendErrorLogs }));
 
 import { ChannelKeySet } from '@/config/constants/channel_key';
 import { RoleKeySet } from '@/config/constants/role_key';
@@ -25,66 +23,82 @@ import { RecruitService } from '@/infra/db/repositories/recruit_service';
 import { UniqueChannelService } from '@/infra/db/repositories/unique_channel_service';
 import { UniqueRoleService } from '@/infra/db/repositories/unique_role_service';
 
-describe('DBサービスの例外安全網', () => {
+describe('DBサービスは失敗を呼び出し側に伝える', () => {
     beforeEach(() => vi.clearAllMocks());
 
-    it('RecruitService は成功結果を返し、例外時はnullまたは空配列を返す', async () => {
-        const recruit = { guildId: 'g', messageId: 'm' };
-        mocks.recruit.findUnique.mockResolvedValue(recruit);
-        await expect(RecruitService.getRecruit('g', 'm')).resolves.toBe(recruit);
-        mocks.recruit.findMany.mockResolvedValue([recruit]);
-        await expect(RecruitService.getRecruitsByChannelId('g', 'c')).resolves.toEqual([recruit]);
+    // 以前は全メソッドが try/catch でエラーをログに出すだけで正常終了しており、
+    // 「募集がDBに入っていないのに Discord にはメッセージだけ送信される」といった
+    // データ不整合が、表面上は成功して見えるまま起きていた。
+    it('DB障害は握り潰さず throw する', async () => {
         mocks.recruit.findUnique.mockRejectedValueOnce(new Error('db'));
-        await expect(RecruitService.getRecruit('g', 'm')).resolves.toBeNull();
+        await expect(RecruitService.getRecruit('g', 'm')).rejects.toThrow('db');
+
         mocks.recruit.findMany.mockRejectedValueOnce(new Error('db'));
-        await expect(RecruitService.getRecruitsByChannelId('g', 'c')).resolves.toEqual([]);
-        expect(mocks.sendErrorLogs).toHaveBeenCalledTimes(2);
-    });
+        await expect(RecruitService.getRecruitsByChannelId('g', 'c')).rejects.toThrow('db');
 
-    it('MemberService は成功結果を返し、例外時はnullまたは空配列を返す', async () => {
-        const member = { guildId: 'g', userId: 'u' };
-        mocks.member.findUnique.mockResolvedValue(member);
-        await expect(MemberService.getMemberByUserId('g', 'u')).resolves.toBe(member as never);
-        mocks.member.findMany.mockResolvedValue([{ guildId: 'g1' }, { guildId: 'g2' }]);
-        await expect(MemberService.getMemberGuildIdsByUserId('u')).resolves.toEqual(['g1', 'g2']);
-        mocks.member.findUnique.mockRejectedValueOnce(new Error('db'));
-        await expect(MemberService.getMemberByUserId('g', 'u')).resolves.toBeNull();
-        mocks.member.findMany.mockRejectedValueOnce(new Error('db'));
-        await expect(MemberService.getMemberGuildIdsByUserId('u')).resolves.toEqual([]);
-    });
-
-    it('UniqueChannelService は値を取り出し、例外時はnullまたは空配列を返す', async () => {
-        mocks.uniqueChannel.findUnique.mockResolvedValue({ channelId: 'c' });
+        mocks.recruit.create.mockRejectedValueOnce(new Error('db'));
         await expect(
-            UniqueChannelService.getChannelIdByKey('g', ChannelKeySet.Lobby.key),
-        ).resolves.toBe('c');
-        mocks.uniqueChannel.findMany.mockResolvedValue([
-            { guildId: 'g', key: ChannelKeySet.Lobby.key, channelId: 'c' },
-        ]);
-        await expect(UniqueChannelService.getAllUniqueChannels('g')).resolves.toHaveLength(1);
+            RecruitService.registerRecruit('g', 'c', 'm', 'u', 4, 'なし', null, null, 2),
+        ).rejects.toThrow('db');
+
+        mocks.member.upsert.mockRejectedValueOnce(new Error('db'));
+        await expect(
+            MemberService.saveMember('g', 'u', 'name', 'icon', new Date(), false),
+        ).rejects.toThrow('db');
+
         mocks.uniqueChannel.findUnique.mockRejectedValueOnce(new Error('db'));
         await expect(
             UniqueChannelService.getChannelIdByKey('g', ChannelKeySet.Lobby.key),
-        ).resolves.toBeNull();
-        mocks.uniqueChannel.findMany.mockRejectedValueOnce(new Error('db'));
-        await expect(UniqueChannelService.getAllUniqueChannels('g')).resolves.toEqual([]);
+        ).rejects.toThrow('db');
     });
 
-    it('UniqueRoleService は値を取り出し、例外時はnullまたは空配列を返す', async () => {
+    it('正常時は結果を返す', async () => {
+        const recruit = { guildId: 'g', messageId: 'm' };
+        mocks.recruit.findUnique.mockResolvedValue(recruit);
+        await expect(RecruitService.getRecruit('g', 'm')).resolves.toBe(recruit);
+
+        mocks.recruit.findMany.mockResolvedValue([recruit]);
+        await expect(RecruitService.getRecruitsByChannelId('g', 'c')).resolves.toEqual([recruit]);
+
         mocks.uniqueRole.findUnique.mockResolvedValue({ roleId: 'r' });
         await expect(UniqueRoleService.getRoleIdByKey('g', RoleKeySet.Developer.key)).resolves.toBe(
             'r',
         );
-        mocks.uniqueRole.findMany.mockResolvedValue([
-            { guildId: 'g', key: RoleKeySet.Developer.key, roleId: 'r' },
-        ]);
-        await expect(UniqueRoleService.getAllUniqueRoles('g')).resolves.toHaveLength(1);
-        mocks.uniqueRole.findUnique.mockRejectedValueOnce(new Error('db'));
+    });
+
+    it('レコードが無い場合は null を返す(エラーではない)', async () => {
+        mocks.uniqueChannel.findUnique.mockResolvedValue(null);
+        await expect(
+            UniqueChannelService.getChannelIdByKey('g', ChannelKeySet.Lobby.key),
+        ).resolves.toBeNull();
+
+        mocks.uniqueRole.findUnique.mockResolvedValue(null);
         await expect(
             UniqueRoleService.getRoleIdByKey('g', RoleKeySet.Developer.key),
         ).resolves.toBeNull();
-        mocks.uniqueRole.findMany.mockRejectedValueOnce(new Error('db'));
-        await expect(UniqueRoleService.getAllUniqueRoles('g')).resolves.toEqual([]);
-        expect(mocks.sendErrorLogs).toHaveBeenCalledTimes(2);
+
+        mocks.member.findUnique.mockResolvedValue(null);
+        await expect(MemberService.getMemberByUserId('g', 'u')).resolves.toBeNull();
+    });
+
+    // 〆ボタンと自動締切ジョブが競合して二重削除になるのは正常系のため、
+    // 0件マッチで throw しない deleteMany を使っている。
+    it('募集の二重削除は正常系として扱う', async () => {
+        mocks.recruit.deleteMany.mockResolvedValue({ count: 0 });
+
+        await expect(RecruitService.deleteRecruit('g', 'm')).resolves.toBeUndefined();
+        expect(mocks.recruit.deleteMany).toHaveBeenCalledWith({
+            where: { guildId: 'g', messageId: 'm' },
+        });
+    });
+
+    it('ユニークチャンネルの解除は、解除できたかを boolean で返す', async () => {
+        mocks.uniqueChannel.deleteMany.mockResolvedValue({ count: 1 });
+        await expect(UniqueChannelService.delete('g', ChannelKeySet.Lobby.key)).resolves.toBe(true);
+
+        mocks.uniqueChannel.deleteMany.mockResolvedValue({ count: 0 });
+        await expect(UniqueChannelService.delete('g', ChannelKeySet.Lobby.key)).resolves.toBe(
+            false,
+        );
     });
 });

--- a/test/infra/db/services.test.ts
+++ b/test/infra/db/services.test.ts
@@ -101,4 +101,12 @@ describe('DBサービスは失敗を呼び出し側に伝える', () => {
             false,
         );
     });
+
+    it('ユニークロールの解除は、解除できたかを boolean で返す', async () => {
+        mocks.uniqueRole.deleteMany.mockResolvedValue({ count: 1 });
+        await expect(UniqueRoleService.delete('g', RoleKeySet.Developer.key)).resolves.toBe(true);
+
+        mocks.uniqueRole.deleteMany.mockResolvedValue({ count: 0 });
+        await expect(UniqueRoleService.delete('g', RoleKeySet.Developer.key)).resolves.toBe(false);
+    });
 });


### PR DESCRIPTION
Closes #804（後編。境界の整備は #814）

> [!IMPORTANT]
> **#814 の上に積んでいます。** base は `refactor/804a-error-boundaries`。#812 → #813 → #814 の順にマージしてください。

## 変更

`infra/db/repositories/` の **81箇所**の try/catch を除去し、失敗を throw で呼び出し側に伝えるようにした。catch は境界（gateway のハンドラ）に集約する。

**-1461行 / +1037行。**

サービス層が `sendErrorLogs` を呼ばなくなったため、「**DBに依存するロガーがDB障害を報告する**」という循環も解消されています。

## P2025（対象行なし）を正常系として扱う

単一行の `update()` / `delete()` は **`updateMany()` / `deleteMany()` に置き換え**ました。

`update`/`delete` は対象行が無いと P2025 で throw しますが、このコードベースでは「対象行が無い」のは**日常的に起きる正常系**です。

- 〆ボタンと自動締切ジョブ（#813）の競合による**二重削除** — `deleteRecruit` は7箇所から呼ばれ、互いに競合しうる
- DBに未登録のチャンネルの `channelDelete` イベント
- DBに居ないメンバーのフラグ更新
- キャンセルボタンの**ダブルクリック**

つまり今までの catch は、実質的に**冪等性の仕組み**として機能していました。0件マッチで throw しない Many 系にすることで、その冪等性を保ったまま「本物のDB障害」だけを throw できます。

変換後の prisma 操作の内訳（**単一行の update/delete はゼロ**）:

| 操作 | 件数 |
|---|---|
| findMany / findUnique / findFirst | 41 |
| upsert | 18 |
| updateMany | 12 |
| deleteMany | 11 |
| create | 2 |

`setVCToolsEnabled` / `setAdminChannel` だけは呼び出し側が更新後のレコード（`type` でカテゴリ判定）を使うため、`updateMany` + `findUnique` で契約を維持しています。

## 副次的に直ったバグ

### 参加者テーブルの全削除

`deleteUnuseParticipant` は `RecruitService.getAllMessageId()` の結果を `notIn` に渡していました。

```ts
const messageIdList = await RecruitService.getAllMessageId();  // ← DBエラー時に [] を返していた
await prisma.participant.deleteMany({ where: { messageId: { notIn: messageIdList } } });
```

**`notIn: []` は全行にマッチします。** つまり一時的なDBエラーで**参加者テーブルが丸ごと消える**状態でした（起動時に走ります）。エラーが throw されるようになったことで、`deleteMany` に到達しなくなります。

### 1行の破損で全設定が「未設定」に見える

`getAllUniqueChannels` / `getAllUniqueRoles` は不正なキーの行に対して `throw new Error('Invalid ChannelKey')` していましたが、catch がそれを `[]` にしていました。**1行壊れるだけで、全てのユニークチャンネル設定が「未設定」に見えていました。** 今は throw が境界まで届きます。

## 到達不能になったコードの削除

catch のせいだけで `T | null` だった戻り値の型を締め、死んだ null チェックを消しました。

- `sync_member.ts` の `if (notExists(storedMember)) { sendErrorLogs('failed to set member to DB') }` — まさに issue が言う「失敗が呼び出し側に伝わらない」パターンそのもので、save が throw するようになった今は不要
- `member_manager.ts` の同型の分岐 2箇所
- `admin_channel_setting.ts` / `vcTools_setting.ts` のカテゴリ配下ループの `if (notExists(result)) return null`

## 確認

- `tsc --noEmit` ✅
- `eslint .` ✅
- `vitest` 87 tests ✅

`test/db/services.test.ts` は**握り潰しを保証するテスト**だったので、throw することを保証するテストに書き換えました（DB障害は throw する／正常時は結果を返す／レコード無しは null（エラーではない）／募集の二重削除は正常系／解除の成否は boolean）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xn8R2XrHnp2852UVdcunjL