### PR TITLE
fix: 構造移行中に見つかった既存バグ3件を修正する (#805)

### DIFF
--- a/src/features/retire_log/send_retire_log.ts
+++ b/src/features/retire_log/send_retire_log.ts
@@ -13,12 +13,13 @@ const logger = log4js_obj.getLogger();
  * 退部したメンバーの情報を退部ログチャンネルに送る。
  * joinedAt が Discord から取得できない場合は DB の記録で補う。
  *
- * @returns 退部ログチャンネルが設定されていれば true
+ * 退部ログチャンネルが未設定でも、部員数の更新など後続の処理は行われるべきなので、
+ * ここでは警告を出して戻るだけにする。
  */
 export async function sendRetireLog(
     member: GuildMember | PartialGuildMember,
     guild: Guild,
-): Promise<boolean> {
+): Promise<void> {
     const displayName = member.displayName;
     const username = member.user.username;
     let joinedAt = member.joinedAt;
@@ -46,11 +47,10 @@ export async function sendRetireLog(
     );
     if (notExists(logChannelId)) {
         logger.warn(`${ChannelKeySet.RetireLog.key} is not set. [${guild.name}]`);
-        return false;
+        return;
     }
     const retireLog = await searchChannelById(guild, logChannelId);
     if (retireLog?.isTextBased()) {
         await retireLog.send(text);
     }
-    return true;
 }

--- a/src/features/voice/disconnect_from_vc.ts
+++ b/src/features/voice/disconnect_from_vc.ts
@@ -10,10 +10,12 @@ const logger = log4js_obj.getLogger();
  * 起動時に、前回の停止で残ってしまったボイスチャンネル接続を切る。
  */
 export async function disconnectFromVC(client: Client<true>) {
-    // ギルド（サーバー）ごとに処理
-    client.guilds.cache.forEach(async (guild) => {
+    // forEach(async ...) は返り値の Promise を捨てるため、呼び出し元(起動時の
+    // ready_handler)が await しても切断の完了は保証されず、ループ内の例外も
+    // 握り潰されていた。逐次 await する。
+    for (const guild of client.guilds.cache.values()) {
         const botMember = await searchAPIMemberById(guild, client.user.id);
-        if (notExists(botMember)) return;
+        if (notExists(botMember)) continue;
         // ボイスチャンネルにBotが接続しているか確認
         const voiceState = botMember.voice;
         const voiceChannel = voiceState.channel;
@@ -21,5 +23,5 @@ export async function disconnectFromVC(client: Client<true>) {
             logger.info(`Disconnecting from 🔊${voiceChannel.name} in ${guild.name}`);
             await voiceState.disconnect(); // ボイスチャンネルから切断
         }
-    });
+    }
 }

--- a/src/gateway/member_handler.ts
+++ b/src/gateway/member_handler.ts
@@ -33,12 +33,10 @@ export async function handleGuildMemberRemove(
     try {
         const guild = await member.guild.fetch();
 
-        const retireLogChannelExists = await sendRetireLog(member, guild);
-
-        // 移行前は「退部ログチャンネルが未設定なら early return」だったため、
-        // その場合は部員数の更新も行われていなかった。挙動を変えないためここで打ち切る。
-        // (意図した仕様ではなさそうなので、別途修正を検討する)
-        if (!retireLogChannelExists) return;
+        // 退部ログの送信可否と部員数の更新は独立している。
+        // 以前は退部ログチャンネルが未設定だと early return していたため、
+        // ログチャンネルを設定していないサーバーでは部員数が更新されなかった。
+        await sendRetireLog(member, guild);
 
         if (guild.id === env.serverId) {
             assertExistCheck(client.user, 'client.user');

--- a/src/infra/logging/send_error_logs.ts
+++ b/src/infra/logging/send_error_logs.ts
@@ -61,7 +61,36 @@ async function notifyErrorLogChannel(error: unknown) {
         return defaultLogger.warn('error log channel is not text based.');
     }
 
+    await errorLogChannel.send('### エラーログ\n' + '```\n' + formatError(error) + '\n```');
+}
+
+/** Discord の1メッセージ上限(2000文字)からコードブロックの装飾分を引いた余裕 */
+const MAX_ERROR_LENGTH = 1900;
+
+/**
+ * 通知本文を組み立てる。
+ *
+ * 以前は `error instanceof Error` のときしか送信していなかったため、
+ * 文字列やオブジェクトを渡している呼び出し箇所(interaction のエラーなど)は
+ * Discord への通知が一切飛んでいなかった。スタックが無いだけで通知価値はあるので、
+ * Error でなくても送る。
+ */
+function formatError(error: unknown): string {
+    const text = stringifyError(error);
+    return text.length > MAX_ERROR_LENGTH ? text.slice(0, MAX_ERROR_LENGTH) + '\n…(省略)' : text;
+}
+
+function stringifyError(error: unknown): string {
     if (error instanceof Error) {
-        await errorLogChannel.send('### エラーログ\n' + '```\n' + (error.stack ?? error) + '\n```');
+        return error.stack ?? String(error);
+    }
+    if (typeof error === 'string') {
+        return error;
+    }
+    try {
+        return JSON.stringify(error, null, 2) ?? String(error);
+    } catch {
+        // 循環参照などで JSON 化できない場合
+        return String(error);
     }
 }

--- a/src/jobs/stage_schedule_job.ts
+++ b/src/jobs/stage_schedule_job.ts
@@ -30,7 +30,9 @@ export function startStageScheduleJob(client: Client) {
                 // ステージ情報の送信
                 await stageInfo(guild);
             } catch (error) {
-                await sendErrorLogs(logger, 'schedule job failed: \n' + error);
+                // 文字列連結するとスタックトレースが消えるため、Error のまま渡す
+                logger.error('schedule job failed');
+                await sendErrorLogs(logger, error);
             }
 
             logger.info('cron job finished');

--- a/test/infra/logging/send_error_logs.test.ts
+++ b/test/infra/logging/send_error_logs.test.ts
@@ -71,4 +71,41 @@ describe('sendErrorLogs', () => {
 
         await expect(sendErrorLogs(fakeLogger(), new Error('original'))).resolves.toBeUndefined();
     });
+
+    // 以前は `error instanceof Error` のときしか送信していなかったため、
+    // 文字列やオブジェクトを渡している呼び出し箇所は通知が一切飛んでいなかった。
+    describe('Error でない値も通知する', () => {
+        beforeEach(() => mocks.getChannelIdByKey.mockResolvedValue('c1'));
+
+        it('文字列', async () => {
+            await sendErrorLogs(fakeLogger(), 'rankRoleKey is not RoleKey');
+
+            expect(vi.mocked(mocks.send).mock.calls[0][0]).toContain('rankRoleKey is not RoleKey');
+        });
+
+        it('オブジェクト(interaction のエラー詳細など)', async () => {
+            await sendErrorLogs(fakeLogger(), { content: 'Command failed', replied: true });
+
+            const sent = vi.mocked(mocks.send).mock.calls[0][0] as string;
+            expect(sent).toContain('Command failed');
+            expect(sent).toContain('replied');
+        });
+
+        it('循環参照があっても throw しない', async () => {
+            const circular: Record<string, unknown> = {};
+            circular.self = circular;
+
+            await expect(sendErrorLogs(fakeLogger(), circular)).resolves.toBeUndefined();
+            expect(mocks.send).toHaveBeenCalledOnce();
+        });
+    });
+
+    it('Discordの文字数上限を超えないよう切り詰める', async () => {
+        mocks.getChannelIdByKey.mockResolvedValue('c1');
+
+        await sendErrorLogs(fakeLogger(), 'a'.repeat(5000));
+
+        const sent = vi.mocked(mocks.send).mock.calls[0][0] as string;
+        expect(sent.length).toBeLessThanOrEqual(2000);
+    });
 });


### PR DESCRIPTION
Closes #805

> [!IMPORTANT]
> **#815 の上に積んでいます。** base は `refactor/804b-db-service-throw`。#812 → #813 → #814 → #815 の順にマージしてください。

## 1. `sendErrorLogs` が非 Error を Discord に通知しない（実害が最も大きい）

`error instanceof Error` のときだけ通知していたため、**文字列やオブジェクトを渡している呼び出し箇所はエラー通知が一切飛んでいませんでした。** ログファイルには出ているものの、運用上は気づけません。

該当していた箇所（`interaction` のエラーが Discord に通知されていなかった、が一番痛い）:

| 箇所 | 渡していたもの |
|---|---|
| `gateway/interaction_router.ts` | `errorDetail` オブジェクト |
| `jobs/stage_schedule_job.ts` | 文字列連結 |
| `features/onboarding/set_rookie.ts` | 文字列 ×2 |
| `features/recruit/create/anarchy_recruit.ts` | 文字列 |
| `features/stage_info/event_match_register.ts` | 文字列 |
| `features/stage_info/stageinfo.ts` | 文字列 |

issue の 方針どおり **`sendErrorLogs` 側で対応**しました（呼び出し箇所を全部直すより、通知経路を1箇所直すほうが漏れません）。文字列・オブジェクト・**循環参照を含むオブジェクト**のいずれも扱えます。

あわせて2点:

- **Discord の1メッセージ上限（2000文字）を超えないよう切り詰め**ました。長いスタックトレースで送信が失敗して通知そのものを落とすのを防ぎます
- `stage_schedule_job` が `'schedule job failed: \n' + error` と**文字列連結**していた箇所は、スタックトレースが消えてしまうので `Error` のまま渡すよう直しました

## 2. 退部ログチャンネル未設定時に部員数が更新されない

`guildMemberRemove` が、退部ログチャンネル未設定のとき early return しており、**部員数（アクティビティ表示）の更新まで行われなくなっていました。**

退部ログの送信可否と部員数の更新は独立した処理なので分離しました。`sendRetireLog` の戻り値（`boolean`）は Phase 5 でこの挙動を再現するために足されたものなので、`void` に戻しています。

## 3. `disconnectFromVC` の `forEach(async ...)` が await されない

`forEach` は返り値の Promise を捨てるため、**呼び出し元（起動時の `ready_handler`）が await しても切断処理の完了が保証されず**、ループ内の例外も握り潰されていました。前回の停止で残った VC 接続が切れないまま後続処理に進む可能性があります。

`for...of` で逐次 await するようにしました。

## 確認

- `tsc --noEmit` ✅
- `eslint .` ✅
- `vitest` 91 tests ✅

`sendErrorLogs` に4件テストを追加しました（文字列／オブジェクト／循環参照／文字数上限）。**いずれも修正前の `instanceof Error` ゲートに対して落ちることを確認済み**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xn8R2XrHnp2852UVdcunjL